### PR TITLE
Add bandits ambush repeat chance and data-based loot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.14.0] - 2025-07-03
+### Changed
+- Bandits Ambush now has a very low chance to reoccur after the first guaranteed encounter.
+- Loot from Bandits Ambush is determined by the encounter data file.
+
 ## [0.13.0] - 2025-07-02
 ### Added
 - Autoprogress checkbox in the Adventure tab to pause encounter level ups.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Version 0.6.0 introduces an Inventory tab and item generator to track loot from 
 Version 0.7.0 adds level-gated encounters ranging from common to legendary tiers with new item rewards.
 Version 0.9.0 adds story encounters that trigger once at specific location levels. The first, Bandits Ambush, grants a gem and an iron sword.
 Version 0.13.0 introduces an Autoprogress checkbox to pause encounter level ups.
+Version 0.14.0 lets Bandits Ambush return with a very low chance and drops items defined in the data files.
 
 #### 3. Core Gameplay Loop
 

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -46,6 +46,7 @@ const EncounterGenerator = {
         rare: 0.5,
         epic: 0.2,
         legendary: 0.1,
+        story: 0.05,
     },
     lootBaseByCategory: {
         strength: 0.02,
@@ -153,14 +154,16 @@ const EncounterGenerator = {
 
     resolve(encounter) {
         if (encounter.id === 'banditsAmbush') {
-            const gem = ItemGenerator.itemList.find(i => i.id === 'gem');
-            const sword = ItemGenerator.itemList.find(i => i.id === 'iron_sword');
-            if (gem) Inventory.add(gem);
-            if (sword) Inventory.add(sword);
+            for (const [id, chance] of Object.entries(encounter.items || {})) {
+                const item = ItemGenerator.itemList.find(i => i.id === id);
+                if (item && Math.random() < chance) {
+                    Inventory.add(item);
+                }
+            }
             Log.add('You survived the bandits ambush and claimed your reward.');
             if (!State.banditsAmbushSeen) {
                 Story.show(
-                    'Bruised but victorious, you find a glittering gem and a sturdy sword among the fallen bandits.',
+                    'Bruised but victorious, you gather loot from the fallen bandits.',
                     '',
                     () => {
                         State.banditsAmbushSeen = true;

--- a/tests/test_encounters.py
+++ b/tests/test_encounters.py
@@ -28,5 +28,10 @@ def test_story_encounter():
         data = json.load(f)
     story = next(e for e in data if e['id'] == 'banditsAmbush')
     assert story['rarity'] == 'story'
-    assert story['items']['gem'] == 1.0
-    assert story['items']['iron_sword'] == 1.0
+    expected_items = {
+        'gem': 1.0,
+        'iron_sword': 1.0,
+        'wooden_shield': 1.0,
+        'leather_armor': 1.0,
+    }
+    assert story['items'] == expected_items


### PR DESCRIPTION
## Summary
- allow rare bandits ambush repeat by adding a small weight to story rarity
- drop bandits ambush loot using items from the encounter data
- update README with new feature note
- document change in CHANGELOG
- adjust tests for updated bandits ambush items

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a5b7c204c8330a2205553140ad506