### PR TITLE
Fix changelog ordering and update guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,4 @@
 - Open a pull request for every change instead of pushing directly to `main`
 - Provide a clear PR title and summary of the changes
 - Update `CHANGELOG.md` with a short note describing each change
+- Add new entries to the **top** of the changelog so the latest changes appear first

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,50 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.16.0] - 2025-07-06
-### Changed
-- Delta calculations moved to new engine module and now accept multipliers for game speed.
-
-## [0.17.0] - 2025-07-07
-### Changed
-- DeltaEngine now handles aging and action experience so all progression uses the same speed scaling.
-
-## [0.18.0] - 2025-07-08
-### Changed
-- Encounter progress is now processed by DeltaEngine so adventure timing respects game speed.
-
-## [0.19.0] - 2025-07-09
-### Added
-- Border colors now reflect item and encounter rarity.
-- Log entries highlight item and encounter names by rarity without showing rarity text.
-- Bonus Engine module applies additive, multiplicative and exponential modifiers before deltas update stats and resources, and supports cost divisors for consumptions.
-
-## [0.20.0] - 2025-07-10
-### Added
-- Encounters now include a `maxLevel` property to remove them from the pool once the adventure level surpasses it.
-
-## [0.21.0] - 2025-07-11
-### Added
-- Encounters can specify guaranteed `loot` amounts alongside probability-based `items` drops.
-
-## [0.22.0] - 2025-07-12
-### Changed
-- Loot yield now scales with your stats based on each encounter's category.
-
-## [0.23.0] - 2025-07-13
-### Added
-- Rare items now occasionally drop from common encounters and wood gathering tasks scale into a new "Oversee Lumber Team" encounter.
-### Changed
-- Rebalanced `maxLevel` values so early tasks phase out sooner.
-
-## [0.24.0] - 2025-07-14
-### Changed
-- Encounter duration now derives from level divided by relevant stats and honors `baseDurationScale` as a minimum multiplier.
-
-## [0.25.0] - 2025-07-15
-### Changed
-- Base encounter durations are now set by rarity: 1s for common, 2s for rare, 5s for epic, 10s for legendary and 15s for story.
-
 ## [0.26.0] - 2025-07-16
 ### Added
 - Left panel can now be collapsed via a button in the header.
@@ -53,13 +9,57 @@ All notable changes to this project will be documented in this file.
 - Ore chunk and gem items are now rare.
 - Find Ore and Ancient Vault encounters are rare with shorter base durations.
 
-## [0.15.0] - 2025-07-04
+## [0.25.0] - 2025-07-15
+### Changed
+- Base encounter durations are now set by rarity: 1s for common, 2s for rare, 5s for epic, 10s for legendary and 15s for story.
+
+## [0.24.0] - 2025-07-14
+### Changed
+- Encounter duration now derives from level divided by relevant stats and honors `baseDurationScale` as a minimum multiplier.
+
+## [0.23.0] - 2025-07-13
 ### Added
-- Character background now shows a special image when leather armor, a wooden shield, an iron sword and a gem are equipped.
+- Rare items now occasionally drop from common encounters and wood gathering tasks scale into a new "Oversee Lumber Team" encounter.
+### Changed
+- Rebalanced `maxLevel` values so early tasks phase out sooner.
+
+## [0.22.0] - 2025-07-12
+### Changed
+- Loot yield now scales with your stats based on each encounter's category.
+
+## [0.21.0] - 2025-07-11
+### Added
+- Encounters can specify guaranteed `loot` amounts alongside probability-based `items` drops.
+
+## [0.20.0] - 2025-07-10
+### Added
+- Encounters now include a `maxLevel` property to remove them from the pool once the adventure level surpasses it.
+
+## [0.19.0] - 2025-07-09
+### Added
+- Border colors now reflect item and encounter rarity.
+- Log entries highlight item and encounter names by rarity without showing rarity text.
+- Bonus Engine module applies additive, multiplicative and exponential modifiers before deltas update stats and resources, and supports cost divisors for consumptions.
+
+## [0.18.0] - 2025-07-08
+### Changed
+- Encounter progress is now processed by DeltaEngine so adventure timing respects game speed.
+
+## [0.17.0] - 2025-07-07
+### Changed
+- DeltaEngine now handles aging and action experience so all progression uses the same speed scaling.
+
+## [0.16.0] - 2025-07-06
+### Changed
+- Delta calculations moved to new engine module and now accept multipliers for game speed.
 
 ## [0.15.1] - 2025-07-05
 ### Changed
 - Updated full gear image reference to `set+sword.png`.
+
+## [0.15.0] - 2025-07-04
+### Added
+- Character background now shows a special image when leather armor, a wooden shield, an iron sword and a gem are equipped.
 
 ## [0.14.0] - 2025-07-03
 ### Changed
@@ -76,32 +76,27 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Use existing 'leather+woodshield+spear.png' image for equipped character background.
 
-## [0.10.0] - 2025-06-29
-### Added
-- Python script `scripts/image_pipeline.py` to auto-generate missing item images
-  via OpenAI's DALL·E API.
-- Documentation section on the new image pipeline.
-### Fixed
-- Updated image pipeline to use `client.images.generate` with API key handling.
-
 ## [0.11.0] - 2025-06-30
 ### Added
 - Scripts `image_pipeline_encounters.py` and `image_pipeline_actions.py` for
   generating encounter and action images.
 - Updated README with image pipeline details for all asset types.
 
