### PR TITLE
Fix game not starting when HTML is loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.38.0] - 2025-07-27
+### Fixed
+- Game initialization now runs correctly when scripts load at the end of the page
+  so stats and resources update as expected.
+
 ## [0.37.0] - 2025-07-26
 ### Fixed
 - Guarded UI cap updates when SoftCapSystem values are missing to prevent zero stats.

--- a/js/main.js
+++ b/js/main.js
@@ -917,7 +917,9 @@ async function init() {
     }, UI_UPDATE_MS);
 }
 
-document.addEventListener('DOMContentLoaded', init);
+// Directly invoke init because scripts load at the end of the page,
+// meaning the DOMContentLoaded event has already fired
+init();
 
 function toggleLeftPanel() {
     const body = document.body;


### PR DESCRIPTION
## Summary
- make sure the game initializes when scripts are loaded at the end of the page
- document fix in the changelog

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_685cce7e9dc483308e1ee9a0ee2f264e