### PR TITLE
Change encounter slot text to white

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -124,14 +124,8 @@ main {
     text-align: center;
     font-size: 0.8rem;
     pointer-events: none;
-    color: #000;
-}
-# Adventure slots display encounter names on top of background images.
-# Use a white font for better readability.
-# This overrides the default black text color above.
-
-#adventure-slots .slot .label {
     color: #fff;
+}
 }
 
 .tooltip {

--- a/css/styles.css
+++ b/css/styles.css
@@ -126,6 +126,13 @@ main {
     pointer-events: none;
     color: #000;
 }
+# Adventure slots display encounter names on top of background images.
+# Use a white font for better readability.
+# This overrides the default black text color above.
+
+#adventure-slots .slot .label {
+    color: #fff;
+}
 
 .tooltip {
     position: absolute;


### PR DESCRIPTION
## Summary
- make adventure slot labels white for readability on background images

## Testing
- `pytest`
- `pytest --cov` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68584b3bdbf48330bf528baf9d2b718e