### PR TITLE
Add rare drops and lumber team encounter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,4 @@
 - Open a pull request for every change instead of pushing directly to `main`
 - Provide a clear PR title and summary of the changes
 - Update `CHANGELOG.md` with a short note describing each change
+- Add new entries to the **top** of the changelog so the latest changes appear first

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.27.0] - 2025-07-17
+### Changed
+- Slots now have a dark background so labels remain visible when no image is set.
+
 ## [0.26.0] - 2025-07-16
 ### Added
 - Left panel can now be collapsed via a button in the header.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.31.0] - 2025-07-20
+### Changed
+- Removed numeric amounts from item tooltips.
+
+## [0.30.0] - 2025-07-20
+### Added
+- Tooltips now appear on all slots.
+- Inventory slots display item descriptions and effects.
+- Adventure slots show encounter descriptions and loot chances.
+
 ## [0.29.0] - 2025-07-19
 ### Changed
 - Modals now follow dark mode theme.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,13 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Base encounter durations are now set by rarity: 1s for common, 2s for rare, 5s for epic, 10s for legendary and 15s for story.
 
+## [0.26.0] - 2025-07-16
+### Added
+- Left panel can now be collapsed via a button in the header.
+### Changed
+- Ore chunk and gem items are now rare.
+- Find Ore and Ancient Vault encounters are rare with shorter base durations.
+
 ## [0.15.0] - 2025-07-04
 ### Added
 - Character background now shows a special image when leather armor, a wooden shield, an iron sword and a gem are equipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Rebalanced `maxLevel` values so early tasks phase out sooner.
 
+## [0.24.0] - 2025-07-14
+### Changed
+- Encounter duration now derives from level divided by relevant stats and honors `baseDurationScale` as a minimum multiplier.
+
+## [0.25.0] - 2025-07-15
+### Changed
+- Base encounter durations are now set by rarity: 1s for common, 2s for rare, 5s for epic, 10s for legendary and 15s for story.
+
 ## [0.15.0] - 2025-07-04
 ### Added
 - Character background now shows a special image when leather armor, a wooden shield, an iron sword and a gem are equipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,50 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.16.0] - 2025-07-06
-### Changed
-- Delta calculations moved to new engine module and now accept multipliers for game speed.
-
-## [0.17.0] - 2025-07-07
-### Changed
-- DeltaEngine now handles aging and action experience so all progression uses the same speed scaling.
-
-## [0.18.0] - 2025-07-08
-### Changed
-- Encounter progress is now processed by DeltaEngine so adventure timing respects game speed.
-
-## [0.19.0] - 2025-07-09
-### Added
-- Border colors now reflect item and encounter rarity.
-- Log entries highlight item and encounter names by rarity without showing rarity text.
-- Bonus Engine module applies additive, multiplicative and exponential modifiers before deltas update stats and resources, and supports cost divisors for consumptions.
-
-## [0.20.0] - 2025-07-10
-### Added
-- Encounters now include a `maxLevel` property to remove them from the pool once the adventure level surpasses it.
-
-## [0.21.0] - 2025-07-11
-### Added
-- Encounters can specify guaranteed `loot` amounts alongside probability-based `items` drops.
-
-## [0.22.0] - 2025-07-12
-### Changed
-- Loot yield now scales with your stats based on each encounter's category.
-
-## [0.23.0] - 2025-07-13
-### Added
-- Rare items now occasionally drop from common encounters and wood gathering tasks scale into a new "Oversee Lumber Team" encounter.
-### Changed
-- Rebalanced `maxLevel` values so early tasks phase out sooner.
-
-## [0.24.0] - 2025-07-14
-### Changed
-- Encounter duration now derives from level divided by relevant stats and honors `baseDurationScale` as a minimum multiplier.
-
-## [0.25.0] - 2025-07-15
-### Changed
-- Base encounter durations are now set by rarity: 1s for common, 2s for rare, 5s for epic, 10s for legendary and 15s for story.
-
 ## [0.26.0] - 2025-07-16
 ### Added
 - Left panel can now be collapsed via a button in the header.
@@ -53,13 +9,57 @@ All notable changes to this project will be documented in this file.
 - Ore chunk and gem items are now rare.
 - Find Ore and Ancient Vault encounters are rare with shorter base durations.
 
-## [0.15.0] - 2025-07-04
+## [0.25.0] - 2025-07-15
+### Changed
+- Base encounter durations are now set by rarity: 1s for common, 2s for rare, 5s for epic, 10s for legendary and 15s for story.
+
+## [0.24.0] - 2025-07-14
+### Changed
+- Encounter duration now derives from level divided by relevant stats and honors `baseDurationScale` as a minimum multiplier.
+
+## [0.23.0] - 2025-07-13
 ### Added
-- Character background now shows a special image when leather armor, a wooden shield, an iron sword and a gem are equipped.
+- Rare items now occasionally drop from common encounters and wood gathering tasks scale into a new "Oversee Lumber Team" encounter.
+### Changed
+- Rebalanced `maxLevel` values so early tasks phase out sooner.
+
+## [0.22.0] - 2025-07-12
+### Changed
+- Loot yield now scales with your stats based on each encounter's category.
+
+## [0.21.0] - 2025-07-11
+### Added
+- Encounters can specify guaranteed `loot` amounts alongside probability-based `items` drops.
+
+## [0.20.0] - 2025-07-10
+### Added
+- Encounters now include a `maxLevel` property to remove them from the pool once the adventure level surpasses it.
+
+## [0.19.0] - 2025-07-09
+### Added
+- Border colors now reflect item and encounter rarity.
+- Log entries highlight item and encounter names by rarity without showing rarity text.
+- Bonus Engine module applies additive, multiplicative and exponential modifiers before deltas update stats and resources, and supports cost divisors for consumptions.
+
+## [0.18.0] - 2025-07-08
+### Changed
+- Encounter progress is now processed by DeltaEngine so adventure timing respects game speed.
+
+## [0.17.0] - 2025-07-07
+### Changed
+- DeltaEngine now handles aging and action experience so all progression uses the same speed scaling.
+
+## [0.16.0] - 2025-07-06
+### Changed
+- Delta calculations moved to new engine module and now accept multipliers for game speed.
 
 ## [0.15.1] - 2025-07-05
 ### Changed
 - Updated full gear image reference to `set+sword.png`.
