### PR TITLE
Fix #8: toggle action selection

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -420,9 +420,14 @@ function createActionElement(action) {
         });
         li.addEventListener('dragend', () => li.classList.remove('dragging'));
         li.addEventListener('click', () => {
-            selectedActionId = action.id;
+            const alreadySelected = selectedActionId === action.id;
             document.querySelectorAll('#task-list li').forEach(el => el.classList.remove('selected'));
-            li.classList.add('selected');
+            if (alreadySelected) {
+                selectedActionId = null;
+            } else {
+                selectedActionId = action.id;
+                li.classList.add('selected');
+            }
         });
     }
     return li;


### PR DESCRIPTION
## Summary
- allow clicking a selected action again to deselect it

## Testing
- `pytest --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_685828ad0b808330a68adfa32a1c3d73