### PR TITLE
Implement standardized encounter durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,14 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Rebalanced `maxLevel` values so early tasks phase out sooner.
 
+## [0.24.0] - 2025-07-14
+### Changed
+- Encounter duration now derives from level divided by relevant stats and honors `baseDurationScale` as a minimum multiplier.
+
+## [0.25.0] - 2025-07-15
+### Changed
+- Base encounter durations are now set by rarity: 1s for common, 2s for rare, 5s for epic, 10s for legendary and 15s for story.
+
 ## [0.15.0] - 2025-07-04
 ### Added
 - Character background now shows a special image when leather armor, a wooden shield, an iron sword and a gem are equipped.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Version 0.20.0 adds a `maxLevel` property to encounters so early events stop app
 Version 0.21.0 introduces a `loot` dictionary for encounters, defining fixed rewards in addition to probability-based drops.
 Version 0.22.0 scales guaranteed loot amounts with your stats based on the encounter category.
 Version 0.23.0 rebalances encounter `maxLevel` values and introduces rare item drops for common encounters.
+Version 0.24.0 calculates encounter duration from level and stats with a
+`baseDurationScale` for future tuning.
+Version 0.25.0 standardizes base encounter durations by rarity: 1s for
+common, 2s for rare, 5s for epic, 10s for legendary and 15s for story.
 
 
 #### 3. Core Gameplay Loop

--- a/data/encounters.json
+++ b/data/encounters.json
@@ -5,7 +5,7 @@
     "description": "Dewy plants grow in the underbrush, promising useful herbs.",
     "rarity": "common",
     "category": "intelligence",
-    "baseDuration": 5,
+    "baseDuration": 1,
     "minLevel": 0,
     "image": "assets/enc/foraging.png",
     "resourceConsumption": {
@@ -27,7 +27,7 @@
     "description": "A swift rabbit darts between the trees, ripe for the chase.",
     "rarity": "common",
     "category": "strength",
-    "baseDuration": 6,
+    "baseDuration": 1,
     "minLevel": 0,
     "image": "assets/enc/rabbit.png",
     "resourceConsumption": {
@@ -48,7 +48,7 @@
     "description": "Hungry wolves burst from the shadows with fangs bared.",
     "rarity": "rare",
     "category": "strength",
-    "baseDuration": 10,
+    "baseDuration": 2,
     "minLevel": 0,
     "image": "assets/enc/wolf.png",
     "resourceConsumption": {
@@ -68,7 +68,7 @@
     "description": "Gather firewood from the nearby forest.",
     "rarity": "common",
     "category": "strength",
-    "baseDuration": 15,
+    "baseDuration": 1,
     "minLevel": 1,
     "image": "assets/enc/chopwood.jpg",
     "resourceConsumption": {
@@ -89,7 +89,7 @@
     "description": "Search the ground for useful stones.",
     "rarity": "common",
     "category": "strength",
-    "baseDuration": 15,
+    "baseDuration": 1,
     "minLevel": 1,
     "image": "assets/enc/collectstone.jpg",
     "resourceConsumption": {
@@ -109,7 +109,7 @@
     "description": "Manage workers collecting timber in larger quantities.",
     "rarity": "common",
     "category": "strength",
-    "baseDuration": 20,
+    "baseDuration": 1,
     "minLevel": 12,
     "image": "assets/generated/oversee_lumber.png",
     "resourceConsumption": {
@@ -130,7 +130,7 @@
     "description": "A wild boar charges through the brush\u2014dangerous but rewarding.",
     "rarity": "rare",
     "category": "strength",
-    "baseDuration": 10,
+    "baseDuration": 2,
     "minLevel": 10,
     "image": "assets/enc/foghtboar.jpg",
     "resourceConsumption": {
@@ -151,7 +151,7 @@
     "description": "Deep in the earth lies precious ore waiting to be mined.",
     "rarity": "epic",
     "category": "strength",
-    "baseDuration": 15,
+    "baseDuration": 5,
     "minLevel": 15,
     "image": "assets/enc/mineore.jpg",
     "resourceConsumption": {
@@ -170,7 +170,7 @@
     "description": "Outlaws spring from hiding to surround you with blades drawn.",
     "rarity": "story",
     "category": "strength",
-    "baseDuration": 20,
+    "baseDuration": 15,
     "minLevel": 50,
     "storyLevel": 50,
     "image": "assets/enc/wolf.png",
@@ -194,7 +194,7 @@
     "description": "A mysterious vault opens, promising untold riches.",
     "rarity": "legendary",
     "category": "intelligence",
-    "baseDuration": 25,
+    "baseDuration": 10,
     "minLevel": 30,
     "image": "assets/enc/ancientvault.jpg",
     "resourceConsumption": {

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -16,9 +16,11 @@ class Encounter {
     }
 
     getDuration() {
-        const stat = State.stats[this.category] || 0;
-        const reduction = stat * EncounterGenerator.durationModPerStat;
-        return Math.max(this.baseDuration * (1 - reduction), 1);
+        const stat = Math.max(State.stats[this.category] || 0, 1);
+        const level = Math.max(EncounterGenerator.level, 1);
+        const minDuration = this.baseDuration * EncounterGenerator.baseDurationScale;
+        const calculated = level / stat;
+        return Math.max(minDuration, calculated);
     }
 
     getLootChance() {
@@ -64,6 +66,7 @@ const EncounterGenerator = {
     lootYieldBonusPerStat: 0.02, // +2% loot amount per stat point
     durationModPerStat: 0.02, // -2% duration per stat point
     costScalePerLevel: 0.1, // +10% cost per encounter level
+    baseDurationScale: 1, // multiplier for encounter minimum duration
 
     async load() {
         try {

--- a/tests/test_encounters.py
+++ b/tests/test_encounters.py
@@ -75,6 +75,28 @@ def test_loot_yield_constant_present():
     assert 'lootYieldBonusPerStat' in text
 
 
+def test_base_duration_scale_present():
+    path = os.path.join('js', 'encounter.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'baseDurationScale' in text
+
+
+def test_base_durations_by_rarity():
+    path = os.path.join('data', 'encounters.json')
+    with open(path) as f:
+        data = json.load(f)
+    expected = {
+        'common': 1,
+        'rare': 2,
+        'epic': 5,
+        'legendary': 10,
+        'story': 15,
+    }
+    for enc in data:
+        assert enc['baseDuration'] == expected[enc['rarity']]
+
+
 def test_oversee_lumber_team_exists():
     path = os.path.join('data', 'encounters.json')
     with open(path) as f:


### PR DESCRIPTION
## Summary
- set base encounter durations by rarity in `encounters.json`
- document new timings in README
- record update in CHANGELOG
- test base durations for each rarity

## Testing
- `pytest --maxfail=1 -q`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_685c19b148708330817581506792deda