+
+## [0.15.0] - 2025-07-04
+### Added
+- Character background now shows a special image when leather armor, a wooden shield, an iron sword and a gem are equipped.
 
 ## [0.14.0] - 2025-07-03
 ### Changed
@@ -76,32 +76,27 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Use existing 'leather+woodshield+spear.png' image for equipped character background.
 
-## [0.10.0] - 2025-06-29
-### Added
-- Python script `scripts/image_pipeline.py` to auto-generate missing item images
-  via OpenAI's DALL·E API.
-- Documentation section on the new image pipeline.
-### Fixed
-- Updated image pipeline to use `client.images.generate` with API key handling.
-
 ## [0.11.0] - 2025-06-30
 ### Added
 - Scripts `image_pipeline_encounters.py` and `image_pipeline_actions.py` for
   generating encounter and action images.
 - Updated README with image pipeline details for all asset types.
 
-## [0.6.0] - 2025-06-24
+## [0.10.0] - 2025-06-29
 ### Added
-- Inventory tab with item generator. Items now drop from encounters and appear in your inventory.
-### Documentation
-- Updated README and docs with inventory details and modularization progress.
-- Added `docs/AGENTS.md` with documentation update rules.
+- Python script `scripts/image_pipeline.py` to auto-generate missing item images  via OpenAI's DALL·E API.
+- Documentation section on the new image pipeline.
+### Fixed
+- Updated image pipeline to use `client.images.generate` with API key handling.
 
-## [0.7.0] - 2025-06-25
+## [0.9.0] - 2025-06-28
 ### Added
-- New level-gated encounters from common to legendary tiers with item rewards.
-### Documentation
-- Updated README with encounter tier details.
+- Story encounter rarity with level-triggered events.
+- New "Bandits Ambush" story encounter grants a gem and an iron sword on first completion.
+
+## [0.8.1] - 2025-06-27
+### Fixed
+- Corrected image paths for woodcutting, stone collecting, boar hunting and ore finding encounters.
 
 ## [0.8.0] - 2025-06-26
 ### Changed
@@ -109,14 +104,18 @@ All notable changes to this project will be documented in this file.
 - Updated image references for items and encounters.
 - Reduced resource cost of legendary vault encounter.
 
-## [0.8.1] - 2025-06-27
-### Fixed
-- Corrected image paths for woodcutting, stone collecting, boar hunting and ore finding encounters.
-
-## [0.9.0] - 2025-06-28
+## [0.7.0] - 2025-06-25
 ### Added
-- Story encounter rarity with level-triggered events.
-- New "Bandits Ambush" story encounter grants a gem and an iron sword on first completion.
+- New level-gated encounters from common to legendary tiers with item rewards.
+### Documentation
+- Updated README with encounter tier details.
+
+## [0.6.0] - 2025-06-24
+### Added
+- Inventory tab with item generator. Items now drop from encounters and appear in your inventory.
+### Documentation
+- Updated README and docs with inventory details and modularization progress.
+- Added `docs/AGENTS.md` with documentation update rules.
 
 ## [0.5.0]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.28.0] - 2025-07-18
+### Added
+- Dark mode enabled by default with toggle in new Settings panel.
+
 ## [0.27.0] - 2025-07-17
 ### Changed
 - Slots now have a dark background so labels remain visible when no image is set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@ All notable changes to this project will be documented in this file.
 - Log entries highlight item and encounter names by rarity without showing rarity text.
 - Bonus Engine module applies additive, multiplicative and exponential modifiers before deltas update stats and resources, and supports cost divisors for consumptions.
 
+## [0.20.0] - 2025-07-10
+### Added
+- Encounters now include a `maxLevel` property to remove them from the pool once the adventure level surpasses it.
+
+## [0.21.0] - 2025-07-11
+### Added
+- Encounters can specify guaranteed `loot` amounts alongside probability-based `items` drops.
+
+## [0.22.0] - 2025-07-12
+### Changed
+- Loot yield now scales with your stats based on each encounter's category.
+
+## [0.23.0] - 2025-07-13
+### Added
+- Rare items now occasionally drop from common encounters and wood gathering tasks scale into a new "Oversee Lumber Team" encounter.
+### Changed
+- Rebalanced `maxLevel` values so early tasks phase out sooner.
+
 ## [0.15.0] - 2025-07-04
 ### Added
 - Character background now shows a special image when leather armor, a wooden shield, an iron sword and a gem are equipped.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.29.0] - 2025-07-19
+### Changed
+- Modals now follow dark mode theme.
+
 ## [0.28.0] - 2025-07-18
 ### Added
 - Dark mode enabled by default with toggle in new Settings panel.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Version 0.20.0 adds a `maxLevel` property to encounters so early events stop app
 Version 0.21.0 introduces a `loot` dictionary for encounters, defining fixed rewards in addition to probability-based drops.
 Version 0.22.0 scales guaranteed loot amounts with your stats based on the encounter category.
 Version 0.23.0 rebalances encounter `maxLevel` values and introduces rare item drops for common encounters.
