### PR TITLE
Add character background module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.12.0] - 2025-07-01
+### Added
+- CharacterBackground module updates left panel based on equipment.
+### Changed
+- Use existing 'leather+woodshield+spear.png' image for equipped character background.
+
 ## [0.10.0] - 2025-06-29
 ### Added
 - Python script `scripts/image_pipeline.py` to auto-generate missing item images

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Version 0.9.0 adds story encounters that trigger once at specific location level
 | Inventory    | Manages player's resource quantities and magical components                |
 | Automation   | Enables actions to loop with or without conditions                         |
 | UI           | Interface for selecting tasks, viewing stats/resources, and managing slots |
+| Character Background | Updates left panel image based on equipped items |
 
 #### 5. Core Stats (Initial Set)
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -58,6 +58,12 @@ main {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
+#left {
+    background-size: cover;
+    background-position: center;
+    background-repeat: no-repeat;
+}
+
 #task-list {
     list-style: none;
     padding: 0;

--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -11,3 +11,4 @@ Use this list to verify the first playable prototype of **Progress Realm**:
 - [x] Multiple action slots with drag-and-drop
 - [x] Introductory story modal and log panel
 - [x] Inventory tab with basic item generator
+- [x] Character background art updates when equipped with starter gear

--- a/index.html
+++ b/index.html
@@ -99,6 +99,7 @@
     <script src="js/encounter.js"></script>
     <script src="js/items.js"></script>
     <script src="js/ui.js"></script>
+    <script src="js/char_bg.js"></script>
     <script src="js/main.js"></script>
 </body>
 </html>

--- a/js/char_bg.js
+++ b/js/char_bg.js
@@ -1,0 +1,23 @@
+const CharacterBackground = {
+    baseImage: 'assets/char/new_char.png',
+    equippedImage: 'assets/char/leather+woodshield+spear.png',
+    container: null,
+    init() {
+        this.container = document.getElementById('left');
+        this.update();
+    },
+    update() {
+        if (!this.container) return;
+        if (Inventory.hasItem('leather_armor') &&
+            Inventory.hasItem('wooden_shield') &&
+            Inventory.hasItem('stone_spear')) {
+            this.container.style.backgroundImage = `url(${this.equippedImage})`;
+        } else {
+            this.container.style.backgroundImage = `url(${this.baseImage})`;
+        }
+    }
+};
+
+if (typeof module !== 'undefined') {
+    module.exports = { CharacterBackground };
+}

--- a/js/items.js
+++ b/js/items.js
@@ -97,6 +97,9 @@ const Inventory = {
         }
         SoftCapSystem.recalculateCaps(State.inventory);
         InventoryUI.update();
+        if (typeof CharacterBackground !== 'undefined') {
+            CharacterBackground.update();
+        }
     },
     getItems() {
         return Object.entries(State.inventory).map(([id, data]) => {
@@ -108,6 +111,9 @@ const Inventory = {
                 image: itemData.image,
             };
         });
+    },
+    hasItem(id) {
+        return State.inventory[id] && State.inventory[id].quantity > 0;
     },
 };
 

--- a/js/main.js
+++ b/js/main.js
@@ -823,6 +823,9 @@ async function init() {
     ResourcesUI.init();
     MasteryUI.init();
     InventoryUI.init();
+    if (typeof CharacterBackground !== 'undefined') {
+        CharacterBackground.init();
+    }
     updateTaskList();
     setupSlots();
     setupAdventureSlots();


### PR DESCRIPTION
## Summary
- update UI styling for left panel background
- add CharacterBackground module to swap images based on inventory items
- allow inventory to check for items and notify background update
- initialize CharacterBackground in main logic
- document the new feature in README, docs and changelog
- include placeholder image for equipped character
- remove placeholder and use proper char equipped image

## Testing
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_685a44df8a708330afdd77e62cbd0212