### PR TITLE
Introduce story modal and logging panel

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -202,3 +202,19 @@ main {
     color: #666;
     font-size: 0.9rem;
 }
+
+.log-panel {
+    display: flex;
+    flex-direction: column;
+}
+
+.log-view {
+    flex: 1;
+    overflow-y: auto;
+    margin-top: 0.5rem;
+}
+
+.log-entry {
+    margin-bottom: 0.25rem;
+    font-size: 0.9rem;
+}

--- a/index.html
+++ b/index.html
@@ -20,11 +20,11 @@
         </div>
     </header>
 
-    <div id="intro-modal" class="modal">
+    <div id="story-modal" class="modal hidden">
         <div class="modal-content">
-            <div id="intro-image" class="intro-image">Image goes here</div>
-            <p>You awaken in a healer's hut, the sole survivor of a caravan ambush. Months have passed in recovery and now, with strength slowly returning, your true journey begins. The healer, an old woman with eyes like weathered stone, presses a worn pendant into your hand — the only item found with you. Its unfamiliar symbol stirs something deep and cold in your chest, but no memory surfaces. </p>
-            <button id="intro-close">Start</button>
+            <div id="story-image" class="intro-image"></div>
+            <p id="story-text"></p>
+            <button id="story-close">Continue</button>
         </div>
     </div>
 
@@ -91,9 +91,9 @@
             </div>
         </div>
 
-        <div id="right" class="panel">
-            <h2>Control</h2>
-            <p>Crafting and Automation go here.</p>
+        <div id="right" class="panel log-panel">
+            <h2>Log</h2>
+            <div id="log" class="log-view"></div>
         </div>
     </main>
 

--- a/js/main.js
+++ b/js/main.js
@@ -88,6 +88,47 @@ const MasteryUI = {
     }
 };
 
+const Log = {
+    messages: [],
+    init() {
+        this.el = document.getElementById('log');
+    },
+    add(msg) {
+        this.messages.push(msg);
+        if (this.el) {
+            const div = document.createElement('div');
+            div.className = 'log-entry';
+            div.textContent = msg;
+            this.el.appendChild(div);
+            this.el.scrollTop = this.el.scrollHeight;
+        }
+    }
+};
+
+const Story = {
+    show(text, image, onClose) {
+        const modal = document.getElementById('story-modal');
+        const textEl = document.getElementById('story-text');
+        const imageEl = document.getElementById('story-image');
+        textEl.textContent = text;
+        imageEl.innerHTML = '';
+        if (image) {
+            const img = document.createElement('img');
+            img.src = image;
+            img.alt = '';
+            imageEl.appendChild(img);
+        }
+        modal.classList.remove('hidden');
+        function close() {
+            modal.classList.add('hidden');
+            document.getElementById('story-close').removeEventListener('click', close);
+            Log.add(text);
+            if (onClose) onClose();
+        }
+        document.getElementById('story-close').addEventListener('click', close);
+    }
+};
+
 const SoftCapSystem = {
     statCaps: { strength: 50, intelligence: 50, creativity: 50 },
     resourceCaps: { energy: 20, focus: 20 },
@@ -428,14 +469,16 @@ function updateUI() {
 
 async function init() {
     const loadedActions = SaveSystem.load();
-    const intro = document.getElementById('intro-modal');
-    document.getElementById('intro-close').addEventListener('click', () => {
-        intro.classList.add('hidden');
-        State.introSeen = true;
-        SaveSystem.save();
-    });
-    if (loadedActions && State.introSeen) {
-        intro.classList.add('hidden');
+    Log.init();
+    if (!State.introSeen) {
+        Story.show(
+            "You awaken in a healer's hut, the sole survivor of a caravan ambush. Months have passed in recovery and now, with strength slowly returning, your true journey begins. The healer, an old woman with eyes like weathered stone, presses a worn pendant into your hand — the only item found with you. Its unfamiliar symbol stirs something deep and cold in your chest, but no memory surfaces.",
+            'assets/Intro.png',
+            () => {
+                State.introSeen = true;
+                SaveSystem.save();
+            }
+        );
     }
     document.getElementById('speed-controls').addEventListener('click', e => {
         const s = e.target.dataset.speed;


### PR DESCRIPTION
## Summary
- add generic story modal markup
- create scrollable log panel on the right
- implement Log and Story helpers in JavaScript
- show intro story via new modal and record it to the log

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6856fcfad1bc833099d689d37063ee37