### PR TITLE
Improve slot visibility with fallback background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.27.0] - 2025-07-17
+### Changed
+- Slots now have a dark background so labels remain visible when no image is set.
+
 ## [0.26.0] - 2025-07-16
 ### Added
 - Left panel can now be collapsed via a button in the header.

--- a/css/styles.css
+++ b/css/styles.css
@@ -203,6 +203,7 @@ body.left-collapsed #left {
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
+    background-color: #333;
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;


### PR DESCRIPTION
## Summary
- add a dark background color to `.slot` elements so text shows when no image is present
- document the change in `CHANGELOG.md`

## Testing
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_685c8492d9e0833082c8a2c0d5808b41