+Version 0.24.0 calculates encounter duration from level and stats with a
+`baseDurationScale` for future tuning.
+Version 0.25.0 standardizes base encounter durations by rarity: 1s for
+common, 2s for rare, 5s for epic, 10s for legendary and 15s for story.
 
 
 #### 3. Core Gameplay Loop

--- a/README.md
+++ b/README.md
@@ -11,36 +11,6 @@ A progression and resource management game inspired by Progress Knight and Theor
 
 In this prototype you awaken in the body of a 16‑year‑old after bandits ambush your family's caravan. A stranger rescues you from the wreckage and brings you to a small town to recover. With everyone else lost, your early routines involve rebuilding strength and earning coin in this medieval setting.
 
-This release (v0.1.0) introduces automatic saving and loading of progress via localStorage.
-It also adds a drag-and-drop task system with tooltips and simple completion animations.
-
-Version 0.2.0 introduced a leveled action system with per-second yields and resource blocking.
-Version 0.3.0 expands the prototype with six starting action slots, an introductory story modal, and a simple log panel.
-Version 0.4.0 adds weighted random encounters with durations and loot chances influenced by your stats.
-Version 0.5.0 redesigns the Adventure tab with a single slot. Encounter level now increases after ten consecutive successes.
-Version 0.6.0 introduces an Inventory tab and item generator to track loot from encounters.
-Version 0.7.0 adds level-gated encounters ranging from common to legendary tiers with new item rewards.
-Version 0.9.0 adds story encounters that trigger once at specific location levels. The first, Bandits Ambush, grants a gem and an iron sword.
-Version 0.13.0 introduces an Autoprogress checkbox to pause encounter level ups.
-Version 0.14.0 lets Bandits Ambush return with a very low chance and drops items defined in the data files.
-Version 0.16.0 separates delta calculations into a new engine module with speed multipliers.
-Version 0.17.0 moves aging and experience generation into DeltaEngine so all progression scales with game speed.
-Version 0.18.0 ties encounter progress to DeltaEngine so adventure speed follows game time.
-Version 0.19.0 adds rarity-based borders for items and encounters and highlights names in the log.
-Version 0.19.1 introduces a Bonus Engine that applies additive and multiplicative modifiers before deltas update stats and resources. It now supports exponent bonuses for stats and cost divisors for resource consumption.
-Version 0.20.0 adds a `maxLevel` property to encounters so early events stop appearing once the adventure level surpasses them.
-Version 0.21.0 introduces a `loot` dictionary for encounters, defining fixed rewards in addition to probability-based drops.
-Version 0.22.0 scales guaranteed loot amounts with your stats based on the encounter category.
-Version 0.23.0 rebalances encounter `maxLevel` values and introduces rare item drops for common encounters.
-Version 0.24.0 calculates encounter duration from level and stats with a
-`baseDurationScale` for future tuning.
-Version 0.25.0 standardizes base encounter durations by rarity: 1s for
-common, 2s for rare, 5s for epic, 10s for legendary and 15s for story.
-Version 0.26.0 introduces a collapsible left panel and updates rarities:
-Ore and Gem are now rare items. The Find Ore and Ancient Vault encounters
-are also rare and use the shorter base duration.
-
-
 #### 3. Core Gameplay Loop
 
 * Player assigns actions to limited slots

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ Version 0.17.0 moves aging and experience generation into DeltaEngine so all pro
 Version 0.18.0 ties encounter progress to DeltaEngine so adventure speed follows game time.
 Version 0.19.0 adds rarity-based borders for items and encounters and highlights names in the log.
 Version 0.19.1 introduces a Bonus Engine that applies additive and multiplicative modifiers before deltas update stats and resources. It now supports exponent bonuses for stats and cost divisors for resource consumption.
+Version 0.20.0 adds a `maxLevel` property to encounters so early events stop appearing once the adventure level surpasses them.
+Version 0.21.0 introduces a `loot` dictionary for encounters, defining fixed rewards in addition to probability-based drops.
+Version 0.22.0 scales guaranteed loot amounts with your stats based on the encounter category.
+Version 0.23.0 rebalances encounter `maxLevel` values and introduces rare item drops for common encounters.
 
 
 #### 3. Core Gameplay Loop
@@ -142,6 +146,7 @@ ensure the `openai` Python package version 1.x is installed.
 * Dynamic events or time-limited quests
 * Mastery points earned from action tiers
 * Player avatar or magical tower interface (for immersion)
+* Evaluate scripting to automatically generate new encounter JSON entries
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Version 0.24.0 calculates encounter duration from level and stats with a
 `baseDurationScale` for future tuning.
 Version 0.25.0 standardizes base encounter durations by rarity: 1s for
 common, 2s for rare, 5s for epic, 10s for legendary and 15s for story.
+Version 0.26.0 introduces a collapsible left panel and updates rarities:
+Ore and Gem are now rare items. The Find Ore and Ancient Vault encounters
+are also rare and use the shorter base duration.
 
 
 #### 3. Core Gameplay Loop

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 | Automation   | Enables actions to loop with or without conditions |
 | Bonus Engine | Centralizes additive, multiplicative, and exponential bonuses for stats and resources, including cost divisors |
 | Engine       | Calculates deltas with multipliers and drives the main tick loop |
-| UI           | Interface for selecting tasks, viewing stats/resources, and managing slots |
+| UI           | Interface for selecting tasks, viewing stats/resources, and managing slots. Includes a settings panel with dark mode toggle |
 | Character Background | Updates left panel image based on equipped items, including a pose for full gear (leather armor, wooden shield, iron sword, gem) |
 
 #### 5. Core Stats (Initial Set)

