### PR TITLE
Add repeatable task logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ docs/MVP.md       - checklist for the initial prototype
 #### Prototype Layout
 
 The page uses a simple header/main/footer structure. Stats and resources are kept in a left sidebar, routine controls sit in the center, and crafting or automation placeholders occupy the right panel. The header shows the current age and provides buttons to adjust the game speed.
+Habits are quick actions found below the routine buttons for instant resource gains.
 
 See **docs/MVP.md** for the MVP list.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # progress-realm
-### Game Design Document – v0.2
+### Game Design Document – v0.1.0
 
 #### 1. Game Title (Working)
 
@@ -10,6 +10,8 @@
 A progression and resource management game inspired by Progress Knight and Theory of Magic: Arcanum. Players assign limited action slots to repeatable tasks that consume resources and grant stat growth or magical benefits. The core loop involves efficiency optimization, task automation, and progression toward mastery.
 
 In the prototype scenario you are reborn as the son of a retired mercenary who was granted a small territory for his service. Early routines revolve around training with your father and guarding the family lands.
+
+This release (v0.1.0) introduces automatic saving and loading of progress via localStorage.
 
 #### 3. Core Gameplay Loop
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 A progression and resource management game inspired by Progress Knight and Theory of Magic: Arcanum. Players assign limited action slots to repeatable tasks that consume resources and grant stat growth or magical benefits. The core loop involves efficiency optimization, task automation, and progression toward mastery.
 
-In the prototype scenario you are reborn as the son of a retired mercenary who was granted a small territory for his service. Early routines revolve around training with your father and guarding the family lands.
+In this prototype you awaken in the body of a 16‑year‑old after bandits ambush your family's caravan. A stranger rescues you from the wreckage and brings you to a small town to recover. With everyone else lost, your early routines involve rebuilding strength and earning coin in this medieval setting.
 
 This release (v0.1.0) introduces automatic saving and loading of progress via localStorage.
 
@@ -94,7 +94,7 @@ docs/MVP.md       - checklist for the initial prototype
 #### Prototype Layout
 
 The page uses a simple header/main/footer structure. Stats and resources are kept in a left sidebar, routine controls sit in the center, and crafting or automation placeholders occupy the right panel. The header shows the current age and provides buttons to adjust the game speed.
-Habits are quick actions found below the routine buttons for instant resource gains. Action buttons now display progress bars so you can see when the next effect will occur.
+Habits are quick actions found below the routines for instant resource gains. Routines themselves are triggered by clicking their progress bars; hovering shows the cost and effect.
 
 See **docs/MVP.md** for the MVP list.
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ docs/MVP.md       - checklist for the initial prototype
 #### Prototype Layout
 
 The page uses a simple header/main/footer structure. Stats and resources are kept in a left sidebar, routine controls sit in the center, and crafting or automation placeholders occupy the right panel. The header shows the current age and provides buttons to adjust the game speed.
-Habits are quick actions found below the routine buttons for instant resource gains.
+Habits are quick actions found below the routine buttons for instant resource gains. Action buttons now display progress bars so you can see when the next effect will occur.
 
 See **docs/MVP.md** for the MVP list.
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 A progression and resource management game inspired by Progress Knight and Theory of Magic: Arcanum. Players assign limited action slots to repeatable tasks that consume resources and grant stat growth or magical benefits. The core loop involves efficiency optimization, task automation, and progression toward mastery.
 