-## [0.6.0] - 2025-06-24
+## [0.10.0] - 2025-06-29
 ### Added
-- Inventory tab with item generator. Items now drop from encounters and appear in your inventory.
-### Documentation
-- Updated README and docs with inventory details and modularization progress.
-- Added `docs/AGENTS.md` with documentation update rules.
+- Python script `scripts/image_pipeline.py` to auto-generate missing item images  via OpenAI's DALL·E API.
+- Documentation section on the new image pipeline.
+### Fixed
+- Updated image pipeline to use `client.images.generate` with API key handling.
 
-## [0.7.0] - 2025-06-25
+## [0.9.0] - 2025-06-28
 ### Added
-- New level-gated encounters from common to legendary tiers with item rewards.
-### Documentation
-- Updated README with encounter tier details.
+- Story encounter rarity with level-triggered events.
+- New "Bandits Ambush" story encounter grants a gem and an iron sword on first completion.
+
+## [0.8.1] - 2025-06-27
+### Fixed
+- Corrected image paths for woodcutting, stone collecting, boar hunting and ore finding encounters.
 
 ## [0.8.0] - 2025-06-26
 ### Changed
@@ -109,14 +104,18 @@ All notable changes to this project will be documented in this file.
 - Updated image references for items and encounters.
 - Reduced resource cost of legendary vault encounter.
 
-## [0.8.1] - 2025-06-27
-### Fixed
-- Corrected image paths for woodcutting, stone collecting, boar hunting and ore finding encounters.
-
-## [0.9.0] - 2025-06-28
+## [0.7.0] - 2025-06-25
 ### Added
-- Story encounter rarity with level-triggered events.
-- New "Bandits Ambush" story encounter grants a gem and an iron sword on first completion.
+- New level-gated encounters from common to legendary tiers with item rewards.
+### Documentation
+- Updated README with encounter tier details.
+
+## [0.6.0] - 2025-06-24
+### Added
+- Inventory tab with item generator. Items now drop from encounters and appear in your inventory.
+### Documentation
+- Updated README and docs with inventory details and modularization progress.
+- Added `docs/AGENTS.md` with documentation update rules.
 
 ## [0.5.0]
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,36 +11,6 @@ A progression and resource management game inspired by Progress Knight and Theor
 
 In this prototype you awaken in the body of a 16‑year‑old after bandits ambush your family's caravan. A stranger rescues you from the wreckage and brings you to a small town to recover. With everyone else lost, your early routines involve rebuilding strength and earning coin in this medieval setting.
 
-This release (v0.1.0) introduces automatic saving and loading of progress via localStorage.
-It also adds a drag-and-drop task system with tooltips and simple completion animations.
-
-Version 0.2.0 introduced a leveled action system with per-second yields and resource blocking.
-Version 0.3.0 expands the prototype with six starting action slots, an introductory story modal, and a simple log panel.
-Version 0.4.0 adds weighted random encounters with durations and loot chances influenced by your stats.
-Version 0.5.0 redesigns the Adventure tab with a single slot. Encounter level now increases after ten consecutive successes.
-Version 0.6.0 introduces an Inventory tab and item generator to track loot from encounters.
-Version 0.7.0 adds level-gated encounters ranging from common to legendary tiers with new item rewards.
-Version 0.9.0 adds story encounters that trigger once at specific location levels. The first, Bandits Ambush, grants a gem and an iron sword.
-Version 0.13.0 introduces an Autoprogress checkbox to pause encounter level ups.
-Version 0.14.0 lets Bandits Ambush return with a very low chance and drops items defined in the data files.
-Version 0.16.0 separates delta calculations into a new engine module with speed multipliers.
-Version 0.17.0 moves aging and experience generation into DeltaEngine so all progression scales with game speed.
-Version 0.18.0 ties encounter progress to DeltaEngine so adventure speed follows game time.
-Version 0.19.0 adds rarity-based borders for items and encounters and highlights names in the log.
-Version 0.19.1 introduces a Bonus Engine that applies additive and multiplicative modifiers before deltas update stats and resources. It now supports exponent bonuses for stats and cost divisors for resource consumption.
-Version 0.20.0 adds a `maxLevel` property to encounters so early events stop appearing once the adventure level surpasses them.
-Version 0.21.0 introduces a `loot` dictionary for encounters, defining fixed rewards in addition to probability-based drops.
-Version 0.22.0 scales guaranteed loot amounts with your stats based on the encounter category.
-Version 0.23.0 rebalances encounter `maxLevel` values and introduces rare item drops for common encounters.
-Version 0.24.0 calculates encounter duration from level and stats with a
-`baseDurationScale` for future tuning.
-Version 0.25.0 standardizes base encounter durations by rarity: 1s for
-common, 2s for rare, 5s for epic, 10s for legendary and 15s for story.
-Version 0.26.0 introduces a collapsible left panel and updates rarities:
-Ore and Gem are now rare items. The Find Ore and Ancient Vault encounters
-are also rare and use the shorter base duration.
-
-
 #### 3. Core Gameplay Loop
 
 * Player assigns actions to limited slots


### PR DESCRIPTION
## Summary
- sort CHANGELOG so newest entries are first
- remove outdated changelog notes from README
- mention ordering rule in AGENTS guidelines

## Testing
- `pytest`
- `pytest --cov` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_685c7bd86c688330a1b16c6a0b68b03e