### PR TITLE
Add home system and additional slots

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -77,6 +77,7 @@ main {
 
 .slots {
     display: flex;
+    flex-wrap: wrap;
     gap: 1rem;
     margin-top: 1rem;
 }

--- a/data/actions.json
+++ b/data/actions.json
@@ -2,6 +2,8 @@
   {
     "id": "studying",
     "name": "Studying",
+    "category": "home",
+    "requiresItem": "oldBooks",
     "level": 1,
     "exp": 0,
     "expToNext": 10,
@@ -16,6 +18,8 @@
   {
     "id": "training",
     "name": "Training",
+    "category": "home",
+    "requiresItem": "backyard",
     "level": 1,
     "exp": 0,
     "expToNext": 10,
@@ -30,15 +34,32 @@
   {
     "id": "rest",
     "name": "Rest",
+    "category": "home",
+    "requiresItem": "bed",
     "level": 1,
     "exp": 0,
     "expToNext": 5,
     "baseYield": {
       "stats": {},
-      "resources": {"focus": 1, "energy": 1},
+      "resources": {"focus": 1, "energy": 1, "health": 0.1},
       "exp": 0
     },
     "scaling": {"type": "softcap", "base": 1, "multiplier": 0, "softcapLevel": 1, "falloff": 0},
     "resourceConsumption": {}
+  },
+  {
+    "id": "goHunting",
+    "name": "Go Hunting",
+    "category": "tasks",
+    "level": 1,
+    "exp": 0,
+    "expToNext": 10,
+    "baseYield": {
+      "stats": {"strength": 0.01},
+      "resources": {"gold": 1, "health": -0.1},
+      "exp": 1
+    },
+    "scaling": {"type": "softcap", "base": 1, "multiplier": 0.1, "softcapLevel": 5, "falloff": 0.5},
+    "resourceConsumption": {"energy": 2}
   }
 ]

--- a/index.html
+++ b/index.html
@@ -52,6 +52,11 @@
                 <h2>Resources</h2>
                 <ul id="resources-list"></ul>
             </section>
+
+            <section id="economy">
+                <h2>Economy</h2>
+                <ul id="economy-list"></ul>
+            </section>
         </div>
 
         <div id="center" class="panel">
@@ -67,14 +72,14 @@
                                 <span class="label"></span>
                                 <div class="progress-wrapper">
                                     <progress value="0" max="100"></progress>
-                                    
+
                                 </div>
                             </div>
                             <div class="slot" data-slot="1" data-tooltip="Drag an action here">
                                 <span class="label"></span>
                                 <div class="progress-wrapper">
                                     <progress value="0" max="100"></progress>
-                                    
+
                                 </div>
                             </div>
                             <div class="slot" data-slot="2" data-tooltip="Drag an action here">
@@ -84,11 +89,36 @@
 
                                 </div>
                             </div>
+                            <div class="slot" data-slot="3" data-tooltip="Drag an action here">
+                                <span class="label"></span>
+                                <div class="progress-wrapper">
+                                    <progress value="0" max="100"></progress>
+
+                                </div>
+                            </div>
+                            <div class="slot" data-slot="4" data-tooltip="Drag an action here">
+                                <span class="label"></span>
+                                <div class="progress-wrapper">
+                                    <progress value="0" max="100"></progress>
+
+                                </div>
+                            </div>
+                            <div class="slot" data-slot="5" data-tooltip="Drag an action here">
+                                <span class="label"></span>
+                                <div class="progress-wrapper">
+                                    <progress value="0" max="100"></progress>
+
+                                </div>
+                            </div>
                         </div>
                     </div>
-                    <div class="tab-content hidden" data-tab="automation">
-                        <h2>Control</h2>
-                        <p>Crafting and Automation go here.</p>
+                    <div class="tab-content hidden" data-tab="home">
+                        <h2>Home Items</h2>
+                        <div id="home-slots" class="slots">
+                            <div class="slot" data-item-slot="0"></div>
+                            <div class="slot" data-item-slot="1"></div>
+                            <div class="slot" data-item-slot="2"></div>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- enable adjustable 6 action slots and prepare for future slot control
- add Economy section with Gold and a Home tab with item slots
- introduce Health resource and expand Resources view
- unlock `Go Hunting` task after new recovery story event
- categorize actions and connect them to home items

## Testing
- `node --check js/main.js`

------
https://chatgpt.com/codex/tasks/task_e_68571f9d3968833089464163ec19d37a