### PR TITLE
Add background images for action slots

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -97,6 +97,9 @@ main {
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
 }
 
 .slot.active {

--- a/data/actions.json
+++ b/data/actions.json
@@ -2,6 +2,7 @@
   {
     "id": "studying",
     "name": "Studying",
+    "image": "assets/enc/studying.png",
     "level": 1,
     "exp": 0,
     "expToNext": 10,
@@ -16,6 +17,7 @@
   {
     "id": "training",
     "name": "Training",
+    "image": "assets/enc/training.png",
     "level": 1,
     "exp": 0,
     "expToNext": 10,
@@ -30,6 +32,7 @@
   {
     "id": "rest",
     "name": "Rest",
+    "image": "assets/enc/rest.png",
     "level": 1,
     "exp": 0,
     "expToNext": 5,

--- a/js/main.js
+++ b/js/main.js
@@ -580,12 +580,18 @@ function updateSlotUI(i) {
         progressEl.value = 0;
         progressEl.max = 1;
         labelEl.textContent = slot.text || '';
+        slotEl.style.backgroundImage = 'none';
         return;
     }
     const action = actions[slot.actionId];
     progressEl.max = 1;
     progressEl.value = slot.progress;
     labelEl.textContent = slot.text || `${action.name} Lv.${action.level}`;
+    if (action.image) {
+        slotEl.style.backgroundImage = `url(${action.image})`;
+    } else {
+        slotEl.style.backgroundImage = 'none';
+    }
 }
 
 function updateAdventureSlotUI(i) {


### PR DESCRIPTION
## Summary
- show background images in action slots
- include image paths for each action
- style slot backgrounds for images

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_685864bb56048330a98301da62ae7158