--- a/css/styles.css
+++ b/css/styles.css
@@ -120,7 +120,8 @@ header, footer {
 }
 
 .modal-content {
-    background: #fff;
+    background: var(--panel-bg);
+    color: var(--text-color);
     padding: 1rem;
     border-radius: 4px;
     max-width: 400px;

--- a/css/styles.css
+++ b/css/styles.css
@@ -203,6 +203,7 @@ body.left-collapsed #left {
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
+    background-color: #333;
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,7 +1,18 @@
+:root {
+    --bg-color: #f5f5f5;
+    --panel-bg: #fff;
+    --text-color: #000;
+    --header-bg: #333;
+    --header-text: #fff;
+    --task-bg: #eee;
+    --slot-bg: #333;
+}
+
 body {
     font-family: Arial, sans-serif;
     margin: 0;
-    background-color: #f5f5f5;
+    background-color: var(--bg-color);
+    color: var(--text-color);
     display: grid;
     grid-template-rows: auto auto 1fr auto;
     height: 100vh;
@@ -12,8 +23,8 @@ header h1 {
 }
 
 header, footer {
-    background: #333;
-    color: #fff;
+    background: var(--header-bg);
+    color: var(--header-text);
     padding: 0.5rem 1rem;
 }
 
@@ -133,7 +144,7 @@ body.left-collapsed #left {
 }
 
 .panel {
-    background: #fff;
+    background: var(--panel-bg);
     padding: 1rem;
     border-radius: 4px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -150,7 +161,7 @@ body.left-collapsed #left {
 }
 
 #task-list li {
-    background: #eee;
+    background: var(--task-bg);
     margin-bottom: 0.5rem;
     padding: 0.5rem;
     cursor: grab;
@@ -203,7 +214,7 @@ body.left-collapsed #left {
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
-    background-color: #333;
+    background-color: var(--slot-bg);
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
@@ -375,3 +386,13 @@ body.left-collapsed #left {
 .log-entry .rarity-epic { color: #a335ee; font-weight: bold; }
 .log-entry .rarity-legendary { color: #e69138; font-weight: bold; }
 .log-entry .rarity-story { color: #f1c40f; font-weight: bold; }
+
+body.dark {
+    --bg-color: #222;
+    --panel-bg: #333;
+    --text-color: #eee;
+    --header-bg: #111;
+    --header-text: #eee;
+    --task-bg: #444;
+    --slot-bg: #555;
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -269,7 +269,7 @@ body.left-collapsed #left {
     font-size: 0.75rem;
     pointer-events: none;
     z-index: 10;
-    white-space: nowrap;
+    white-space: pre-line;
 }
 
 @keyframes completeFlash {

--- a/css/styles.css
+++ b/css/styles.css
@@ -124,6 +124,14 @@ main {
     align-items: start;
 }
 
+body.left-collapsed main {
+    grid-template-columns: 2fr minmax(180px, 1fr);
+}
+
+body.left-collapsed #left {
+    display: none;
+}
+
 .panel {
     background: #fff;
     padding: 1rem;

--- a/data/encounters.json
+++ b/data/encounters.json
@@ -13,8 +13,13 @@
       "focus": 1
     },
     "items": {
-      "herb": 1.0
-    }
+      "herb": 1.0,
+      "sturdy_bark": 0.05
+    },
+    "loot": {
+      "herb": 1
+    },
+    "maxLevel": 5
   },
   {
     "id": "rabbitHunt",
@@ -31,8 +36,11 @@
     },
     "items": {
       "rabbit_meat": 0.7,
-      "herb": 0.3
-    }
+      "herb": 0.3,
+      "wolf_pelt": 0.05
+    },
+    "loot": {},
+    "maxLevel": 8
   },
   {
     "id": "wolfAmbush",
@@ -50,7 +58,9 @@
     },
     "items": {
       "wolf_pelt": 0.5
-    }
+    },
+    "loot": {},
+    "maxLevel": 15
   },
   {
     "id": "chopWood",
@@ -66,8 +76,12 @@
       "focus": 0.5
     },
     "items": {
-      "wood_log": 0.8
-    }
+      "sturdy_bark": 0.05
+    },
+    "loot": {
+      "wood_log": 0.1
+    },
+    "maxLevel": 12
   },
   {
     "id": "collectStones",
@@ -83,13 +97,37 @@
       "focus": 0.6
     },
     "items": {
-      "stone_piece": 0.8
-    }
+      "stone_piece": 0.8,
+      "ore_chunk": 0.05
+    },
+    "loot": {},
+    "maxLevel": 18
+  },
+  {
+    "id": "overseeLumberTeam",
+    "name": "Oversee Lumber Team",
+    "description": "Manage workers collecting timber in larger quantities.",
+    "rarity": "common",
+    "category": "strength",
+    "baseDuration": 20,
+    "minLevel": 12,
+    "image": "assets/generated/oversee_lumber.png",
+    "resourceConsumption": {
+      "energy": 1.5,
+      "focus": 1
+    },
+    "items": {
+      "sturdy_bark": 0.25
+    },
+    "loot": {
+      "wood_log": 0.1
+    },
+    "maxLevel": 25
   },
   {
     "id": "boarHunt",
     "name": "Boar Hunt",
-    "description": "A wild boar charges through the brush—dangerous but rewarding.",
+    "description": "A wild boar charges through the brush\u2014dangerous but rewarding.",
     "rarity": "rare",
     "category": "strength",
     "baseDuration": 10,
@@ -103,7 +141,9 @@
     "items": {
       "boar_tusk": 0.7,
       "herb": 0.3
-    }
+    },
+    "loot": {},
+    "maxLevel": 25
   },
   {
     "id": "findOre",
@@ -120,7 +160,9 @@
     },
     "items": {
       "ore_chunk": 0.6
-    }
+    },
+    "loot": {},
+    "maxLevel": 45
   },
   {
     "id": "banditsAmbush",
@@ -137,12 +179,14 @@
       "focus": 2,
       "health": 3
     },
