### PR TITLE
Add scaling resource costs to encounters

### DIFF
--- a/data/encounters.json
+++ b/data/encounters.json
@@ -6,7 +6,8 @@
         "rarity": "common",
         "category": "intelligence",
         "baseDuration": 5,
-        "image": "assets/enc/foraging.png"
+        "image": "assets/enc/foraging.png",
+        "resourceConsumption": {"energy": 1}
     },
     {
         "id": "rabbitHunt",
@@ -15,7 +16,8 @@
         "rarity": "common",
         "category": "strength",
         "baseDuration": 6,
-        "image": "assets/enc/rabbit.png"
+        "image": "assets/enc/rabbit.png",
+        "resourceConsumption": {"energy": 1.5}
     },
     {
         "id": "wolfAmbush",
@@ -24,6 +26,7 @@
         "rarity": "rare",
         "category": "strength",
         "baseDuration": 10,
-        "image": "assets/enc/wolf.png"
+        "image": "assets/enc/wolf.png",
+        "resourceConsumption": {"energy": 2, "health": 0.5}
     }
 ]

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -7,6 +7,7 @@ class Encounter {
         this.rarity = data.rarity || 'common';
         this.category = data.category || 'strength';
         this.baseDuration = data.baseDuration || 5;
+        this.resourceConsumption = data.resourceConsumption || {};
     }
 
     getDuration() {
@@ -19,6 +20,16 @@ class Encounter {
         const base = EncounterGenerator.lootBaseByCategory[this.category] || 0;
         const stat = State.stats[this.category] || 0;
         return base + stat * EncounterGenerator.lootBonusPerStat;
+    }
+
+    getResourceCost() {
+        const scale =
+            1 + EncounterGenerator.level * EncounterGenerator.costScalePerLevel;
+        const cost = {};
+        for (const k in this.resourceConsumption) {
+            cost[k] = this.resourceConsumption[k] * scale;
+        }
+        return cost;
     }
 }
 
@@ -44,6 +55,7 @@ const EncounterGenerator = {
     },
     lootBonusPerStat: 0.001, // +0.1% loot chance per stat point
     durationModPerStat: 0.02, // -2% duration per stat point
+    costScalePerLevel: 0.1, // +10% cost per encounter level
 
     async load() {
         try {

--- a/js/main.js
+++ b/js/main.js
@@ -246,6 +246,12 @@ const AdventureEngine = {
         }
         const slot = State.adventureSlots[this.activeIndex];
         if (!slot.encounter) return;
+        const cost = slot.encounter.getResourceCost();
+        const canRun = consume(cost, delta);
+        if (!canRun) {
+            updateAdventureSlotUI(this.activeIndex);
+            return;
+        }
         slot.progress += delta / slot.duration;
         if (slot.progress >= 1) {
             EncounterGenerator.resolve(slot.encounter);

--- a/tests/test_encounters.py
+++ b/tests/test_encounters.py
@@ -10,3 +10,8 @@ def test_encounter_fields():
         assert 'baseDuration' in enc
         assert isinstance(enc['baseDuration'], (int, float))
         assert enc['baseDuration'] > 0
+        assert 'resourceConsumption' in enc
+        assert isinstance(enc['resourceConsumption'], dict)
+        for val in enc['resourceConsumption'].values():
+            assert isinstance(val, (int, float))
+            assert val > 0


### PR DESCRIPTION
## Summary
- introduce `resourceConsumption` for each encounter
- scale resource costs by encounter level with `costScalePerLevel`
- prevent adventure progress when resources are insufficient
- test that encounters define resource consumption

## Testing
- `pip install pytest-cov`
- `pytest --cov -q`

------
https://chatgpt.com/codex/tasks/task_e_6859512270448330853afacd3124db29