### PR TITLE
Implement intro modal and tabbed center panel

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -17,9 +17,6 @@ header, footer {
     padding: 0.5rem 1rem;
 }
 
-#intro {
-    margin: 0.5rem 1rem;
-}
 
 main {
     display: grid;
@@ -47,6 +44,11 @@ main {
     padding: 0.5rem;
     cursor: grab;
     border-radius: 4px;
+}
+
+#task-list li.locked {
+    opacity: 0.5;
+    cursor: not-allowed;
 }
 
 #task-list li.dragging {
@@ -116,6 +118,54 @@ main {
 
 .slot.complete {
     animation: completeFlash 1s;
+}
+
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 20;
+}
+
+.modal-content {
+    background: #fff;
+    padding: 1rem;
+    border-radius: 4px;
+    max-width: 400px;
+    text-align: center;
+}
+
+.hidden {
+    display: none;
+}
+
+.tab-bar {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.tab-bar button {
+    flex: 1;
+    padding: 0.5rem;
+    border: 1px solid #ccc;
+    background: #eee;
+    cursor: pointer;
+}
+
+.tab-bar button.active {
+    background: #ddd;
+    font-weight: bold;
+}
+
+.tab-content.hidden {
+    display: none;
 }
 
 @media (max-width: 700px) {

--- a/data/tasks.json
+++ b/data/tasks.json
@@ -6,7 +6,9 @@
     "category": "physical",
     "duration": 5,
     "cost": {"energy": 1},
-    "reward": {"strength": 0.5}
+    "reward": {"strength": 0.5},
+    "locked": false,
+    "hidden": false
   },
   {
     "id": "guardDuty",
@@ -15,7 +17,9 @@
     "category": "physical",
     "duration": 10,
     "cost": {"energy": 2},
-    "reward": {"gold": 1}
+    "reward": {"gold": 1},
+    "locked": false,
+    "hidden": false
   },
   {
     "id": "rest",
@@ -24,6 +28,8 @@
     "category": "rest",
     "duration": 5,
     "cost": {},
-    "reward": {"energy": 1}
+    "reward": {"energy": 1},
+    "locked": false,
+    "hidden": false
   }
 ]

--- a/index.html
+++ b/index.html
@@ -20,7 +20,12 @@
         </div>
     </header>
 
-    <p id="intro">You awaken as a 16-year-old survivor of a caravan ambush. A passing stranger saved you and brought you to a small medieval town.</p>
+    <div id="intro-modal" class="modal hidden">
+        <div class="modal-content">
+            <p>You awaken as a 16-year-old survivor of a caravan ambush. A passing stranger saved you and brought you to a small medieval town.</p>
+            <button id="intro-close">Continue</button>
+        </div>
+    </div>
 
     <main id="app">
         <div id="left" class="panel">
@@ -52,28 +57,38 @@
         </div>
 
         <div id="center" class="panel">
-            <h2>Available Tasks</h2>
-            <ul id="task-list"></ul>
-            <h2>Task Slots</h2>
-            <div id="slots" class="slots">
-                <div class="slot" data-slot="0" data-tooltip="Drag a task here">
-                    <div class="progress-wrapper">
-                        <progress value="0" max="100"></progress>
-                        <span class="label"></span>
+            <nav id="center-tabs" class="tab-bar">
+                <button data-tab="tasks" class="active">Routines</button>
+                <button data-tab="crafting">Crafting</button>
+            </nav>
+            <div class="tab-content" data-tab="tasks">
+                <h2>Available Tasks</h2>
+                <ul id="task-list"></ul>
+                <h2>Task Slots</h2>
+                <div id="slots" class="slots">
+                    <div class="slot" data-slot="0" data-tooltip="Drag a task here">
+                        <div class="progress-wrapper">
+                            <progress value="0" max="100"></progress>
+                            <span class="label"></span>
+                        </div>
+                    </div>
+                    <div class="slot" data-slot="1" data-tooltip="Drag a task here">
+                        <div class="progress-wrapper">
+                            <progress value="0" max="100"></progress>
+                            <span class="label"></span>
+                        </div>
+                    </div>
+                    <div class="slot" data-slot="2" data-tooltip="Drag a task here">
+                        <div class="progress-wrapper">
+                            <progress value="0" max="100"></progress>
+                            <span class="label"></span>
+                        </div>
                     </div>
                 </div>
