### PR TITLE
Add dark mode with settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.28.0] - 2025-07-18
+### Added
+- Dark mode enabled by default with toggle in new Settings panel.
+
 ## [0.27.0] - 2025-07-17
 ### Changed
 - Slots now have a dark background so labels remain visible when no image is set.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 | Automation   | Enables actions to loop with or without conditions |
 | Bonus Engine | Centralizes additive, multiplicative, and exponential bonuses for stats and resources, including cost divisors |
 | Engine       | Calculates deltas with multipliers and drives the main tick loop |
-| UI           | Interface for selecting tasks, viewing stats/resources, and managing slots |
+| UI           | Interface for selecting tasks, viewing stats/resources, and managing slots. Includes a settings panel with dark mode toggle |
 | Character Background | Updates left panel image based on equipped items, including a pose for full gear (leather armor, wooden shield, iron sword, gem) |
 
 #### 5. Core Stats (Initial Set)

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,7 +1,18 @@
+:root {
+    --bg-color: #f5f5f5;
+    --panel-bg: #fff;
+    --text-color: #000;
+    --header-bg: #333;
+    --header-text: #fff;
+    --task-bg: #eee;
+    --slot-bg: #333;
+}
+
 body {
     font-family: Arial, sans-serif;
     margin: 0;
-    background-color: #f5f5f5;
+    background-color: var(--bg-color);
+    color: var(--text-color);
     display: grid;
     grid-template-rows: auto auto 1fr auto;
     height: 100vh;
@@ -12,8 +23,8 @@ header h1 {
 }
 
 header, footer {
-    background: #333;
-    color: #fff;
+    background: var(--header-bg);
+    color: var(--header-text);
     padding: 0.5rem 1rem;
 }
 
@@ -133,7 +144,7 @@ body.left-collapsed #left {
 }
 
 .panel {
-    background: #fff;
+    background: var(--panel-bg);
     padding: 1rem;
     border-radius: 4px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
@@ -150,7 +161,7 @@ body.left-collapsed #left {
 }
 
 #task-list li {
-    background: #eee;
+    background: var(--task-bg);
     margin-bottom: 0.5rem;
     padding: 0.5rem;
     cursor: grab;
@@ -203,7 +214,7 @@ body.left-collapsed #left {
     display: flex;
     flex-direction: column;
     justify-content: flex-end;
-    background-color: #333;
+    background-color: var(--slot-bg);
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
@@ -375,3 +386,13 @@ body.left-collapsed #left {
 .log-entry .rarity-epic { color: #a335ee; font-weight: bold; }
 .log-entry .rarity-legendary { color: #e69138; font-weight: bold; }
 .log-entry .rarity-story { color: #f1c40f; font-weight: bold; }
+
+body.dark {
+    --bg-color: #222;
+    --panel-bg: #333;
+    --text-color: #eee;
+    --header-bg: #111;
+    --header-text: #eee;
+    --task-bg: #444;
+    --slot-bg: #555;
+}

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Progress Realm Prototype</title>
     <link rel="stylesheet" href="css/styles.css">
 </head>
-<body>
+<body class="dark">
     <header>
         <h1>Progress Realm</h1>
         <div id="header-info">
@@ -26,6 +26,13 @@
             <div id="story-image" class="story-image"></div>
             <p id="story-text"></p>
             <button id="story-close">Continue</button>
+        </div>
+    </div>
+
+    <div id="settings-modal" class="modal hidden">
+        <div class="modal-content">
+            <label><input type="checkbox" id="dark-mode-toggle" checked> Dark Mode</label>
+            <button id="settings-close">Close</button>
         </div>
     </div>
 

--- a/js/main.js
+++ b/js/main.js
@@ -74,6 +74,7 @@ const State = {
     encounterLevel: 0,
     encounterStreak: 0,
     autoProgress: true,
+    darkMode: true,
 };
 
 for (let i = 0; i < State.slotCount; i++) {
@@ -279,6 +280,9 @@ const SaveSystem = {
                 }
                 if (State.autoProgress === undefined) {
                     State.autoProgress = true;
+                }
+                if (State.darkMode === undefined) {
+                    State.darkMode = true;
                 }
                 return data.actions || null;
             } else {
@@ -783,6 +787,22 @@ async function init() {
     if (toggleBtn) {
         toggleBtn.addEventListener('click', toggleLeftPanel);
     }
+    const settingsBtn = document.getElementById('settings-btn');
+    if (settingsBtn) {
+        settingsBtn.addEventListener('click', openSettings);
+    }
+    const settingsClose = document.getElementById('settings-close');
+    if (settingsClose) {
+        settingsClose.addEventListener('click', closeSettings);
+    }
+    const darkToggle = document.getElementById('dark-mode-toggle');
+    if (darkToggle) {
+        darkToggle.addEventListener('change', () => {
+            State.darkMode = darkToggle.checked;
+            applyDarkMode();
+            SaveSystem.save();
+        });
+    }
     const autoBox = document.getElementById('autoprogress-toggle');
     if (autoBox) {
         autoBox.checked = State.autoProgress;
@@ -795,6 +815,7 @@ async function init() {
         retreat('resolve');
     });
     document.getElementById('reset-btn').addEventListener('click', () => SaveSystem.reset());
+    applyDarkMode();
     updateUI();
     // Game logic ticked separately from UI updates so resource generation
     // remains consistent regardless of UI refresh rate.
@@ -817,4 +838,18 @@ function toggleLeftPanel() {
     if (btn) {
         btn.textContent = body.classList.contains('left-collapsed') ? 'Show Stats' : 'Hide Stats';
     }
+}
+
+function applyDarkMode() {
+    document.body.classList.toggle('dark', State.darkMode);
+    const chk = document.getElementById('dark-mode-toggle');
+    if (chk) chk.checked = State.darkMode;
+}
+
+function openSettings() {
+    document.getElementById('settings-modal').classList.remove('hidden');
+}
+
+function closeSettings() {
+    document.getElementById('settings-modal').classList.add('hidden');
 }


### PR DESCRIPTION
## Summary
- support CSS variables for theme colors
- implement dark mode variables
- add settings modal with dark mode toggle
- enable dark mode by default
- document new feature in README and CHANGELOG

## Testing
- `pytest -q`
- `pytest --cov=.` *(fails: unrecognized arguments)*

------
https://chatgpt.com/codex/tasks/task_e_685c888e8d948330a3214ff1caec988f