-    "items": {
-      "gem": 1.0,
-      "iron_sword": 1.0,
-      "wooden_shield": 1.0,
-      "leather_armor": 1.0
-    }
+    "items": {},
+    "loot": {
+      "gem": 1,
+      "iron_sword": 1,
+      "wooden_shield": 1,
+      "leather_armor": 1
+    },
+    "maxLevel": 100
   },
   {
     "id": "ancientVault",
@@ -163,6 +207,8 @@
       "wooden_shield": 0.3,
       "leather_armor": 0.2,
       "gem": 0.2
-    }
+    },
+    "loot": {},
+    "maxLevel": 60
   }
 ]

--- a/data/encounters.json
+++ b/data/encounters.json
@@ -5,7 +5,7 @@
     "description": "Dewy plants grow in the underbrush, promising useful herbs.",
     "rarity": "common",
     "category": "intelligence",
-    "baseDuration": 5,
+    "baseDuration": 1,
     "minLevel": 0,
     "image": "assets/enc/foraging.png",
     "resourceConsumption": {
@@ -27,7 +27,7 @@
     "description": "A swift rabbit darts between the trees, ripe for the chase.",
     "rarity": "common",
     "category": "strength",
-    "baseDuration": 6,
+    "baseDuration": 1,
     "minLevel": 0,
     "image": "assets/enc/rabbit.png",
     "resourceConsumption": {
@@ -48,7 +48,7 @@
     "description": "Hungry wolves burst from the shadows with fangs bared.",
     "rarity": "rare",
     "category": "strength",
-    "baseDuration": 10,
+    "baseDuration": 2,
     "minLevel": 0,
     "image": "assets/enc/wolf.png",
     "resourceConsumption": {
@@ -68,7 +68,7 @@
     "description": "Gather firewood from the nearby forest.",
     "rarity": "common",
     "category": "strength",
-    "baseDuration": 15,
+    "baseDuration": 1,
     "minLevel": 1,
     "image": "assets/enc/chopwood.jpg",
     "resourceConsumption": {
@@ -89,7 +89,7 @@
     "description": "Search the ground for useful stones.",
     "rarity": "common",
     "category": "strength",
-    "baseDuration": 15,
+    "baseDuration": 1,
     "minLevel": 1,
     "image": "assets/enc/collectstone.jpg",
     "resourceConsumption": {
@@ -109,7 +109,7 @@
     "description": "Manage workers collecting timber in larger quantities.",
     "rarity": "common",
     "category": "strength",
-    "baseDuration": 20,
+    "baseDuration": 1,
     "minLevel": 12,
     "image": "assets/generated/oversee_lumber.png",
     "resourceConsumption": {
@@ -130,7 +130,7 @@
     "description": "A wild boar charges through the brush\u2014dangerous but rewarding.",
     "rarity": "rare",
     "category": "strength",
-    "baseDuration": 10,
+    "baseDuration": 2,
     "minLevel": 10,
     "image": "assets/enc/foghtboar.jpg",
     "resourceConsumption": {
@@ -151,7 +151,7 @@
     "description": "Deep in the earth lies precious ore waiting to be mined.",
     "rarity": "epic",
     "category": "strength",
-    "baseDuration": 15,
+    "baseDuration": 5,
     "minLevel": 15,
     "image": "assets/enc/mineore.jpg",
     "resourceConsumption": {
@@ -170,7 +170,7 @@
     "description": "Outlaws spring from hiding to surround you with blades drawn.",
     "rarity": "story",
     "category": "strength",
-    "baseDuration": 20,
+    "baseDuration": 15,
     "minLevel": 50,
     "storyLevel": 50,
     "image": "assets/enc/wolf.png",
@@ -194,7 +194,7 @@
     "description": "A mysterious vault opens, promising untold riches.",
     "rarity": "legendary",
     "category": "intelligence",
-    "baseDuration": 25,
+    "baseDuration": 10,
     "minLevel": 30,
     "image": "assets/enc/ancientvault.jpg",
     "resourceConsumption": {

--- a/data/encounters.json
+++ b/data/encounters.json
@@ -149,9 +149,9 @@
     "id": "findOre",
     "name": "Find Ore",
     "description": "Deep in the earth lies precious ore waiting to be mined.",
-    "rarity": "epic",
+    "rarity": "rare",
     "category": "strength",
-    "baseDuration": 5,
+    "baseDuration": 2,
     "minLevel": 15,
     "image": "assets/enc/mineore.jpg",
     "resourceConsumption": {
@@ -192,9 +192,9 @@
     "id": "ancientVault",
     "name": "Ancient Vault Awakens",
     "description": "A mysterious vault opens, promising untold riches.",
-    "rarity": "legendary",
+    "rarity": "rare",
     "category": "intelligence",
-    "baseDuration": 10,
+    "baseDuration": 2,
     "minLevel": 30,
     "image": "assets/enc/ancientvault.jpg",
     "resourceConsumption": {

--- a/data/items.json
+++ b/data/items.json
@@ -1,132 +1,145 @@
 [
-  {
-    "id": "herb",
-    "name": "Herb",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "focus": 1
+    {
+        "id": "herb",
+        "name": "Herb",
+        "rarity": "common",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "focus": 1
+        },
+        "image": "assets/items/herb.png",
+        "description": "A collection of useful medicinal plants."
     },
-    "image": "assets/items/herb.png"
-  },
-  {
-    "id": "rabbit_meat",
-    "name": "Rabbit Meat",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "strength": 1
+    {
+        "id": "rabbit_meat",
+        "name": "Rabbit Meat",
+        "rarity": "common",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "strength": 1
+        },
+        "image": "assets/items/rabbit.png",
+        "description": "Fresh meat from a hunted rabbit."
     },
-    "image": "assets/items/rabbit.png"
-  },
-  {
-    "id": "wolf_pelt",
-    "name": "Wolf Pelt",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "health": 2
+    {
+        "id": "wolf_pelt",
+        "name": "Wolf Pelt",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "health": 2
+        },
+        "image": "assets/items/wolfpelt.png",
+        "description": "Thick hide taken from a wolf."
     },
-    "image": "assets/items/wolfpelt.png"
-  },
-  {
-    "id": "wood_log",
-    "name": "Wood Log",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "energy": 1
+    {
+        "id": "wood_log",
+        "name": "Wood Log",
+        "rarity": "common",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "energy": 1
+        },
+        "image": "assets/items/woodlog.PNG",
+        "description": "Sturdy timber cut from local trees."
     },
-    "image": "assets/items/woodlog.PNG"
-  },
-  {
-    "id": "stone_piece",
-    "name": "Stone Piece",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "strength": 0.5
+    {
+        "id": "stone_piece",
+        "name": "Stone Piece",
+        "rarity": "common",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "strength": 0.5
+        },
+        "image": "assets/items/stone.PNG",
+        "description": "A chunk of stone useful for building."
     },
-    "image": "assets/items/stone.PNG"
-  },
-  {
-    "id": "boar_tusk",
-    "name": "Boar Tusk",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "health": 1
+    {
+        "id": "boar_tusk",
+        "name": "Boar Tusk",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "health": 1
+        },
+        "image": "assets/items/boartusk.PNG",
+        "description": "A sharp tusk prized by craftsmen."
     },
-    "image": "assets/items/boartusk.PNG"
-  },
-  {
-    "id": "ore_chunk",
-    "name": "Rare Ore",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "strength": 2
+    {
+        "id": "ore_chunk",
+        "name": "Rare Ore",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "strength": 2
+        },
+        "image": "assets/items/Ore.PNG",
+        "description": "Raw ore ready for smelting."
     },
-    "image": "assets/items/Ore.PNG"
-  },
-  {
-    "id": "stone_spear",
-    "name": "Stone Spear",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "strength": 1.5
+    {
+        "id": "stone_spear",
+        "name": "Stone Spear",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "strength": 1.5
+        },
+        "image": "assets/items/spear.PNG",
+        "description": "Crude spear tipped with sharpened stone."
     },
-    "image": "assets/items/spear.PNG"
-  },
-  {
-    "id": "wooden_shield",
-    "name": "Wooden Shield",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "health": 1
+    {
+        "id": "wooden_shield",
+        "name": "Wooden Shield",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "health": 1
+        },
+        "image": "assets/items/woodshield.PNG",
+        "description": "Simple shield offering basic protection."
     },
-    "image": "assets/items/woodshield.PNG"
-  },
-  {
-    "id": "leather_armor",
-    "name": "Leather Armor",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "health": 2
+    {
+        "id": "leather_armor",
+        "name": "Leather Armor",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "health": 2
+        },
+        "image": "assets/items/leatherarmor.PNG",
+        "description": "Light armor made from treated hides."
     },
-    "image": "assets/items/leatherarmor.PNG"
-  },
-  {
-    "id": "gem",
-    "name": "Gem",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "focus": 2
+    {
+        "id": "gem",
+        "name": "Gem",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "focus": 2
+        },
+        "image": "assets/items/gem.PNG",
+        "description": "A shimmering gemstone of unknown origin."
     },
-    "image": "assets/items/gem.PNG"
-  },
-  {
-    "id": "iron_sword",
-    "name": "Iron Sword",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "strength": 2
+    {
+        "id": "iron_sword",
+        "name": "Iron Sword",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "strength": 2
+        },
+        "image": "assets/generated/iron_sword.png",
+        "description": "A sturdy blade forged from iron."
     },
-    "image": "assets/generated/iron_sword.png"
-  },
-  {
-    "id": "sturdy_bark",
-    "name": "Sturdy Bark",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "health": 1
-    },
-    "image": "assets/generated/sturdy_bark.png"
-  }
+    {
+        "id": "sturdy_bark",
+        "name": "Sturdy Bark",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "health": 1
+        },
+        "image": "assets/generated/sturdy_bark.png",
+        "description": "Thick bark that can reinforce armor."
+    }
 ]