-                <div class="slot" data-slot="1" data-tooltip="Drag a task here">
-                    <div class="progress-wrapper">
-                        <progress value="0" max="100"></progress>
-                        <span class="label"></span>
-                    </div>
-                </div>
-                <div class="slot" data-slot="2" data-tooltip="Drag a task here">
-                    <div class="progress-wrapper">
-                        <progress value="0" max="100"></progress>
-                        <span class="label"></span>
-                    </div>
-                </div>
+            </div>
+            <div class="tab-content hidden" data-tab="crafting">
+                <h2>Control</h2>
+                <p>Crafting and Automation go here.</p>
             </div>
         </div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -106,16 +106,21 @@ const TaskEngine = {
 };
 
 function createTaskElement(task) {
+    if (task.hidden) return null;
     const li = document.createElement('li');
     li.textContent = task.name;
-    li.setAttribute('draggable', 'true');
     li.dataset.taskId = task.id;
     li.dataset.tooltip = task.description;
-    li.addEventListener('dragstart', e => {
-        li.classList.add('dragging');
-        e.dataTransfer.setData('text/plain', task.id);
-    });
-    li.addEventListener('dragend', () => li.classList.remove('dragging'));
+    if (task.locked) {
+        li.classList.add('locked');
+    } else {
+        li.setAttribute('draggable', 'true');
+        li.addEventListener('dragstart', e => {
+            li.classList.add('dragging');
+            e.dataTransfer.setData('text/plain', task.id);
+        });
+        li.addEventListener('dragend', () => li.classList.remove('dragging'));
+    }
     return li;
 }
 
@@ -147,6 +152,27 @@ function setupTooltips() {
     document.addEventListener('mouseover', show);
     document.addEventListener('mousemove', show);
     document.addEventListener('mouseout', hide);
+}
+
+function setupIntroModal() {
+    const modal = document.getElementById('intro-modal');
+    const close = document.getElementById('intro-close');
+    if (!modal) return;
+    modal.classList.remove('hidden');
+    close.addEventListener('click', () => modal.classList.add('hidden'));
+}
+
+function setupTabs() {
+    const buttons = document.querySelectorAll('#center-tabs button');
+    const contents = document.querySelectorAll('#center .tab-content');
+    buttons.forEach(btn => {
+        btn.addEventListener('click', () => {
+            buttons.forEach(b => b.classList.remove('active'));
+            contents.forEach(c => c.classList.add('hidden'));
+            btn.classList.add('active');
+            document.querySelector(`#center .tab-content[data-tab="${btn.dataset.tab}"]`).classList.remove('hidden');
+        });
+    });
 }
 
 function flashSlot(i) {
@@ -205,10 +231,15 @@ async function init() {
     }
     const taskList = document.getElementById('task-list');
     Object.values(tasks).forEach(task => {
-        if (task.id !== 'rest') taskList.appendChild(createTaskElement(task));
+        if (task.id !== 'rest') {
+            const el = createTaskElement(task);
+            if (el) taskList.appendChild(el);
+        }
     });
     setupDragAndDrop();
     setupTooltips();
+    setupIntroModal();
+    setupTabs();
     updateUI();
     setInterval(() => TaskEngine.tick(), 1000);
 }


### PR DESCRIPTION
## Summary
- add intro modal with continue button
- switch center panel to tab-based layout
- show/hide tabs with JS
- allow tasks to define `locked` and `hidden` states
- style modal, tabs, and locked tasks

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6856006ce8188330ae99d301d40cadfb