### PR TITLE
Use set+sword full gear image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.15.0] - 2025-07-04
+### Added
+- Character background now shows a special image when leather armor, a wooden shield, an iron sword and a gem are equipped.
+
+## [0.15.1] - 2025-07-05
+### Changed
+- Updated full gear image reference to `set+sword.png`.
+
 ## [0.14.0] - 2025-07-03
 ### Changed
 - Bandits Ambush now has a very low chance to reoccur after the first guaranteed encounter.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Version 0.14.0 lets Bandits Ambush return with a very low chance and drops items
 | Inventory    | Manages player's resource quantities and magical components                |
 | Automation   | Enables actions to loop with or without conditions                         |
 | UI           | Interface for selecting tasks, viewing stats/resources, and managing slots |
-| Character Background | Updates left panel image based on equipped items |
+| Character Background | Updates left panel image based on equipped items, including a pose for full gear (leather armor, wooden shield, iron sword, gem) |
 
 #### 5. Core Stats (Initial Set)
 

--- a/js/char_bg.js
+++ b/js/char_bg.js
@@ -1,6 +1,7 @@
 const CharacterBackground = {
     baseImage: 'assets/char/new_char.png',
     equippedImage: 'assets/char/leather+woodshield+spear.png',
+    fullGearImage: 'assets/char/set+sword.png',
     container: null,
     init() {
         this.container = document.getElementById('left');
@@ -8,9 +9,12 @@ const CharacterBackground = {
     },
     update() {
         if (!this.container) return;
-        if (Inventory.hasItem('leather_armor') &&
-            Inventory.hasItem('wooden_shield') &&
-            Inventory.hasItem('stone_spear')) {
+        const fullGear = ['leather_armor', 'wooden_shield', 'iron_sword', 'gem'];
+        const spearSet = ['leather_armor', 'wooden_shield', 'stone_spear'];
+
+        if (fullGear.every(item => Inventory.hasItem(item))) {
+            this.container.style.backgroundImage = `url(${this.fullGearImage})`;
+        } else if (spearSet.every(item => Inventory.hasItem(item))) {
             this.container.style.backgroundImage = `url(${this.equippedImage})`;
         } else {
             this.container.style.backgroundImage = `url(${this.baseImage})`;


### PR DESCRIPTION
## Summary
- rename full gear image to `set+sword.png` and update JS reference
- document the asset change in the changelog

## Testing
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_685a60c338f88330bf3ccd82c376c1d7