### PR TITLE
Add hover tooltips for slots with item info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.31.0] - 2025-07-20
+### Changed
+- Removed numeric amounts from item tooltips.
+
+## [0.30.0] - 2025-07-20
+### Added
+- Tooltips now appear on all slots.
+- Inventory slots display item descriptions and effects.
+- Adventure slots show encounter descriptions and loot chances.
+
 ## [0.29.0] - 2025-07-19
 ### Changed
 - Modals now follow dark mode theme.

--- a/css/styles.css
+++ b/css/styles.css
@@ -269,7 +269,7 @@ body.left-collapsed #left {
     font-size: 0.75rem;
     pointer-events: none;
     z-index: 10;
-    white-space: nowrap;
+    white-space: pre-line;
 }
 
 @keyframes completeFlash {

--- a/data/items.json
+++ b/data/items.json
@@ -1,132 +1,145 @@
 [
-  {
-    "id": "herb",
-    "name": "Herb",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "focus": 1
+    {
+        "id": "herb",
+        "name": "Herb",
+        "rarity": "common",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "focus": 1
+        },
+        "image": "assets/items/herb.png",
+        "description": "A collection of useful medicinal plants."
     },
-    "image": "assets/items/herb.png"
-  },
-  {
-    "id": "rabbit_meat",
-    "name": "Rabbit Meat",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "strength": 1
+    {
+        "id": "rabbit_meat",
+        "name": "Rabbit Meat",
+        "rarity": "common",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "strength": 1
+        },
+        "image": "assets/items/rabbit.png",
+        "description": "Fresh meat from a hunted rabbit."
     },
-    "image": "assets/items/rabbit.png"
-  },
-  {
-    "id": "wolf_pelt",
-    "name": "Wolf Pelt",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "health": 2
+    {
+        "id": "wolf_pelt",
+        "name": "Wolf Pelt",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "health": 2
+        },
+        "image": "assets/items/wolfpelt.png",
+        "description": "Thick hide taken from a wolf."
     },
-    "image": "assets/items/wolfpelt.png"
-  },
-  {
-    "id": "wood_log",
-    "name": "Wood Log",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "energy": 1
+    {
+        "id": "wood_log",
+        "name": "Wood Log",
+        "rarity": "common",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "energy": 1
+        },
+        "image": "assets/items/woodlog.PNG",
+        "description": "Sturdy timber cut from local trees."
     },
-    "image": "assets/items/woodlog.PNG"
-  },
-  {
-    "id": "stone_piece",
-    "name": "Stone Piece",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "strength": 0.5
+    {
+        "id": "stone_piece",
+        "name": "Stone Piece",
+        "rarity": "common",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "strength": 0.5
+        },
+        "image": "assets/items/stone.PNG",
+        "description": "A chunk of stone useful for building."
     },
-    "image": "assets/items/stone.PNG"
-  },
-  {
-    "id": "boar_tusk",
-    "name": "Boar Tusk",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "health": 1
+    {
+        "id": "boar_tusk",
+        "name": "Boar Tusk",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "health": 1
+        },
+        "image": "assets/items/boartusk.PNG",
+        "description": "A sharp tusk prized by craftsmen."
     },
-    "image": "assets/items/boartusk.PNG"
-  },
-  {
-    "id": "ore_chunk",
-    "name": "Rare Ore",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "strength": 2
+    {
+        "id": "ore_chunk",
+        "name": "Rare Ore",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "strength": 2
+        },
+        "image": "assets/items/Ore.PNG",
+        "description": "Raw ore ready for smelting."
     },
-    "image": "assets/items/Ore.PNG"
-  },
-  {
-    "id": "stone_spear",
-    "name": "Stone Spear",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "strength": 1.5
+    {
+        "id": "stone_spear",
+        "name": "Stone Spear",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "strength": 1.5
+        },
+        "image": "assets/items/spear.PNG",
+        "description": "Crude spear tipped with sharpened stone."
     },
-    "image": "assets/items/spear.PNG"
-  },
-  {
-    "id": "wooden_shield",
-    "name": "Wooden Shield",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "health": 1
+    {
+        "id": "wooden_shield",
+        "name": "Wooden Shield",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "health": 1
+        },
+        "image": "assets/items/woodshield.PNG",
+        "description": "Simple shield offering basic protection."
     },
-    "image": "assets/items/woodshield.PNG"
-  },
-  {
-    "id": "leather_armor",
-    "name": "Leather Armor",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "health": 2
+    {
+        "id": "leather_armor",
+        "name": "Leather Armor",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "health": 2
+        },
+        "image": "assets/items/leatherarmor.PNG",
+        "description": "Light armor made from treated hides."
     },
