### PR TITLE
Simplify adventure loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It also adds a drag-and-drop task system with tooltips and simple completion ani
 Version 0.2.0 introduced a leveled action system with per-second yields and resource blocking.
 Version 0.3.0 expands the prototype with six starting action slots, an introductory story modal, and a simple log panel.
 Version 0.4.0 adds weighted random encounters with durations and loot chances influenced by your stats.
+Version 0.5.0 redesigns the Adventure tab with a single slot. Encounter level now increases after ten consecutive successes.
 
 #### 3. Core Gameplay Loop
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -91,6 +91,10 @@ main {
     margin-top: 0.5rem;
 }
 
+#return-btn {
+    margin-top: 0.5rem;
+}
+
 .slot {
     flex: 1;
     border: 2px dashed #ccc;

--- a/css/styles.css
+++ b/css/styles.css
@@ -81,12 +81,10 @@ main {
     margin-top: 1rem;
 }
 
-.grid-slots {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 1rem;
-    margin-top: 1rem;
+#adventure-slots {
+    display: flex;
 }
+
 
 #encounter-location {
     font-style: italic;
@@ -211,6 +209,10 @@ main {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
         gap: 0.5rem;
+    }
+    #adventure-slots {
+        display: flex;
+        flex-direction: column;
     }
 }
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -99,7 +99,7 @@ main {
     flex: 1;
     border: 2px dashed #ccc;
     padding: 0.5rem;
-    min-height: 3rem;
+    min-height: 5rem;
     position: relative;
     display: flex;
     flex-direction: column;

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
                     <div class="tab-content hidden" data-tab="adventure">
                         <h2>Adventure</h2>
                         <p id="encounter-location"></p>
+                        <button id="return-btn">Return</button>
                         <div id="adventure-slots" class="slots"></div>
                     </div>
                     <div class="tab-content hidden" data-tab="automation">

--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
                     <div class="tab-content hidden" data-tab="adventure">
                         <h2>Adventure</h2>
                         <p id="encounter-location"></p>
-                        <div id="adventure-slots" class="slots grid-slots"></div>
+                        <div id="adventure-slots" class="slots"></div>
                     </div>
                     <div class="tab-content hidden" data-tab="automation">
                         <h2>Control</h2>

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -101,6 +101,7 @@ const EncounterGenerator = {
 
     resetProgress() {
         this.populateSlots();
+        State.encounterStreak = 0;
         if (typeof AdventureEngine !== 'undefined') {
             AdventureEngine.startSlot(0);
         }

--- a/js/main.js
+++ b/js/main.js
@@ -64,11 +64,12 @@ const State = {
     // number of available action slots
     slotCount: 6,
     slots: [],
-    adventureSlotCount: 9,
+    adventureSlotCount: 1,
     adventureSlots: [],
     time: 1,
     masteryPoints: 0,
     encounterLevel: 0,
+    encounterStreak: 0,
 };
 
 for (let i = 0; i < State.slotCount; i++) {
@@ -227,6 +228,12 @@ const SaveSystem = {
                 if (State.encounterLevel === undefined) {
                     State.encounterLevel = 0;
                 }
+                if (State.encounterStreak === undefined) {
+                    State.encounterStreak = 0;
+                }
+                if (State.adventureSlotCount === undefined || State.adventureSlotCount > 1) {
+                    State.adventureSlotCount = 1;
+                }
                 if (Array.isArray(State.adventureSlots)) {
                     State.adventureSlots.forEach(s => {
                         if (s.active === undefined) s.active = false;
@@ -261,7 +268,7 @@ const AgeSystem = {
 
 const AdventureEngine = {
     activeIndex: null,
-    startSlot(i) {
+    startSlot(i = 0) {
         const encounter = EncounterGenerator.randomEncounter();
         const slot = State.adventureSlots[i];
         slot.encounter = encounter;
@@ -290,14 +297,13 @@ const AdventureEngine = {
             slot.active = false;
             slot.encounter = null;
             slot.progress = 0;
+            State.encounterStreak += 1;
             updateAdventureSlotUI(this.activeIndex);
-            const nextIndex = this.activeIndex + 1;
-            if (nextIndex < State.adventureSlots.length) {
-                this.startSlot(nextIndex);
-            } else {
+            if (State.encounterStreak >= 10) {
                 EncounterGenerator.incrementLevel();
-                this.activeIndex = null;
+                State.encounterStreak = 0;
             }
+            this.startSlot(this.activeIndex);
         } else {
             updateAdventureSlotUI(this.activeIndex);
         }

--- a/js/main.js
+++ b/js/main.js
@@ -373,7 +373,7 @@ function applyDeltas(deltaSeconds) {
 }
 
 function checkHealth() {
-    if (State.resources.health.value <= 0) {
+    if (State.resources.health.value < 0.1) {
         EncounterGenerator.decrementLevel();
         EncounterGenerator.resetProgress();
     }
@@ -772,6 +772,10 @@ async function init() {
     setupDragAndDrop();
     setupTooltips();
     TabManager.init();
+    document.getElementById('return-btn').addEventListener('click', () => {
+        EncounterGenerator.decrementLevel();
+        EncounterGenerator.resetProgress();
+    });
     document.getElementById('reset-btn').addEventListener('click', () => SaveSystem.reset());
     updateUI();
     // Game logic ticked separately from UI updates so resource generation


### PR DESCRIPTION
## Summary
- redesign the adventure tab with only one encounter slot
- increase encounter level after 10 consecutive encounters
- carry over encounter streak in save data
- note the update in README

## Testing
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_68599673a40c8330b9dfd36553d46fba