### PR TITLE
Load locations from JSON and reset on health loss

### DIFF
--- a/data/locations.json
+++ b/data/locations.json
@@ -1,0 +1,5 @@
+[
+    {"level": 0, "name": "Hut in the Forest"},
+    {"level": 3, "name": "Abandoned Clearing"},
+    {"level": 6, "name": "Ruined Keep"}
+]

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -37,11 +37,7 @@ const EncounterGenerator = {
     encounters: [],
     container: null,
     level: 0,
-    milestones: [
-        { level: 0, name: 'Hut in the Forest' },
-        { level: 3, name: 'Abandoned Clearing' },
-        { level: 6, name: 'Ruined Keep' }
-    ],
+    milestones: [],
     rarityWeights: {
         common: 1,
         rare: 0.5,
@@ -66,6 +62,15 @@ const EncounterGenerator = {
             console.error('Failed to load encounters', e);
             this.encounters = [];
         }
+
+        try {
+            const res = await fetch('data/locations.json');
+            const json = await res.json();
+            this.milestones = json;
+        } catch (e) {
+            console.error('Failed to load locations', e);
+            this.milestones = [{ level: 0, name: 'Unknown' }];
+        }
     },
 
     updateName() {
@@ -84,6 +89,21 @@ const EncounterGenerator = {
         this.level += 1;
         State.encounterLevel = this.level;
         this.updateName();
+    },
+
+    decrementLevel() {
+        if (this.level > 0) {
+            this.level -= 1;
+            State.encounterLevel = this.level;
+            this.updateName();
+        }
+    },
+
+    resetProgress() {
+        this.populateSlots();
+        if (typeof AdventureEngine !== 'undefined') {
+            AdventureEngine.activeIndex = null;
+        }
     },
 
     init() {

--- a/js/main.js
+++ b/js/main.js
@@ -301,6 +301,7 @@ const AdventureEngine = {
         } else {
             updateAdventureSlotUI(this.activeIndex);
         }
+        checkHealth();
     }
 };
 
@@ -363,6 +364,13 @@ function applyDeltas(deltaSeconds) {
             ResourceSystem.consume(State.resources[k], -change);
         }
     });
+}
+
+function checkHealth() {
+    if (State.resources.health.value <= 0) {
+        EncounterGenerator.decrementLevel();
+        EncounterGenerator.resetProgress();
+    }
 }
 
 function formatDelta(v) {
@@ -494,6 +502,7 @@ const ActionEngine = {
         });
         checkStoryEvents();
         SoftCapSystem.apply();
+        checkHealth();
         SaveSystem.save();
     }
 };

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -1,0 +1,13 @@
+import json
+import os
+
+def test_location_fields():
+    path = os.path.join('data', 'locations.json')
+    with open(path) as f:
+        data = json.load(f)
+    assert isinstance(data, list)
+    for loc in data:
+        assert 'level' in loc
+        assert 'name' in loc
+        assert isinstance(loc['level'], int)
+        assert isinstance(loc['name'], str)


### PR DESCRIPTION
## Summary
- read encounter location milestones from new `data/locations.json`
- add decrementLevel/resetProgress helpers to EncounterGenerator
- lower encounter level and reset adventure progress when health hits zero
- call the new health check from Action and Adventure engines
- add test coverage for location file

## Testing
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_68598bfc12488330912dd17e90c7b88e