### PR TITLE
Update item system to modify softcaps

### DIFF
--- a/data/items.json
+++ b/data/items.json
@@ -4,7 +4,7 @@
         "name": "Herb",
         "rarity": "common",
         "effectType": "increaseSoftcap",
-        "effectValue": {"focus": 2},
+        "effectValue": {"focus": 1},
         "image": "assets/items/herb.png"
     },
     {

--- a/data/items.json
+++ b/data/items.json
@@ -3,18 +3,16 @@
         "id": "herb",
         "name": "Herb",
         "rarity": "common",
-        "effectType": "generateResource",
-        "effectValue": {"health": 2},
-        "maxQuantity": 10,
+        "effectType": "increaseSoftcap",
+        "effectValue": {"focus": 2},
         "image": "assets/items/herb.png"
     },
     {
         "id": "rabbit_meat",
         "name": "Rabbit Meat",
         "rarity": "common",
-        "effectType": "generateResource",
-        "effectValue": {"energy": 3},
-        "maxQuantity": 5,
+        "effectType": "increaseSoftcap",
+        "effectValue": {"strength": 1},
         "image": "assets/items/rabbit.png"
     },
     {
@@ -22,8 +20,7 @@
         "name": "Wolf Pelt",
         "rarity": "rare",
         "effectType": "increaseSoftcap",
-        "effectValue": {"strength": 1},
-        "maxQuantity": 3,
+        "effectValue": {"health": 2},
         "image": "assets/items/wolfpelt.png"
     }
 ]

--- a/js/main.js
+++ b/js/main.js
@@ -147,6 +147,11 @@ const SoftCapSystem = {
                 }
             }
         }
+        for (const r in this.resourceCaps) {
+            if (State.resources[r]) {
+                State.resources[r].baseMax = this.resourceCaps[r];
+            }
+        }
     },
     apply() {
         for (const s in this.statCaps) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -5,13 +5,15 @@ const StatsUI = {
         const listEl = document.getElementById('stats-list');
         this.list.forEach(key => {
             const li = document.createElement('li');
-            li.innerHTML = `${capitalize(key)}: <span id="stat-${key}">0</span>(<span id="stat-${key}-delta" class="delta">0</span>/s)`;
+            li.innerHTML = `${capitalize(key)}: <span id="stat-${key}">0</span>/<span id="stat-${key}-cap">0</span> (<span id="stat-${key}-delta" class="delta">0</span>/s)`;
             listEl.appendChild(li);
         });
     },
     update() {
         this.list.forEach(key => {
             document.getElementById(`stat-${key}`).textContent = State.stats[key].toFixed(1);
+            const capEl = document.getElementById(`stat-${key}-cap`);
+            if (capEl) capEl.textContent = SoftCapSystem.statCaps[key].toFixed(1);
             document.getElementById(`stat-${key}-delta`).textContent = formatDelta(statDeltas[key]);
         });
     }
@@ -30,7 +32,8 @@ const ResourcesUI = {
     update() {
         this.list.forEach(key => {
             document.getElementById(`res-${key}`).textContent = getResourceValue(key).toFixed(1);
-            document.getElementById(`res-${key}-cap`).textContent = getResourceMax(key);
+            const capEl = document.getElementById(`res-${key}-cap`);
+            if (capEl) capEl.textContent = SoftCapSystem.resourceCaps[key].toFixed(1);
             document.getElementById(`res-${key}-delta`).textContent = formatDelta(resourceDeltas[key]);
         });
     }

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -12,6 +12,17 @@ def test_item_fields():
         assert 'rarity' in item
         assert 'effectType' in item
         assert 'effectValue' in item
-        assert 'maxQuantity' in item
-        assert isinstance(item['maxQuantity'], int)
+        assert isinstance(item['effectValue'], dict)
         assert 'image' in item
+
+
+def test_effect_formula_log():
+    path = os.path.join('data', 'items.json')
+    with open(path) as f:
+        data = json.load(f)
+    herb = next(i for i in data if i['id'] == 'herb')
+    qty = 1
+    effect_val = herb['effectValue']['focus']
+    import math
+    effect = effect_val * math.log(qty + 1)
+    assert effect > 0


### PR DESCRIPTION
## Summary
- rework item definitions to remove quantity limits and switch to softcap bonuses
- recalc softcaps from inventory via `SoftCapSystem.recalculateCaps`
- update inventory logic to refresh softcaps when items change
- add tests for new item data and formulas

## Testing
- `pip install pytest-cov`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_6859bdec9a1883308afa93b9d3821a65