### PR TITLE
Add text property for action slots

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -109,16 +109,12 @@ main {
     display: block;
 }
 
-.progress-wrapper .label {
+.slot .label {
     position: absolute;
     top: 0;
     left: 0;
     right: 0;
-    bottom: 0;
-    display: flex;
-    align-items: flex-start;
-    justify-content: center;
-    padding-top: 2px;
+    text-align: center;
     font-size: 0.8rem;
     pointer-events: none;
     color: #000;

--- a/css/styles.css
+++ b/css/styles.css
@@ -116,8 +116,9 @@ main {
     right: 0;
     bottom: 0;
     display: flex;
-    align-items: center;
+    align-items: flex-start;
     justify-content: center;
+    padding-top: 2px;
     font-size: 0.8rem;
     pointer-events: none;
     color: #000;

--- a/index.html
+++ b/index.html
@@ -64,21 +64,24 @@
                         <h2>Action Slots</h2>
                         <div id="slots" class="slots">
                             <div class="slot" data-slot="0" data-tooltip="Drag an action here">
+                                <span class="label"></span>
                                 <div class="progress-wrapper">
                                     <progress value="0" max="100"></progress>
-                                    <span class="label"></span>
+                                    
                                 </div>
                             </div>
                             <div class="slot" data-slot="1" data-tooltip="Drag an action here">
+                                <span class="label"></span>
                                 <div class="progress-wrapper">
                                     <progress value="0" max="100"></progress>
-                                    <span class="label"></span>
+                                    
                                 </div>
                             </div>
                             <div class="slot" data-slot="2" data-tooltip="Drag an action here">
+                                <span class="label"></span>
                                 <div class="progress-wrapper">
                                     <progress value="0" max="100"></progress>
-                                    <span class="label"></span>
+
                                 </div>
                             </div>
                         </div>

--- a/js/main.js
+++ b/js/main.js
@@ -17,9 +17,9 @@ const State = {
         maxFocus: 10,
     },
     slots: [
-        { actionId: null, progress: 0, blocked: false },
-        { actionId: null, progress: 0, blocked: false },
-        { actionId: null, progress: 0, blocked: false },
+        { actionId: null, progress: 0, blocked: false, text: '' },
+        { actionId: null, progress: 0, blocked: false, text: '' },
+        { actionId: null, progress: 0, blocked: false, text: '' },
     ],
     time: 1,
     masteryPoints: 0,
@@ -202,6 +202,11 @@ const SaveSystem = {
             if (data.version !== VERSION) return null;
             if (data.state) {
                 Object.assign(State, data.state);
+                if (Array.isArray(State.slots)) {
+                    State.slots.forEach(s => {
+                        if (s.text === undefined) s.text = '';
+                    });
+                }
                 return data.actions || null;
             } else {
                 Object.assign(State, data); // legacy save
@@ -338,6 +343,7 @@ const ActionEngine = {
         slot.actionId = actionId;
         slot.progress = 0;
         slot.blocked = false;
+        slot.text = actions[actionId] ? actions[actionId].name : '';
         updateSlotUI(slotIndex);
     },
     tick() {
@@ -448,13 +454,13 @@ function updateSlotUI(i) {
     if (!slot.actionId) {
         progressEl.value = 0;
         progressEl.max = 1;
-        labelEl.textContent = '';
+        labelEl.textContent = slot.text || '';
         return;
     }
     const action = actions[slot.actionId];
     progressEl.max = 1;
     progressEl.value = slot.progress;
-    labelEl.textContent = `${action.name} Lv.${action.level}`;
+    labelEl.textContent = slot.text || `${action.name} Lv.${action.level}`;
 }
 
 function updateUI() {


### PR DESCRIPTION
## Summary
- let each slot hold its own progress label
- persist new text field in saves
- center text at the top of progress bar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68570b9f9f2083308ba7f340ecdb2b72