### PR TITLE
Introduce modular tabbed UI with intro modal

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -17,8 +17,30 @@ header, footer {
     padding: 0.5rem 1rem;
 }
 
-#intro {
-    margin: 0.5rem 1rem;
+
+.hidden {
+    display: none !important;
+}
+
+.modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0,0,0,0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 20;
+}
+
+.modal-content {
+    background: #fff;
+    padding: 1rem;
+    border-radius: 4px;
+    max-width: 400px;
+    text-align: center;
 }
 
 main {
@@ -120,6 +142,26 @@ main {
 
 .slot.blocked {
     border-color: #cc6666;
+}
+
+#task-list li.locked {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.tab-headers {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+}
+
+.tab-headers button.active {
+    background: #333;
+    color: #fff;
+}
+
+.tab-content.hidden {
+    display: none;
 }
 
 @media (max-width: 700px) {

--- a/index.html
+++ b/index.html
@@ -20,7 +20,12 @@
         </div>
     </header>
 
-    <p id="intro">You awaken as a 16-year-old survivor of a caravan ambush. A passing stranger saved you and brought you to a small medieval town.</p>
+    <div id="intro-modal" class="modal">
+        <div class="modal-content">
+            <p>You awaken as a 16-year-old survivor of a caravan ambush. A passing stranger saved you and brought you to a small medieval town.</p>
+            <button id="intro-close">Start</button>
+        </div>
+    </div>
 
     <main id="app">
         <div id="left" class="panel">
@@ -52,26 +57,37 @@
         </div>
 
         <div id="center" class="panel">
-            <h2>Available Actions</h2>
-            <ul id="task-list"></ul>
-            <h2>Action Slots</h2>
-            <div id="slots" class="slots">
-                <div class="slot" data-slot="0" data-tooltip="Drag an action here">
-                    <div class="progress-wrapper">
-                        <progress value="0" max="100"></progress>
-                        <span class="label"></span>
+            <div class="tabs">
+                <div id="tab-headers" class="tab-headers"></div>
+                <div id="tab-contents">
+                    <div class="tab-content" data-tab="routines">
+                        <h2>Available Actions</h2>
+                        <ul id="task-list"></ul>
+                        <h2>Action Slots</h2>
+                        <div id="slots" class="slots">
+                            <div class="slot" data-slot="0" data-tooltip="Drag an action here">
+                                <div class="progress-wrapper">
+                                    <progress value="0" max="100"></progress>
+                                    <span class="label"></span>
+                                </div>
+                            </div>
+                            <div class="slot" data-slot="1" data-tooltip="Drag an action here">
+                                <div class="progress-wrapper">
+                                    <progress value="0" max="100"></progress>
+                                    <span class="label"></span>
+                                </div>
+                            </div>
+                            <div class="slot" data-slot="2" data-tooltip="Drag an action here">
+                                <div class="progress-wrapper">
+                                    <progress value="0" max="100"></progress>
+                                    <span class="label"></span>
+                                </div>
+                            </div>
+                        </div>
                     </div>
-                </div>
-                <div class="slot" data-slot="1" data-tooltip="Drag an action here">
-                    <div class="progress-wrapper">
-                        <progress value="0" max="100"></progress>
-                        <span class="label"></span>
-                    </div>
-                </div>
-                <div class="slot" data-slot="2" data-tooltip="Drag an action here">
-                    <div class="progress-wrapper">
-                        <progress value="0" max="100"></progress>
-                        <span class="label"></span>
+                    <div class="tab-content hidden" data-tab="automation">
+                        <h2>Control</h2>
+                        <p>Crafting and Automation go here.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- present the intro text in a modal popup
- reorganize the center panel to use tabbed content
- add tab management logic and default tabs
- support locked/hidden actions and style updates

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685602aeb39083309f1c95a48dc96ae0