+In the prototype scenario you are reborn as the son of a retired mercenary who was granted a small territory for his service. Early routines revolve around training with your father and guarding the family lands.
+
 #### 3. Core Gameplay Loop
 
 * Player assigns actions to limited slots

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ js/main.js        - starter script that initializes the app
 docs/MVP.md       - checklist for the initial prototype
 ```
 
+#### Prototype Layout
+
+The page uses a simple header/main/footer structure. Stats and resources are kept in a left sidebar, routine controls sit in the center, and crafting or automation placeholders occupy the right panel. The header shows the current age and provides buttons to adjust the game speed.
+
 See **docs/MVP.md** for the MVP list.
 
 #### 12. Future Extensions

--- a/css/styles.css
+++ b/css/styles.css
@@ -44,11 +44,33 @@ main {
     margin-bottom: 0.5rem;
 }
 
-.action progress {
-    width: 100%;
-    height: 0.5rem;
-    display: block;
+.action .progress-wrapper {
     margin-top: 0.25rem;
+}
+
+.progress-wrapper {
+    position: relative;
+    cursor: pointer;
+}
+
+.progress-wrapper progress {
+    width: 100%;
+    height: 1rem;
+    display: block;
+}
+
+.progress-wrapper .label {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.8rem;
+    pointer-events: none;
+    color: #000;
 }
 
 @media (max-width: 700px) {

--- a/css/styles.css
+++ b/css/styles.css
@@ -13,6 +13,10 @@ header, footer {
     padding: 0.5rem 1rem;
 }
 
+#intro {
+    margin: 0.5rem 1rem;
+}
+
 main {
     display: grid;
     grid-template-columns: 1fr 2fr 1fr;
@@ -25,6 +29,10 @@ main {
     padding: 1rem;
     border-radius: 4px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+#habits {
+    margin-top: 1rem;
 }
 
 @media (max-width: 700px) {

--- a/css/styles.css
+++ b/css/styles.css
@@ -3,8 +3,12 @@ body {
     margin: 0;
     background-color: #f5f5f5;
     display: grid;
-    grid-template-rows: auto 1fr auto;
+    grid-template-rows: auto auto 1fr auto;
     height: 100vh;
+}
+
+header h1 {
+    margin: 0;
 }
 
 header, footer {
@@ -19,9 +23,10 @@ header, footer {
 
 main {
     display: grid;
-    grid-template-columns: 1fr 2fr 1fr;
+    grid-template-columns: minmax(180px, 1fr) 2fr minmax(180px, 1fr);
     gap: 1rem;
     padding: 1rem;
+    align-items: start;
 }
 
 .panel {

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,13 +1,34 @@
 body {
     font-family: Arial, sans-serif;
     margin: 0;
-    padding: 1rem;
     background-color: #f5f5f5;
+    display: grid;
+    grid-template-rows: auto 1fr auto;
+    height: 100vh;
 }
 
-#app {
+header, footer {
+    background: #333;
+    color: #fff;
+    padding: 0.5rem 1rem;
+}
+
+main {
+    display: grid;
+    grid-template-columns: 1fr 2fr 1fr;
+    gap: 1rem;
+    padding: 1rem;
+}
+
+.panel {
     background: #fff;
     padding: 1rem;
     border-radius: 4px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+@media (max-width: 700px) {
+    main {
+        grid-template-columns: 1fr;
+    }
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -35,6 +35,17 @@ main {
     margin-top: 1rem;
 }
 
+.action {
+    margin-bottom: 0.5rem;
+}
+
+.action progress {
+    width: 100%;
+    height: 0.5rem;
+    display: block;
+    margin-top: 0.25rem;
+}
+
 @media (max-width: 700px) {
     main {
         grid-template-columns: 1fr;

--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -2,8 +2,8 @@
 
 Use this list to verify the first playable prototype of **Progress Realm**:
 
-- [ ] Basic HTML/CSS/JS skeleton loads without errors
-- [ ] Display placeholder text in the main app container
-- [ ] Allow simple task execution logic (placeholder function)
-- [ ] Show stat and resource placeholders on screen
+- [x] Basic HTML/CSS/JS skeleton loads without errors
+- [x] Display placeholder text in the main app container
+- [x] Allow simple task execution logic (placeholder function)
+- [x] Show stat and resource placeholders on screen
 - [ ] Ensure page reload keeps game state using `localStorage` (optional for prototype)

--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -6,4 +6,4 @@ Use this list to verify the first playable prototype of **Progress Realm**:
 - [x] Display placeholder text in the main app container
 - [x] Allow simple task execution logic (placeholder function)
 - [x] Show stat and resource placeholders on screen
-- [ ] Ensure page reload keeps game state using `localStorage` (optional for prototype)
+- [x] Ensure page reload keeps game state using `localStorage` (optional for prototype)

--- a/index.html
+++ b/index.html
@@ -7,44 +7,70 @@
     <link rel="stylesheet" href="css/styles.css">
 </head>
 <body>
-    <h1>Progress Realm</h1>
+    <header>
+        <h1>Progress Realm</h1>
+        <div id="header-info">
+            Age: <span id="age-years">16</span>y <span id="age-days">0</span>d <span id="age-hours">0</span>h / <span id="max-age">75</span>y
+            <span id="speed-display">Speed: <span id="speed-value">1x</span></span>
+            <span id="speed-controls">
+                <button data-speed="1">1x</button>
+                <button data-speed="2">2x</button>
+                <button data-speed="10">10x</button>
+            </span>
+        </div>
+    </header>
+
     <p id="intro">Reborn as the son of a retired mercenary, you help oversee a small territory your family earned in the war.</p>
-    <div id="app">
-        <div id="stats">
-            <h2>Stats</h2>
-            <ul>
-                <li>Strength: <span id="stat-strength">0</span></li>
-                <li>Intelligence: <span id="stat-intelligence">0</span></li>
-                <li>Charisma: <span id="stat-charisma">0</span></li>
-            </ul>
 
-            <h3>Prestige</h3>
-            <ul>
-                <li>Strength: <span id="prestige-strength">0</span></li>
-                <li>Intelligence: <span id="prestige-intelligence">0</span></li>
-                <li>Charisma: <span id="prestige-charisma">0</span></li>
-            </ul>
+    <main id="app">
+        <div id="left" class="panel">
+            <section id="stats">
+                <h2>Stats</h2>
+                <ul>
+                    <li>Strength: <span id="stat-strength">0</span></li>
+                    <li>Intelligence: <span id="stat-intelligence">0</span></li>
+                    <li>Charisma: <span id="stat-charisma">0</span></li>
+                </ul>
 
-            <h3>Age</h3>
-            <p><span id="stat-age">0</span>/<span id="stat-max-age">0</span></p>
+                <section id="prestige-block">
+                    <h3>Prestige</h3>
+                    <ul>
+                        <li>Strength: <span id="prestige-strength">0</span></li>
+                        <li>Intelligence: <span id="prestige-intelligence">0</span></li>
+                        <li>Charisma: <span id="prestige-charisma">0</span></li>
+                    </ul>
+                </section>
+            </section>
+
+            <section id="resources">
+                <h2>Resources</h2>
+                <ul>
+                    <li>Energy: <span id="res-energy">0</span>/<span id="res-energy-cap">0</span></li>
+                    <li>Gold: <span id="res-gold">0</span>/<span id="res-gold-cap">0</span></li>
+                </ul>
+            </section>
         </div>
 
-        <div id="resources">
-            <h2>Resources</h2>
-            <ul>
-                <li>Energy: <span id="res-energy">0</span>/<span id="res-energy-cap">0</span></li>
-                <li>Gold: <span id="res-gold">0</span>/<span id="res-gold-cap">0</span></li>
-            </ul>
-        </div>
-
-        <div id="routines">
+        <div id="center" class="panel">
             <h2>Routines</h2>
             <p>Current: <span id="current-routine">Resting</span></p>
             <p id="routine-description"></p>
             <button id="train-strength-btn">Strength Training</button>
             <button id="guard-duty-btn">Guard Duty</button>
         </div>
-    </div>
+
+        <div id="right" class="panel">
+            <h2>Control</h2>
+            <p>Crafting and Automation go here.</p>
+        </div>
+    </main>
+
+    <footer>
+        <button id="save-btn">Save</button>
+        <button id="load-btn">Load</button>
+        <button id="settings-btn">Settings</button>
+    </footer>
+
     <script src="js/main.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <header>
         <h1>Progress Realm</h1>
         <div id="header-info">
-            Age: <span id="age-years">16</span>y <span id="age-days">0</span>d <span id="age-hours">0</span>h / <span id="max-age">75</span>y
+            Age: <span id="age-years">16</span>y <span id="age-days">0</span>d / <span id="max-age">75</span>y
             <span id="speed-display">Speed: <span id="speed-value">1x</span></span>
             <span id="speed-controls">
                 <button data-speed="1">1x</button>
@@ -55,8 +55,13 @@
             <h2>Routines</h2>
             <p>Current: <span id="current-routine">Resting</span></p>
             <p id="routine-description"></p>
-            <button id="train-strength-btn">Strength Training</button>
+            <button id="sword-training-btn">Sword Practice</button>
             <button id="guard-duty-btn">Guard Duty</button>
+
+            <section id="habits">
+                <h3>Habits</h3>
+                <button id="collect-taxes-btn">Collect Taxes</button>
+            </section>
         </div>
 
         <div id="right" class="panel">

--- a/index.html
+++ b/index.html
@@ -55,12 +55,21 @@
             <h2>Routines</h2>
             <p>Current: <span id="current-routine">Resting</span></p>
             <p id="routine-description"></p>
-            <button id="sword-training-btn">Sword Practice</button>
-            <button id="guard-duty-btn">Guard Duty</button>
+            <div class="action">
+                <button id="sword-training-btn">Sword Practice</button>
+                <progress id="sword-training-btn-progress" value="0" max="5"></progress>
+            </div>
+            <div class="action">
+                <button id="guard-duty-btn">Guard Duty</button>
+                <progress id="guard-duty-btn-progress" value="0" max="10"></progress>
+            </div>
 
             <section id="habits">
                 <h3>Habits</h3>
-                <button id="collect-taxes-btn">Collect Taxes</button>
+                <div class="action">
+                    <button id="collect-taxes-btn">Collect Taxes</button>
+                    <progress id="collect-taxes-btn-progress" value="0" max="3"></progress>
+                </div>
             </section>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
         </div>
     </header>
 
-    <p id="intro">Reborn as the son of a retired mercenary, you help oversee a small territory your family earned in the war.</p>
+    <p id="intro">You awaken as a 16-year-old survivor of a caravan ambush. A passing stranger saved you and brought you to a small medieval town.</p>
 
     <main id="app">
         <div id="left" class="panel">
@@ -49,26 +49,37 @@
                     <li>Gold: <span id="res-gold">0</span>/<span id="res-gold-cap">0</span></li>
                 </ul>
             </section>
+
+            <section id="activity">
+                <h2>Activity</h2>
+                <p>Routine: <span id="current-routine">Resting</span> (<span id="current-category">rest</span>)</p>
+                <ul id="active-habits"></ul>
+            </section>
         </div>
 
         <div id="center" class="panel">
             <h2>Routines</h2>
-            <p>Current: <span id="current-routine">Resting</span></p>
             <p id="routine-description"></p>
-            <div class="action">
-                <button id="sword-training-btn">Sword Practice</button>
-                <progress id="sword-training-btn-progress" value="0" max="5"></progress>
+            <div class="action" id="sword-training" title="Cost: 1 Energy per tick, Effect: +0.5 Strength per tick">
+                <div class="progress-wrapper">
+                    <progress id="sword-training-progress" value="0" max="5"></progress>
+                    <span class="label">Sword Practice</span>
+                </div>
             </div>
-            <div class="action">
-                <button id="guard-duty-btn">Guard Duty</button>
-                <progress id="guard-duty-btn-progress" value="0" max="10"></progress>
+            <div class="action" id="guard-duty" title="Cost: 2 Energy per tick, Effect: +1 Gold per tick">
+                <div class="progress-wrapper">
+                    <progress id="guard-duty-progress" value="0" max="10"></progress>
+                    <span class="label">Guard Duty</span>
+                </div>
             </div>
 
             <section id="habits">
                 <h3>Habits</h3>
-                <div class="action">
-                    <button id="collect-taxes-btn">Collect Taxes</button>
-                    <progress id="collect-taxes-btn-progress" value="0" max="3"></progress>
+                <div class="action" id="collect-taxes" title="Effect: +5 Gold after 3s">
+                    <div class="progress-wrapper">
+                        <progress id="collect-taxes-progress" value="0" max="3"></progress>
+                        <span class="label">Collect Taxes</span>
+                    </div>
                 </div>
             </section>
         </div>

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
     <h1>Progress Realm</h1>
+    <p id="intro">Reborn as the son of a retired mercenary, you help oversee a small territory your family earned in the war.</p>
     <div id="app">
         <div id="stats">
             <h2>Stats</h2>
@@ -39,7 +40,9 @@
         <div id="routines">
             <h2>Routines</h2>
             <p>Current: <span id="current-routine">Resting</span></p>
+            <p id="routine-description"></p>
             <button id="train-strength-btn">Strength Training</button>
+            <button id="guard-duty-btn">Guard Duty</button>
         </div>
     </div>
     <script src="js/main.js"></script>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,16 @@
                 <li>Intelligence: <span id="stat-intelligence">0</span></li>
                 <li>Charisma: <span id="stat-charisma">0</span></li>
             </ul>
+
+            <h3>Prestige</h3>
+            <ul>
+                <li>Strength: <span id="prestige-strength">0</span></li>
+                <li>Intelligence: <span id="prestige-intelligence">0</span></li>
+                <li>Charisma: <span id="prestige-charisma">0</span></li>
+            </ul>
+
+            <h3>Age</h3>
+            <p><span id="stat-age">0</span>/<span id="stat-max-age">0</span></p>
         </div>
 
         <div id="resources">
@@ -26,9 +36,10 @@
             </ul>
         </div>
 
-        <div id="actions">
-            <h2>Actions</h2>
-            <button id="train-strength-btn">Train Strength</button>
+        <div id="routines">
+            <h2>Routines</h2>
+            <p>Current: <span id="current-routine">Resting</span></p>
+            <button id="train-strength-btn">Strength Training</button>
         </div>
     </div>
     <script src="js/main.js"></script>

--- a/index.html
+++ b/index.html
@@ -9,7 +9,27 @@
 <body>
     <h1>Progress Realm</h1>
     <div id="app">
-        <!-- Game content will be rendered here -->
+        <div id="stats">
+            <h2>Stats</h2>
+            <ul>
+                <li>Strength: <span id="stat-strength">0</span></li>
+                <li>Intelligence: <span id="stat-intelligence">0</span></li>
+                <li>Charisma: <span id="stat-charisma">0</span></li>
+            </ul>
+        </div>
+
+        <div id="resources">
+            <h2>Resources</h2>
+            <ul>
+                <li>Energy: <span id="res-energy">0</span>/<span id="res-energy-cap">0</span></li>
+                <li>Gold: <span id="res-gold">0</span>/<span id="res-gold-cap">0</span></li>
+            </ul>
+        </div>
+
+        <div id="actions">
+            <h2>Actions</h2>
+            <button id="train-strength-btn">Train Strength</button>
+        </div>
     </div>
     <script src="js/main.js"></script>
 </body>

--- a/js/main.js
+++ b/js/main.js
@@ -106,7 +106,9 @@ function updateUI() {
     document.getElementById('res-gold-cap').textContent = state.resources.maxGold;
 
     const routineName = state.activeRoutine ? state.activeRoutine.name : 'None';
+    const routineCategory = state.activeRoutine ? state.activeRoutine.category : 'none';
     document.getElementById('current-routine').textContent = routineName;
+    document.getElementById('current-category').textContent = routineCategory;
     const descEl = document.getElementById('routine-description');
     if (descEl) {
         const desc = state.activeRoutine ? state.activeRoutine.description : '';
@@ -118,13 +120,24 @@ function updateUI() {
         speedEl.textContent = state.time + 'x';
     }
 
+    const habitList = document.getElementById('active-habits');
+    if (habitList) {
+        habitList.innerHTML = '';
+        Object.values(habits).forEach(h => {
+            if (h.running) {
+                const li = document.createElement('li');
+                li.textContent = `${h.name} (${h.category})`;
+                habitList.appendChild(li);
+            }
+        });
+    }
+
     Object.values(routines).forEach(r => {
-        if (!r.buttonId) return;
-        const el = document.getElementById(r.buttonId);
-        const prog = document.getElementById(r.buttonId + '-progress');
-        if (el) {
-            el.style.display = r.showCondition() ? 'inline-block' : 'none';
-            el.disabled = !r.unlockCondition();
+        if (!r.elementId) return;
+        const container = document.getElementById(r.elementId);
+        const prog = document.getElementById(r.elementId + '-progress');
+        if (container) {
+            container.style.display = r.showCondition() ? 'block' : 'none';
             if (prog) {
                 prog.max = r.duration;
                 prog.value = state.activeRoutine === r ? r.progress : 0;
@@ -133,10 +146,10 @@ function updateUI() {
     });
 
     Object.values(habits).forEach(h => {
-        const el = document.getElementById(h.buttonId);
-        const prog = document.getElementById(h.buttonId + '-progress');
-        if (el) {
-            el.style.display = h.showCondition() ? 'inline-block' : 'none';
+        const container = document.getElementById(h.elementId);
+        const prog = document.getElementById(h.elementId + '-progress');
+        if (container) {
+            container.style.display = h.showCondition() ? 'block' : 'none';
             if (prog) {
                 prog.max = h.duration || 0;
                 prog.value = h.progress || 0;
@@ -151,7 +164,7 @@ const routines = {
         category: 'physical',
         bonusStat: 'strength',
         description: 'Drill at the barracks with your retired mercenary father to build muscle.',
-        buttonId: 'sword-training-btn',
+        elementId: 'sword-training',
         duration: 5,
         progress: 0,
         modifiers: [],
@@ -177,7 +190,7 @@ const routines = {
         category: 'physical',
         bonusStat: 'strength',
         description: 'Patrol the family lands and earn a small wage.',
-        buttonId: 'guard-duty-btn',
+        elementId: 'guard-duty',
         duration: 10,
         progress: 0,
         modifiers: [],
@@ -202,7 +215,7 @@ const routines = {
         name: 'Resting',
         category: 'rest',
         description: 'Take a break to recover your energy.',
-        buttonId: null,
+        elementId: null,
         duration: 5,
         progress: 0,
         modifiers: [],
@@ -227,7 +240,7 @@ const routines = {
 const habits = {
     collectTaxes: {
         name: 'Collect Taxes',
-        buttonId: 'collect-taxes-btn',
+        elementId: 'collect-taxes',
         category: 'social',
         bonusStat: 'charisma',
         duration: 3,
@@ -270,8 +283,6 @@ function runHabit(habit) {
     if (habit.running) return;
     habit.running = true;
     habit.progress = 0;
-    const button = document.getElementById(habit.buttonId);
-    if (button) button.disabled = true;
     const interval = setInterval(() => {
         habit.progress += getSpeedMultiplier(habit);
         if (habit.progress >= habit.duration) {
@@ -279,7 +290,6 @@ function runHabit(habit) {
             habit.effect();
             habit.running = false;
             habit.progress = 0;
-            if (button) button.disabled = false;
             updateUI();
             return;
         }
@@ -320,17 +330,17 @@ function restart() {
 function init() {
     loadState();
     updateUI();
-    const btnTrain = document.getElementById('sword-training-btn');
-    if (btnTrain) {
-        btnTrain.addEventListener('click', () => startRoutine(routines.swordPractice));
+    const trainEl = document.getElementById('sword-training');
+    if (trainEl) {
+        trainEl.addEventListener('click', () => startRoutine(routines.swordPractice));
     }
-    const btnGuard = document.getElementById('guard-duty-btn');
-    if (btnGuard) {
-        btnGuard.addEventListener('click', () => startRoutine(routines.guardDuty));
+    const guardEl = document.getElementById('guard-duty');
+    if (guardEl) {
+        guardEl.addEventListener('click', () => startRoutine(routines.guardDuty));
     }
-    const btnTaxes = document.getElementById('collect-taxes-btn');
-    if (btnTaxes) {
-        btnTaxes.addEventListener('click', () => runHabit(habits.collectTaxes));
+    const taxesEl = document.getElementById('collect-taxes');
+    if (taxesEl) {
+        taxesEl.addEventListener('click', () => runHabit(habits.collectTaxes));
     }
     document.querySelectorAll('[data-speed]').forEach(btn => {
         btn.addEventListener('click', () => {
@@ -343,17 +353,16 @@ function init() {
     });
 
     Object.values(routines).forEach(r => {
-        if (!r.buttonId) return;
-        const el = document.getElementById(r.buttonId);
-        if (el) {
-            el.style.display = r.showCondition() ? 'inline-block' : 'none';
-            el.disabled = !r.unlockCondition();
+        if (!r.elementId) return;
+        const container = document.getElementById(r.elementId);
+        if (container) {
+            container.style.display = r.showCondition() ? 'block' : 'none';
         }
     });
     Object.values(habits).forEach(h => {
-        const el = document.getElementById(h.buttonId);
-        if (el) {
-            el.style.display = h.showCondition() ? 'inline-block' : 'none';
+        const container = document.getElementById(h.elementId);
+        if (container) {
+            container.style.display = h.showCondition() ? 'block' : 'none';
         }
     });
     const saveBtn = document.getElementById('save-btn');

--- a/js/main.js
+++ b/js/main.js
@@ -6,12 +6,21 @@ const state = {
         intelligence: 0,
         charisma: 0,
     },
+    prestige: {
+        strength: 0,
+        intelligence: 0,
+        charisma: 0,
+    },
+    age: 0,
+    maxAge: 100,
     resources: {
         energy: 5,
         maxEnergy: 10,
         gold: 0,
         maxGold: 100,
     },
+    activeRoutine: null,
+    queuedRoutine: null,
 };
 
 function applyResourceCaps() {
@@ -24,15 +33,25 @@ function updateUI() {
     document.getElementById('stat-intelligence').textContent = state.stats.intelligence;
     document.getElementById('stat-charisma').textContent = state.stats.charisma;
 
+    document.getElementById('prestige-strength').textContent = state.prestige.strength;
+    document.getElementById('prestige-intelligence').textContent = state.prestige.intelligence;
+    document.getElementById('prestige-charisma').textContent = state.prestige.charisma;
+
+    document.getElementById('stat-age').textContent = state.age;
+    document.getElementById('stat-max-age').textContent = state.maxAge;
+
     document.getElementById('res-energy').textContent = state.resources.energy;
     document.getElementById('res-energy-cap').textContent = state.resources.maxEnergy;
     document.getElementById('res-gold').textContent = state.resources.gold;
     document.getElementById('res-gold-cap').textContent = state.resources.maxGold;
+
+    const routineName = state.activeRoutine ? state.activeRoutine.name : 'None';
+    document.getElementById('current-routine').textContent = routineName;
 }
 
-const actions = {
+const routines = {
     trainStrength: {
-        name: 'Train Strength',
+        name: 'Strength Training',
         intervalId: null,
         effect() {
             if (state.resources.energy > 0) {
@@ -40,31 +59,77 @@ const actions = {
                 state.stats.strength += 1;
                 applyResourceCaps();
                 updateUI();
-            } else {
-                stopAction(this);
+                if (state.resources.energy === 0) {
+                    stopRoutine(this);
+                    state.queuedRoutine = this;
+                    startRoutine(routines.rest);
+                }
+            }
+        },
+    },
+    rest: {
+        name: 'Resting',
+        intervalId: null,
+        effect() {
+            if (state.resources.energy < state.resources.maxEnergy) {
+                state.resources.energy += 1;
+                applyResourceCaps();
+                updateUI();
+                if (state.resources.energy === state.resources.maxEnergy && state.queuedRoutine) {
+                    const routine = state.queuedRoutine;
+                    state.queuedRoutine = null;
+                    startRoutine(routine);
+                }
             }
         },
     },
 };
 
-function startAction(action) {
-    if (action.intervalId) return;
-    action.intervalId = setInterval(() => action.effect(), 1000);
+function startRoutine(routine) {
+    if (state.activeRoutine === routine) return;
+    if (state.activeRoutine) stopRoutine(state.activeRoutine);
+    routine.intervalId = setInterval(() => routine.effect(), 1000);
+    state.activeRoutine = routine;
+    updateUI();
 }
 
-function stopAction(action) {
-    if (action.intervalId) {
-        clearInterval(action.intervalId);
-        action.intervalId = null;
+function stopRoutine(routine) {
+    if (routine && routine.intervalId) {
+        clearInterval(routine.intervalId);
+        routine.intervalId = null;
     }
+}
+
+function tick() {
+    state.age += 1;
+    if (state.age >= state.maxAge) {
+        restart();
+    }
+    updateUI();
+}
+
+function restart() {
+    for (const key in state.stats) {
+        state.prestige[key] += state.stats[key];
+        state.stats[key] = 0;
+    }
+    state.age = 0;
+    state.resources.energy = state.resources.maxEnergy;
+    state.resources.gold = 0;
+    if (state.activeRoutine) stopRoutine(state.activeRoutine);
+    state.queuedRoutine = null;
+    startRoutine(routines.rest);
+    updateUI();
 }
 
 function init() {
     updateUI();
     const btn = document.getElementById('train-strength-btn');
     if (btn) {
-        btn.addEventListener('click', () => startAction(actions.trainStrength));
+        btn.addEventListener('click', () => startRoutine(routines.trainStrength));
     }
+    startRoutine(routines.rest);
+    setInterval(tick, 1000);
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/js/main.js
+++ b/js/main.js
@@ -311,7 +311,7 @@ function init() {
         }
     });
     startRoutine(routines.rest);
-    setInterval(tick, 1000);
+    setInterval(tick, 50);
 }
 
 document.addEventListener('DOMContentLoaded', init);

--- a/js/main.js
+++ b/js/main.js
@@ -1,9 +1,69 @@
 // Basic setup for Progress Realm prototype
 
+const state = {
+    stats: {
+        strength: 0,
+        intelligence: 0,
+        charisma: 0,
+    },
+    resources: {
+        energy: 5,
+        maxEnergy: 10,
+        gold: 0,
+        maxGold: 100,
+    },
+};
+
+function applyResourceCaps() {
+    state.resources.energy = Math.min(state.resources.energy, state.resources.maxEnergy);
+    state.resources.gold = Math.min(state.resources.gold, state.resources.maxGold);
+}
+
+function updateUI() {
+    document.getElementById('stat-strength').textContent = state.stats.strength;
+    document.getElementById('stat-intelligence').textContent = state.stats.intelligence;
+    document.getElementById('stat-charisma').textContent = state.stats.charisma;
+
+    document.getElementById('res-energy').textContent = state.resources.energy;
+    document.getElementById('res-energy-cap').textContent = state.resources.maxEnergy;
+    document.getElementById('res-gold').textContent = state.resources.gold;
+    document.getElementById('res-gold-cap').textContent = state.resources.maxGold;
+}
+
+const actions = {
+    trainStrength: {
+        name: 'Train Strength',
+        intervalId: null,
+        effect() {
+            if (state.resources.energy > 0) {
+                state.resources.energy -= 1;
+                state.stats.strength += 1;
+                applyResourceCaps();
+                updateUI();
+            } else {
+                stopAction(this);
+            }
+        },
+    },
+};
+
+function startAction(action) {
+    if (action.intervalId) return;
+    action.intervalId = setInterval(() => action.effect(), 1000);
+}
+
+function stopAction(action) {
+    if (action.intervalId) {
+        clearInterval(action.intervalId);
+        action.intervalId = null;
+    }
+}
+
 function init() {
-    const app = document.getElementById('app');
-    if (app) {
-        app.textContent = 'Prototype loaded. Add tasks and resources here.';
+    updateUI();
+    const btn = document.getElementById('train-strength-btn');
+    if (btn) {
+        btn.addEventListener('click', () => startAction(actions.trainStrength));
     }
 }
 


### PR DESCRIPTION
## Summary
- add resource caps to HTML
- implement resource caps and repeatable Train Strength action
- start action via button click and tick every second

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68549d4254fc83308785989ce87b403c