### PR TITLE
Add encounter generator

### DIFF
--- a/data/encounters.json
+++ b/data/encounters.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "banditAmbush",
+    "name": "Bandit Ambush",
+    "description": "A group of bandits block your path.",
+    "image": "assets/HealerGone.png"
+  },
+  {
+    "id": "quietPath",
+    "name": "Quiet Forest Path",
+    "description": "The woods are silent and eerie.",
+    "image": "assets/Intro.png"
+  },
+  {
+    "id": "merchantCaravan",
+    "name": "Merchant Caravan",
+    "description": "A traveling merchant offers goods.",
+    "image": "assets/Intro.png"
+  }
+]

--- a/index.html
+++ b/index.html
@@ -90,6 +90,7 @@
         <button id="settings-btn">Settings</button>
         <button id="reset-btn">Reset</button>
     </footer>
+    <script src="js/encounter.js"></script>
     <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -1,0 +1,44 @@
+class Encounter {
+    constructor(data) {
+        this.id = data.id;
+        this.name = data.name;
+        this.description = data.description || '';
+        this.image = data.image || '';
+    }
+}
+
+const EncounterGenerator = {
+    encounters: [],
+    container: null,
+
+    async load() {
+        try {
+            const res = await fetch('data/encounters.json');
+            const json = await res.json();
+            this.encounters = json.map(e => new Encounter(e));
+        } catch (e) {
+            console.error('Failed to load encounters', e);
+            this.encounters = [];
+        }
+    },
+
+    init() {
+        this.container = document.getElementById('adventure-slots');
+        if (!this.container) return;
+        this.populateSlots();
+    },
+
+    randomEncounter() {
+        if (!this.encounters.length) return null;
+        const idx = Math.floor(Math.random() * this.encounters.length);
+        return this.encounters[idx];
+    },
+
+    populateSlots() {
+        for (let i = 0; i < State.adventureSlots.length; i++) {
+            const encounter = this.randomEncounter();
+            State.adventureSlots[i].encounter = encounter;
+            updateAdventureSlotUI(i);
+        }
+    }
+};

--- a/js/main.js
+++ b/js/main.js
@@ -36,7 +36,7 @@ for (let i = 0; i < State.slotCount; i++) {
 }
 
 for (let i = 0; i < State.adventureSlotCount; i++) {
-    State.adventureSlots.push({ text: '', progress: 0 });
+    State.adventureSlots.push({ text: '', progress: 0, encounter: null });
 }
 
 let actions = {};
@@ -496,7 +496,7 @@ function setupAdventureSlots() {
     if (!Array.isArray(State.adventureSlots)) State.adventureSlots = [];
     if (State.adventureSlotCount === undefined) State.adventureSlotCount = State.adventureSlots.length;
     while (State.adventureSlots.length < State.adventureSlotCount) {
-        State.adventureSlots.push({ text: '', progress: 0 });
+        State.adventureSlots.push({ text: '', progress: 0, encounter: null });
     }
     if (State.adventureSlots.length > State.adventureSlotCount) {
         State.adventureSlots = State.adventureSlots.slice(0, State.adventureSlotCount);
@@ -519,6 +519,7 @@ function setupAdventureSlots() {
         slotEl.appendChild(wrapper);
 
         container.appendChild(slotEl);
+        updateAdventureSlotUI(i);
     }
 }
 
@@ -587,6 +588,26 @@ function updateSlotUI(i) {
     labelEl.textContent = slot.text || `${action.name} Lv.${action.level}`;
 }
 
+function updateAdventureSlotUI(i) {
+    const slot = State.adventureSlots[i];
+    const slotEl = document.querySelector(`#adventure-slots .slot[data-slot="${i}"]`);
+    if (!slotEl) return;
+    const progressEl = slotEl.querySelector('progress');
+    const labelEl = slotEl.querySelector('.label');
+    progressEl.value = slot.progress || 0;
+    progressEl.max = 1;
+    if (slot.encounter) {
+        labelEl.textContent = slot.encounter.name;
+        if (slot.encounter.image) {
+            slotEl.style.backgroundImage = `url(${slot.encounter.image})`;
+            slotEl.style.backgroundSize = 'cover';
+        }
+    } else {
+        labelEl.textContent = slot.text || '';
+        slotEl.style.backgroundImage = 'none';
+    }
+}
+
 function updateUI() {
     StatsUI.update();
     ResourcesUI.update();
@@ -642,12 +663,14 @@ async function init() {
         const el = createActionElement(a);
         if (el) list.appendChild(el);
     });
+    await EncounterGenerator.load();
     StatsUI.init();
     ResourcesUI.init();
     MasteryUI.init();
     updateTaskList();
     setupSlots();
     setupAdventureSlots();
+    EncounterGenerator.init();
     setupDragAndDrop();
     setupTooltips();
     TabManager.init();


### PR DESCRIPTION
## Summary
- create Encounter class and EncounterGenerator module
- load encounter definitions and assign them to adventure slots
- update adventure slots UI to show encounters and optional images
- include sample encounters data file
- load new module from index.html

## Testing
- `pytest`
- `pytest --cov` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_685845b5805883308e1a109625ea4f3c