-    "image": "assets/items/leatherarmor.PNG"
-  },
-  {
-    "id": "gem",
-    "name": "Gem",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "focus": 2
+    {
+        "id": "gem",
+        "name": "Gem",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "focus": 2
+        },
+        "image": "assets/items/gem.PNG",
+        "description": "A shimmering gemstone of unknown origin."
     },
-    "image": "assets/items/gem.PNG"
-  },
-  {
-    "id": "iron_sword",
-    "name": "Iron Sword",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "strength": 2
+    {
+        "id": "iron_sword",
+        "name": "Iron Sword",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "strength": 2
+        },
+        "image": "assets/generated/iron_sword.png",
+        "description": "A sturdy blade forged from iron."
     },
-    "image": "assets/generated/iron_sword.png"
-  },
-  {
-    "id": "sturdy_bark",
-    "name": "Sturdy Bark",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "health": 1
-    },
-    "image": "assets/generated/sturdy_bark.png"
-  }
+    {
+        "id": "sturdy_bark",
+        "name": "Sturdy Bark",
+        "rarity": "rare",
+        "effectType": "increaseSoftcap",
+        "effectValue": {
+            "health": 1
+        },
+        "image": "assets/generated/sturdy_bark.png",
+        "description": "Thick bark that can reinforce armor."
+    }
 ]

--- a/js/items.js
+++ b/js/items.js
@@ -2,10 +2,19 @@ class Item {
     constructor(data) {
         this.id = data.id;
         this.name = data.name;
+        this.description = data.description || '';
         this.rarity = data.rarity || 'common';
         this.effectType = data.effectType;
         this.effectValue = data.effectValue;
         this.image = data.image || null;
+    }
+
+    getEffectDescription() {
+        if (this.effectType === 'increaseSoftcap' && this.effectValue) {
+            const key = Object.keys(this.effectValue)[0];
+            return `Improves ${key} cap`;
+        }
+        return '';
     }
 
     applyEffect() {
@@ -110,6 +119,8 @@ const Inventory = {
                 rarity: itemData.rarity || 'common',
                 quantity: data.quantity,
                 image: itemData.image,
+                description: itemData.description || '',
+                effect: itemData.getEffectDescription ? itemData.getEffectDescription() : ''
             };
         });
     },

--- a/js/main.js
+++ b/js/main.js
@@ -675,6 +675,7 @@ function updateSlotUI(i) {
         progressEl.max = 1;
         labelEl.textContent = slot.text || '';
         slotEl.style.backgroundImage = 'none';
+        slotEl.dataset.tooltip = 'Drag an action here';
         return;
     }
     const action = actions[slot.actionId];
@@ -686,6 +687,7 @@ function updateSlotUI(i) {
     } else {
         slotEl.style.backgroundImage = 'none';
     }
+    slotEl.dataset.tooltip = `${action.name} - ${capitalize(getActionTier(action.level))}`;
 }
 
 function updateAdventureSlotUI(i) {
@@ -704,9 +706,24 @@ function updateAdventureSlotUI(i) {
             slotEl.style.backgroundSize = 'cover';
         }
         slotEl.classList.add(`rarity-${slot.encounter.rarity}`);
+        const parts = [slot.encounter.description];
+        if (slot.encounter.items) {
+            const lines = Object.entries(slot.encounter.items)
+                .map(([id, chance]) => {
+                    const item = ItemGenerator.itemList.find(i => i.id === id);
+                    const name = item ? item.name : id;
+                    return `${name}: ${Math.round(chance * 100)}%`;
+                });
+            if (lines.length) {
+                parts.push('Loot chances:');
+                parts.push(...lines);
+            }
+        }
+        slotEl.dataset.tooltip = parts.join('\n');
     } else {
         labelEl.textContent = slot.text || '';
         slotEl.style.backgroundImage = 'none';
+        slotEl.dataset.tooltip = '';
     }
 }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -75,10 +75,14 @@ const InventoryUI = {
                     slot.style.backgroundImage = `url(${item.image})`;
                 }
                 slot.classList.add(`rarity-${item.rarity}`);
+                const lines = [item.description];
+                if (item.effect) lines.push(item.effect);
+                slot.dataset.tooltip = lines.join('\n');
             } else {
                 slot.style.backgroundImage = 'none';
                 label.textContent = '';
                 countEl.textContent = '';
+                slot.dataset.tooltip = '';
             }
             slot.appendChild(label);
             slot.appendChild(countEl);


### PR DESCRIPTION
## Summary
- show hover tooltips on inventory, action and adventure slots
- include description/effect info for items from `items.json`
- show encounter descriptions and loot percentages on adventure slots
- allow multi-line tooltips via CSS
- update `items.json` with descriptions
- remove numeric amounts from item tooltips

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_685c915b75c483308bb3861c8a69160f