### PR TITLE
Add dark mode styling for modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.29.0] - 2025-07-19
+### Changed
+- Modals now follow dark mode theme.
+
 ## [0.28.0] - 2025-07-18
 ### Added
 - Dark mode enabled by default with toggle in new Settings panel.

--- a/css/styles.css
+++ b/css/styles.css
@@ -120,7 +120,8 @@ header, footer {
 }
 
 .modal-content {
-    background: #fff;
+    background: var(--panel-bg);
+    color: var(--text-color);
     padding: 1rem;
     border-radius: 4px;
     max-width: 400px;


### PR DESCRIPTION
## Summary
- tweak modal-content background to use theme variables
- document dark mode improvement in CHANGELOG

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_685c8c61ffa48330bd1a4271f63b769d