### PR TITLE
Add image for healer gone event

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -298,7 +298,7 @@ function checkStoryEvents() {
     if (currentDays > triggerDays) {
         Story.show(
             "The cot is cold. The fire long dead. The healer is gone — no note, no trace, just the fading scent of herbs. You rise, steadier now. The shelves are bare. Outside, a narrow road cuts through the trees. In the distance, a thin plume of smoke rises. The pendant at your neck feels heavier — as if urging you forward.",
-            null,
+            'assets/HealerGone.png',
             () => {
                 State.healerGoneSeen = true;
                 SaveSystem.save();


### PR DESCRIPTION
## Summary
- display `HealerGone.png` in healer gone story modal

## Testing
- `pytest --cov` *(fails: unrecognized arguments)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6857ef2269b48330a590a675fdefa567