### PR TITLE
Fix healer gone event repeating

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -112,7 +112,10 @@ const Log = {
 };
 
 const Story = {
+    active: false,
     show(text, image, onClose) {
+        if (this.active) return;
+        this.active = true;
         const modal = document.getElementById('story-modal');
         const textEl = document.getElementById('story-text');
         const imageEl = document.getElementById('story-image');
@@ -125,12 +128,13 @@ const Story = {
             imageEl.appendChild(img);
         }
         modal.classList.remove('hidden');
-        function close() {
+        const close = () => {
             modal.classList.add('hidden');
             document.getElementById('story-close').removeEventListener('click', close);
+            this.active = false;
             Log.add(text);
             if (onClose) onClose();
-        }
+        };
         document.getElementById('story-close').addEventListener('click', close);
     }
 };


### PR DESCRIPTION
## Summary
- prevent multiple log entries while the story modal is open by tracking Story.active

## Testing
- `pytest`
- `pytest --cov` *(fails: unrecognized arguments --cov)*

------
https://chatgpt.com/codex/tasks/task_e_6858089e4a988330bb1edc680eff9ee3