--- a/data/items.json
+++ b/data/items.json
@@ -62,7 +62,7 @@
   {
     "id": "ore_chunk",
     "name": "Rare Ore",
-    "rarity": "epic",
+    "rarity": "rare",
     "effectType": "increaseSoftcap",
     "effectValue": {
       "strength": 2
@@ -102,7 +102,7 @@
   {
     "id": "gem",
     "name": "Gem",
-    "rarity": "epic",
+    "rarity": "rare",
     "effectType": "increaseSoftcap",
     "effectValue": {
       "focus": 2

--- a/data/items.json
+++ b/data/items.json
@@ -118,5 +118,15 @@
       "strength": 2
     },
     "image": "assets/generated/iron_sword.png"
+  },
+  {
+    "id": "sturdy_bark",
+    "name": "Sturdy Bark",
+    "rarity": "rare",
+    "effectType": "increaseSoftcap",
+    "effectValue": {
+      "health": 1
+    },
+    "image": "assets/generated/sturdy_bark.png"
   }
 ]

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
                 <button data-speed="2">2x</button>
                 <button data-speed="10">10x</button>
             </span>
+            <button id="toggle-left">Hide Stats</button>
         </div>
     </header>
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Progress Realm Prototype</title>
     <link rel="stylesheet" href="css/styles.css">
 </head>
-<body>
+<body class="dark">
     <header>
         <h1>Progress Realm</h1>
         <div id="header-info">
@@ -26,6 +26,13 @@
             <div id="story-image" class="story-image"></div>
             <p id="story-text"></p>
             <button id="story-close">Continue</button>
+        </div>
+    </div>
+
+    <div id="settings-modal" class="modal hidden">
+        <div class="modal-content">
+            <label><input type="checkbox" id="dark-mode-toggle" checked> Dark Mode</label>
+            <button id="settings-close">Close</button>
         </div>
     </div>
 

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -16,9 +16,11 @@ class Encounter {
     }
 
     getDuration() {
-        const stat = State.stats[this.category] || 0;
-        const reduction = stat * EncounterGenerator.durationModPerStat;
-        return Math.max(this.baseDuration * (1 - reduction), 1);
+        const stat = Math.max(State.stats[this.category] || 0, 1);
+        const level = Math.max(EncounterGenerator.level, 1);
+        const minDuration = this.baseDuration * EncounterGenerator.baseDurationScale;
+        const calculated = level / stat;
+        return Math.max(minDuration, calculated);
     }
 
     getLootChance() {
@@ -64,6 +66,7 @@ const EncounterGenerator = {
     lootYieldBonusPerStat: 0.02, // +2% loot amount per stat point
     durationModPerStat: 0.02, // -2% duration per stat point
     costScalePerLevel: 0.1, // +10% cost per encounter level
+    baseDurationScale: 1, // multiplier for encounter minimum duration
 
     async load() {
         try {

--- a/js/items.js
+++ b/js/items.js
@@ -2,10 +2,19 @@ class Item {
     constructor(data) {
         this.id = data.id;
         this.name = data.name;
+        this.description = data.description || '';
         this.rarity = data.rarity || 'common';
         this.effectType = data.effectType;
         this.effectValue = data.effectValue;
         this.image = data.image || null;
+    }
+
+    getEffectDescription() {
+        if (this.effectType === 'increaseSoftcap' && this.effectValue) {
+            const key = Object.keys(this.effectValue)[0];
+            return `Improves ${key} cap`;
+        }
+        return '';
     }
 
     applyEffect() {
@@ -110,6 +119,8 @@ const Inventory = {
                 rarity: itemData.rarity || 'common',
                 quantity: data.quantity,
                 image: itemData.image,
+                description: itemData.description || '',
+                effect: itemData.getEffectDescription ? itemData.getEffectDescription() : ''
             };
         });
     },

--- a/js/main.js
+++ b/js/main.js
@@ -675,6 +675,7 @@ function updateSlotUI(i) {
         progressEl.max = 1;
         labelEl.textContent = slot.text || '';
         slotEl.style.backgroundImage = 'none';
+        slotEl.dataset.tooltip = 'Drag an action here';
         return;
     }
     const action = actions[slot.actionId];
@@ -686,6 +687,7 @@ function updateSlotUI(i) {
     } else {
         slotEl.style.backgroundImage = 'none';
     }
+    slotEl.dataset.tooltip = `${action.name} - ${capitalize(getActionTier(action.level))}`;
 }
 
 function updateAdventureSlotUI(i) {
@@ -704,9 +706,24 @@ function updateAdventureSlotUI(i) {
             slotEl.style.backgroundSize = 'cover';
         }
         slotEl.classList.add(`rarity-${slot.encounter.rarity}`);
+        const parts = [slot.encounter.description];
+        if (slot.encounter.items) {
+            const lines = Object.entries(slot.encounter.items)
+                .map(([id, chance]) => {
+                    const item = ItemGenerator.itemList.find(i => i.id === id);
+                    const name = item ? item.name : id;
+                    return `${name}: ${Math.round(chance * 100)}%`;
+                });
+            if (lines.length) {
+                parts.push('Loot chances:');
+                parts.push(...lines);
+            }
+        }
+        slotEl.dataset.tooltip = parts.join('\n');
     } else {
         labelEl.textContent = slot.text || '';
         slotEl.style.backgroundImage = 'none';
+        slotEl.dataset.tooltip = '';
     }
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -779,6 +779,10 @@ async function init() {
     setupDragAndDrop();
     setupTooltips();
     TabManager.init();
+    const toggleBtn = document.getElementById('toggle-left');
+    if (toggleBtn) {
+        toggleBtn.addEventListener('click', toggleLeftPanel);
+    }
     const autoBox = document.getElementById('autoprogress-toggle');
     if (autoBox) {
         autoBox.checked = State.autoProgress;
@@ -805,3 +809,12 @@ async function init() {
 }
 
 document.addEventListener('DOMContentLoaded', init);
+
+function toggleLeftPanel() {
+    const body = document.body;
+    body.classList.toggle('left-collapsed');
+    const btn = document.getElementById('toggle-left');
+    if (btn) {
+        btn.textContent = body.classList.contains('left-collapsed') ? 'Show Stats' : 'Hide Stats';
+    }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -74,6 +74,7 @@ const State = {
     encounterLevel: 0,
     encounterStreak: 0,
     autoProgress: true,
+    darkMode: true,
 };
 
 for (let i = 0; i < State.slotCount; i++) {
@@ -279,6 +280,9 @@ const SaveSystem = {
                 }
                 if (State.autoProgress === undefined) {
                     State.autoProgress = true;
+                }
+                if (State.darkMode === undefined) {
+                    State.darkMode = true;
                 }
                 return data.actions || null;
             } else {
@@ -783,6 +787,22 @@ async function init() {
     if (toggleBtn) {
         toggleBtn.addEventListener('click', toggleLeftPanel);
     }
+    const settingsBtn = document.getElementById('settings-btn');
+    if (settingsBtn) {
+        settingsBtn.addEventListener('click', openSettings);
+    }
+    const settingsClose = document.getElementById('settings-close');
+    if (settingsClose) {
+        settingsClose.addEventListener('click', closeSettings);
+    }
+    const darkToggle = document.getElementById('dark-mode-toggle');
+    if (darkToggle) {
+        darkToggle.addEventListener('change', () => {
+            State.darkMode = darkToggle.checked;
+            applyDarkMode();
+            SaveSystem.save();
+        });
+    }
     const autoBox = document.getElementById('autoprogress-toggle');
     if (autoBox) {
         autoBox.checked = State.autoProgress;
@@ -795,6 +815,7 @@ async function init() {
         retreat('resolve');
     });
     document.getElementById('reset-btn').addEventListener('click', () => SaveSystem.reset());
+    applyDarkMode();
     updateUI();
     // Game logic ticked separately from UI updates so resource generation
     // remains consistent regardless of UI refresh rate.
@@ -817,4 +838,18 @@ function toggleLeftPanel() {
     if (btn) {
         btn.textContent = body.classList.contains('left-collapsed') ? 'Show Stats' : 'Hide Stats';
     }
+}
+
+function applyDarkMode() {
+    document.body.classList.toggle('dark', State.darkMode);
+    const chk = document.getElementById('dark-mode-toggle');
+    if (chk) chk.checked = State.darkMode;
+}
+
+function openSettings() {
+    document.getElementById('settings-modal').classList.remove('hidden');
+}
+
+function closeSettings() {
+    document.getElementById('settings-modal').classList.add('hidden');
 }

--- a/js/ui.js
+++ b/js/ui.js
@@ -75,10 +75,14 @@ const InventoryUI = {
                     slot.style.backgroundImage = `url(${item.image})`;
                 }
                 slot.classList.add(`rarity-${item.rarity}`);
+                const lines = [item.description];
+                if (item.effect) lines.push(item.effect);
+                slot.dataset.tooltip = lines.join('\n');
             } else {
                 slot.style.backgroundImage = 'none';
                 label.textContent = '';
                 countEl.textContent = '';
+                slot.dataset.tooltip = '';
             }
             slot.appendChild(label);
             slot.appendChild(countEl);

--- a/tests/test_encounters.py
+++ b/tests/test_encounters.py
@@ -20,6 +20,14 @@ def test_encounter_fields():
         for prob in enc['items'].values():
             assert isinstance(prob, (int, float))
             assert 0 <= prob <= 1
+        assert 'loot' in enc
+        assert isinstance(enc['loot'], dict)
+        for qty in enc['loot'].values():
+            assert isinstance(qty, (int, float))
+            assert qty >= 0
+        assert 'maxLevel' in enc
+        assert isinstance(enc['maxLevel'], (int, float))
+        assert enc['maxLevel'] >= enc.get('minLevel', 0)
 
 
 def test_story_encounter():
@@ -28,10 +36,49 @@ def test_story_encounter():
         data = json.load(f)
     story = next(e for e in data if e['id'] == 'banditsAmbush')
     assert story['rarity'] == 'story'
-    expected_items = {
-        'gem': 1.0,
-        'iron_sword': 1.0,
-        'wooden_shield': 1.0,
-        'leather_armor': 1.0,
+    assert not story['items']
+    expected_loot = {
+        'gem': 1,
+        'iron_sword': 1,
+        'wooden_shield': 1,
+        'leather_armor': 1,
     }
-    assert story['items'] == expected_items
+    assert story['loot'] == expected_loot
+
+
+def test_max_level_filtering():
+    path = os.path.join('data', 'encounters.json')
+    with open(path) as f:
+        data = json.load(f)
+
+    def filter_pool(level):
+        pool = []
+        for e in data:
+            if e.get('minLevel', 0) > level:
+                continue
+            if 'maxLevel' in e and level > e['maxLevel']:
+                continue
+            pool.append(e['id'])
+        return pool
+
+    low_pool = filter_pool(0)
+    high_pool = filter_pool(20)
+
+    assert 'foragingHerbs' in low_pool
+    assert 'foragingHerbs' not in high_pool
+
+
+def test_loot_yield_constant_present():
+    path = os.path.join('js', 'encounter.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'lootYieldBonusPerStat' in text
+
+
+def test_oversee_lumber_team_exists():
+    path = os.path.join('data', 'encounters.json')
+    with open(path) as f:
+        data = json.load(f)
+    enc = next(e for e in data if e['id'] == 'overseeLumberTeam')
+    assert enc['loot'].get('wood_log') == 0.1
+    assert enc['items'].get('sturdy_bark') == 0.25

--- a/tests/test_encounters.py
+++ b/tests/test_encounters.py
@@ -75,6 +75,28 @@ def test_loot_yield_constant_present():
     assert 'lootYieldBonusPerStat' in text
 
 
+def test_base_duration_scale_present():
+    path = os.path.join('js', 'encounter.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'baseDurationScale' in text
+
+
+def test_base_durations_by_rarity():
+    path = os.path.join('data', 'encounters.json')
+    with open(path) as f:
+        data = json.load(f)
+    expected = {
+        'common': 1,
+        'rare': 2,
+        'epic': 5,
+        'legendary': 10,
+        'story': 15,
+    }
+    for enc in data:
+        assert enc['baseDuration'] == expected[enc['rarity']]
+
+
 def test_oversee_lumber_team_exists():
     path = os.path.join('data', 'encounters.json')
     with open(path) as f:


### PR DESCRIPTION
## Summary
- rebalance max levels on early encounters
- add rare item `sturdy_bark` and make common encounters drop rares
- introduce `overseeLumberTeam` with wood log loot
- document the changes and note potential scripted encounter generation
- test for new encounter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b1d102194833087954ed222df1d6a