### PR TITLE
Display encounter level on Adventure tab

### DIFF
--- a/js/encounter.js
+++ b/js/encounter.js
@@ -63,7 +63,9 @@ const EncounterGenerator = {
             .find(m => this.level >= m.level);
         const name = milestone ? milestone.name : this.milestones[0].name;
         const el = document.getElementById('encounter-location');
-        if (el) el.textContent = name;
+        if (el) {
+            el.textContent = `${name} (Level ${this.level})`;
+        }
     },
 
     incrementLevel() {


### PR DESCRIPTION
## Summary
- show the current encounter level alongside the location name

## Testing
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_6859255978bc833090558632de4d81f8