### PR TITLE
Add Inventory tab and loot items

### DIFF
--- a/data/encounters.json
+++ b/data/encounters.json
@@ -7,7 +7,8 @@
         "category": "intelligence",
         "baseDuration": 5,
         "image": "assets/enc/foraging.png",
-        "resourceConsumption": {"energy": 0.5, "focus": 1}
+        "resourceConsumption": {"energy": 0.5, "focus": 1},
+        "items": {"herb": 0.8, "energy_potion": 0.2}
     },
     {
         "id": "rabbitHunt",
@@ -17,7 +18,8 @@
         "category": "strength",
         "baseDuration": 6,
         "image": "assets/enc/rabbit.png",
-        "resourceConsumption": {"energy": 1, "focus": 0.5}
+        "resourceConsumption": {"energy": 1, "focus": 0.5},
+        "items": {"herb": 0.3}
     },
     {
         "id": "wolfAmbush",
@@ -27,6 +29,7 @@
         "category": "strength",
         "baseDuration": 10,
         "image": "assets/enc/wolf.png",
-        "resourceConsumption": {"energy": 1.5, "focus": 1, "health": 2}
+        "resourceConsumption": {"energy": 1.5, "focus": 1, "health": 2},
+        "items": {"energy_potion": 0.5, "ancient_tome": 0.1}
     }
 ]

--- a/data/items.json
+++ b/data/items.json
@@ -14,5 +14,13 @@
         "effectType": "increaseSoftcap",
         "effectValue": {"intelligence": 2},
         "maxQuantity": 1
+    },
+    {
+        "id": "herb",
+        "name": "Herb",
+        "rarity": "common",
+        "effectType": "generateResource",
+        "effectValue": {"health": 2},
+        "maxQuantity": 10
     }
 ]

--- a/index.html
+++ b/index.html
@@ -70,6 +70,10 @@
                         <button id="return-btn">Return</button>
                         <div id="adventure-slots" class="slots"></div>
                     </div>
+                    <div class="tab-content hidden" data-tab="inventory">
+                        <h2>Inventory</h2>
+                        <div id="inventory-slots" class="slots"></div>
+                    </div>
                     <div class="tab-content hidden" data-tab="automation">
                         <h2>Control</h2>
                         <p>Crafting and Automation go here.</p>

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -8,6 +8,7 @@ class Encounter {
         this.category = data.category || 'strength';
         this.baseDuration = data.baseDuration || 5;
         this.resourceConsumption = data.resourceConsumption || {};
+        this.items = data.items || null;
     }
 
     getDuration() {
@@ -140,7 +141,11 @@ const EncounterGenerator = {
     resolve(encounter) {
         const chance = encounter.getLootChance();
         if (Math.random() < chance) {
-            Log.add(`You found loot during ${encounter.name}!`);
+            const item = ItemGenerator.generateFromEncounter(encounter);
+            if (item) {
+                Log.add(`You found ${capitalize(item.rarity)} ${item.name} during ${encounter.name}!`);
+                Inventory.add(item);
+            }
         }
     }
 };

--- a/js/items.js
+++ b/js/items.js
@@ -84,8 +84,48 @@ const ItemGenerator = {
             this.rarityTable.common -= 0.05;
         }
     },
+
+    generateFromEncounter(encounter) {
+        if (!encounter.items) return null;
+        const pool = [];
+        const weights = [];
+        for (const [id, weight] of Object.entries(encounter.items)) {
+            const item = this.itemList.find(i => i.id === id);
+            if (!item) continue;
+            pool.push(item);
+            weights.push(weight);
+        }
+        if (!pool.length) return null;
+        const total = weights.reduce((a, b) => a + b, 0);
+        let r = Math.random() * total;
+        for (let i = 0; i < pool.length; i++) {
+            r -= weights[i];
+            if (r <= 0) return pool[i];
+        }
+        return pool[pool.length - 1];
+    },
+};
+
+const Inventory = {
+    add(item) {
+        if (!State.inventory[item.id]) {
+            State.inventory[item.id] = { quantity: 1 };
+        } else {
+            const result = item.handleDuplicate(State.inventory);
+            if (result !== 'converted') {
+                State.inventory[item.id].quantity += 1;
+            }
+        }
+        InventoryUI.update();
+    },
+    getItems() {
+        return Object.entries(State.inventory).map(([id, data]) => ({
+            id,
+            quantity: data.quantity,
+        }));
+    },
 };
 
 if (typeof module !== 'undefined') {
-    module.exports = { Item, ItemGenerator };
+    module.exports = { Item, ItemGenerator, Inventory };
 }

