### PR TITLE
Add responsive grid for actions

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -61,11 +61,13 @@ main {
 #task-list {
     list-style: none;
     padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 0.5rem;
 }
 
 #task-list li {
     background: #eee;
-    margin-bottom: 0.5rem;
     padding: 0.5rem;
     cursor: grab;
     border-radius: 4px;
@@ -191,6 +193,9 @@ main {
 @media (max-width: 700px) {
     main {
         grid-template-columns: 1fr;
+    }
+    #task-list {
+        grid-template-columns: repeat(3, 1fr);
     }
 }
 


### PR DESCRIPTION
## Summary
- show actions in a grid instead of a vertical list
- keep a maximum of three columns on narrow screens

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68572614e1988330a560ddfdf7e00c75