### PR TITLE
Add item images and dynamic inventory

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -137,6 +137,17 @@ main {
     color: #fff;
 }
 
+.slot .count {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    text-align: center;
+    font-size: 0.8rem;
+    pointer-events: none;
+    color: #fff;
+}
+
 .tooltip {
     position: absolute;
     background: #333;

--- a/data/encounters.json
+++ b/data/encounters.json
@@ -8,7 +8,7 @@
         "baseDuration": 5,
         "image": "assets/enc/foraging.png",
         "resourceConsumption": {"energy": 0.5, "focus": 1},
-        "items": {"herb": 0.8, "energy_potion": 0.2}
+        "items": {"herb": 1.0}
     },
     {
         "id": "rabbitHunt",
@@ -19,7 +19,7 @@
         "baseDuration": 6,
         "image": "assets/enc/rabbit.png",
         "resourceConsumption": {"energy": 1, "focus": 0.5},
-        "items": {"herb": 0.3}
+        "items": {"rabbit_meat": 0.7, "herb": 0.3}
     },
     {
         "id": "wolfAmbush",
@@ -30,6 +30,6 @@
         "baseDuration": 10,
         "image": "assets/enc/wolf.png",
         "resourceConsumption": {"energy": 1.5, "focus": 1, "health": 2},
-        "items": {"energy_potion": 0.5, "ancient_tome": 0.1}
+        "items": {"wolf_pelt": 0.5}
     }
 ]

--- a/data/items.json
+++ b/data/items.json
@@ -1,26 +1,29 @@
 [
     {
-        "id": "energy_potion",
-        "name": "Energy Potion",
-        "rarity": "common",
-        "effectType": "generateResource",
-        "effectValue": {"energy": 5},
-        "maxQuantity": 5
-    },
-    {
-        "id": "ancient_tome",
-        "name": "Ancient Tome",
-        "rarity": "rare",
-        "effectType": "increaseSoftcap",
-        "effectValue": {"intelligence": 2},
-        "maxQuantity": 1
-    },
-    {
         "id": "herb",
         "name": "Herb",
         "rarity": "common",
         "effectType": "generateResource",
         "effectValue": {"health": 2},
-        "maxQuantity": 10
+        "maxQuantity": 10,
+        "image": "assets/items/herb.png"
+    },
+    {
+        "id": "rabbit_meat",
+        "name": "Rabbit Meat",
+        "rarity": "common",
+        "effectType": "generateResource",
+        "effectValue": {"energy": 3},
+        "maxQuantity": 5,
+        "image": "assets/items/rabbit.png"
+    },
+    {
+        "id": "wolf_pelt",
+        "name": "Wolf Pelt",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {"strength": 1},
+        "maxQuantity": 3,
+        "image": "assets/items/wolfpelt.png"
     }
 ]

--- a/js/items.js
+++ b/js/items.js
@@ -6,6 +6,7 @@ class Item {
         this.effectType = data.effectType;
         this.effectValue = data.effectValue;
         this.maxQuantity = data.maxQuantity || 1;
+        this.image = data.image || null;
     }
 
     applyEffect(targetState) {
@@ -46,9 +47,9 @@ const ItemGenerator = {
         legendary: 0.02,
     },
     generationSources: {
-        hunting: ['energy_potion'],
-        exploring: ['ancient_tome'],
-        quests: ['energy_potion', 'ancient_tome'],
+        hunting: ['rabbit_meat', 'wolf_pelt'],
+        exploring: ['herb'],
+        quests: ['herb', 'rabbit_meat', 'wolf_pelt'],
     },
 
     async load() {
@@ -119,10 +120,14 @@ const Inventory = {
         InventoryUI.update();
     },
     getItems() {
-        return Object.entries(State.inventory).map(([id, data]) => ({
-            id,
-            quantity: data.quantity,
-        }));
+        return Object.entries(State.inventory).map(([id, data]) => {
+            const itemData = ItemGenerator.itemList.find(i => i.id === id) || {};
+            return {
+                id,
+                quantity: data.quantity,
+                image: itemData.image,
+            };
+        });
     },
 };
 

--- a/js/items.js
+++ b/js/items.js
@@ -124,6 +124,7 @@ const Inventory = {
             const itemData = ItemGenerator.itemList.find(i => i.id === id) || {};
             return {
                 id,
+                name: itemData.name || id,
                 quantity: data.quantity,
                 image: itemData.image,
             };

--- a/js/main.js
+++ b/js/main.js
@@ -628,18 +628,6 @@ function setupAdventureSlots() {
 }
 
 function setupInventorySlots() {
-    const container = document.getElementById('inventory-slots');
-    if (!container) return;
-    container.innerHTML = '';
-    const count = State.inventorySlotCount || 0;
-    for (let i = 0; i < count; i++) {
-        const slotEl = document.createElement('div');
-        slotEl.className = 'slot';
-        const label = document.createElement('span');
-        label.className = 'label';
-        slotEl.appendChild(label);
-        container.appendChild(slotEl);
-    }
     InventoryUI.update();
 }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -55,7 +55,7 @@ const InventoryUI = {
     update() {
         if (!this.container) return;
         const items = Inventory.getItems();
-        const count = State.inventorySlotCount || 0;
+        const count = items.length;
         this.container.innerHTML = '';
         for (let i = 0; i < count; i++) {
             const slot = document.createElement('div');
@@ -65,6 +65,11 @@ const InventoryUI = {
             if (items[i]) {
                 const item = items[i];
                 label.textContent = `${item.quantity}x ${item.id}`;
+                if (item.image) {
+                    slot.style.backgroundImage = `url(${item.image})`;
+                }
+            } else {
+                slot.style.backgroundImage = 'none';
             }
             slot.appendChild(label);
             this.container.appendChild(slot);

--- a/js/ui.js
+++ b/js/ui.js
@@ -62,16 +62,22 @@ const InventoryUI = {
             slot.className = 'slot';
             const label = document.createElement('span');
             label.className = 'label';
+            const countEl = document.createElement('span');
+            countEl.className = 'count';
             if (items[i]) {
                 const item = items[i];
-                label.textContent = `${item.quantity}x ${item.id}`;
+                label.textContent = capitalize(item.name);
+                countEl.textContent = item.quantity;
                 if (item.image) {
                     slot.style.backgroundImage = `url(${item.image})`;
                 }
             } else {
                 slot.style.backgroundImage = 'none';
+                label.textContent = '';
+                countEl.textContent = '';
             }
             slot.appendChild(label);
+            slot.appendChild(countEl);
             this.container.appendChild(slot);
         }
     }

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -14,3 +14,4 @@ def test_item_fields():
         assert 'effectValue' in item
         assert 'maxQuantity' in item
         assert isinstance(item['maxQuantity'], int)
+        assert 'image' in item


### PR DESCRIPTION
## Summary
- simplify inventory slots setup and make them scale with number of items
- show item images in inventory slots
- support `image` property in Item class and map new generation sources
- replace old items list with Herb, Rabbit Meat and Wolf Pelt
- update encounter loot tables to use the new items
- check for `image` field in item tests

## Testing
- `python3 -m pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_6859b16444408330a16857caade78c93