--- a/js/main.js
+++ b/js/main.js
@@ -66,6 +66,8 @@ const State = {
     slots: [],
     adventureSlotCount: 1,
     adventureSlots: [],
+    inventorySlotCount: 8,
+    inventory: {},
     time: 1,
     masteryPoints: 0,
     encounterLevel: 0,
@@ -147,6 +149,7 @@ const TabManager = {
     tabs: [
         { id: 'routines', name: 'Routines', hidden: false, locked: false },
         { id: 'adventure', name: 'Adventure', hidden: true, locked: false },
+        { id: 'inventory', name: 'Inventory', hidden: false, locked: false },
         { id: 'automation', name: 'Automation', hidden: false, locked: false },
     ],
     init() {
@@ -238,6 +241,12 @@ const SaveSystem = {
                     State.adventureSlots.forEach(s => {
                         if (s.active === undefined) s.active = false;
                     });
+                }
+                if (State.inventorySlotCount === undefined) {
+                    State.inventorySlotCount = 8;
+                }
+                if (!State.inventory) {
+                    State.inventory = {};
                 }
                 return data.actions || null;
             } else {
@@ -618,6 +627,22 @@ function setupAdventureSlots() {
     }
 }
 
+function setupInventorySlots() {
+    const container = document.getElementById('inventory-slots');
+    if (!container) return;
+    container.innerHTML = '';
+    const count = State.inventorySlotCount || 0;
+    for (let i = 0; i < count; i++) {
+        const slotEl = document.createElement('div');
+        slotEl.className = 'slot';
+        const label = document.createElement('span');
+        label.className = 'label';
+        slotEl.appendChild(label);
+        container.appendChild(slotEl);
+    }
+    InventoryUI.update();
+}
+
 function setupDragAndDrop() {
     document.querySelectorAll('#slots .slot').forEach(slotEl => {
         slotEl.addEventListener('dragover', e => e.preventDefault());
@@ -769,9 +794,11 @@ async function init() {
     StatsUI.init();
     ResourcesUI.init();
     MasteryUI.init();
+    InventoryUI.init();
     updateTaskList();
     setupSlots();
     setupAdventureSlots();
+    setupInventorySlots();
     EncounterGenerator.init();
     setupDragAndDrop();
     setupTooltips();

--- a/js/ui.js
+++ b/js/ui.js
@@ -47,6 +47,31 @@ const MasteryUI = {
     }
 };
 
+const InventoryUI = {
+    init() {
+        this.container = document.getElementById('inventory-slots');
+        this.update();
+    },
+    update() {
+        if (!this.container) return;
+        const items = Inventory.getItems();
+        const count = State.inventorySlotCount || 0;
+        this.container.innerHTML = '';
+        for (let i = 0; i < count; i++) {
+            const slot = document.createElement('div');
+            slot.className = 'slot';
+            const label = document.createElement('span');
+            label.className = 'label';
+            if (items[i]) {
+                const item = items[i];
+                label.textContent = `${item.quantity}x ${item.id}`;
+            }
+            slot.appendChild(label);
+            this.container.appendChild(slot);
+        }
+    }
+};
+
 const Log = {
     messages: [],
     init() {

--- a/tests/test_encounters.py
+++ b/tests/test_encounters.py
@@ -15,3 +15,8 @@ def test_encounter_fields():
         for val in enc['resourceConsumption'].values():
             assert isinstance(val, (int, float))
             assert val > 0
+        assert 'items' in enc
+        assert isinstance(enc['items'], dict)
+        for prob in enc['items'].values():
+            assert isinstance(prob, (int, float))
+            assert 0 <= prob <= 1


### PR DESCRIPTION
## Summary
- expand items and encounters data with new loot and drop tables
- add Inventory tab with UI slots
- trigger item generation on encounter resolution
- log loot messages with item rarity and name
- update tests for encounter items

## Testing
- `pytest --cov=./ -q`

------
https://chatgpt.com/codex/tasks/task_e_6859a7e9e34c8330822097b748ebe59f