### PR TITLE
Add autoprogress toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.13.0] - 2025-07-02
+### Added
+- Autoprogress checkbox in the Adventure tab to pause encounter level ups.
+
 ## [0.12.0] - 2025-07-01
 ### Added
 - CharacterBackground module updates left panel based on equipment.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Version 0.5.0 redesigns the Adventure tab with a single slot. Encounter level no
 Version 0.6.0 introduces an Inventory tab and item generator to track loot from encounters.
 Version 0.7.0 adds level-gated encounters ranging from common to legendary tiers with new item rewards.
 Version 0.9.0 adds story encounters that trigger once at specific location levels. The first, Bandits Ambush, grants a gem and an iron sword.
+Version 0.13.0 introduces an Autoprogress checkbox to pause encounter level ups.
 
 #### 3. Core Gameplay Loop
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -169,6 +169,19 @@ main {
     margin-top: 0.5rem;
 }
 
+#adventure-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+#adventure-controls label {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
 #return-btn {
     margin-top: 0.5rem;
 }

--- a/index.html
+++ b/index.html
@@ -67,7 +67,10 @@
                     <div class="tab-content hidden" data-tab="adventure">
                         <h2>Adventure</h2>
                         <p id="encounter-location"></p>
-                        <button id="return-btn">Return</button>
+                        <div id="adventure-controls">
+                            <button id="return-btn">Return</button>
+                            <label><input type="checkbox" id="autoprogress-toggle" checked> Autoprogress</label>
+                        </div>
                         <div id="adventure-slots" class="slots"></div>
                     </div>
                     <div class="tab-content hidden" data-tab="inventory">

--- a/js/main.js
+++ b/js/main.js
@@ -73,6 +73,7 @@ const State = {
     masteryPoints: 0,
     encounterLevel: 0,
     encounterStreak: 0,
+    autoProgress: true,
 };
 
 for (let i = 0; i < State.slotCount; i++) {
@@ -277,6 +278,9 @@ const SaveSystem = {
                 if (State.banditsAmbushSeen === undefined) {
                     State.banditsAmbushSeen = false;
                 }
+                if (State.autoProgress === undefined) {
+                    State.autoProgress = true;
+                }
                 return data.actions || null;
             } else {
                 Object.assign(State, data); // legacy save
@@ -347,8 +351,12 @@ const AdventureEngine = {
             State.encounterStreak += 1;
             updateAdventureSlotUI(this.activeIndex);
             if (State.encounterStreak >= 10) {
-                EncounterGenerator.incrementLevel();
-                State.encounterStreak = 0;
+                if (State.autoProgress) {
+                    EncounterGenerator.incrementLevel();
+                    State.encounterStreak = 0;
+                } else {
+                    State.encounterStreak = 10;
+                }
             }
             this.startSlot(this.activeIndex);
         } else {
@@ -834,6 +842,14 @@ async function init() {
     setupDragAndDrop();
     setupTooltips();
     TabManager.init();
+    const autoBox = document.getElementById('autoprogress-toggle');
+    if (autoBox) {
+        autoBox.checked = State.autoProgress;
+        autoBox.addEventListener('change', () => {
+            State.autoProgress = autoBox.checked;
+            SaveSystem.save();
+        });
+    }
     document.getElementById('return-btn').addEventListener('click', () => {
         retreat('resolve');
     });


### PR DESCRIPTION
## Summary
- add Autoprogress checkbox in the Adventure tab
- store new AutoProgress state and hook into encounter leveling
- style new control with some spacing
- document the new feature and note in CHANGELOG

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685a5755ffc08330bcca406ca3698291