### PR TITLE
Ensure stats exist when loading saves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.39.0] - 2025-07-28
+### Fixed
+- Ensured stats exist when loading saves to prevent UI errors.
+
 ## [0.38.0] - 2025-07-27
 ### Fixed
 - Game initialization now runs correctly when scripts load at the end of the page

--- a/js/main.js
+++ b/js/main.js
@@ -286,6 +286,9 @@ const SaveSystem = {
                 ensureResource("focus", 10, 10);
                 ensureResource("health", 1, 10);
                 ensureResource("money", 0, 100);
+                ensureStat("strength", 0, 50);
+                ensureStat("intelligence", 0, 50);
+                ensureStat("creativity", 0, 50);
                 if (Array.isArray(State.slots)) {
                     State.slots.forEach(s => {
                         if (s.text === undefined) s.text = '';


### PR DESCRIPTION
## Summary
- guard `SaveSystem.load()` by creating missing stats
- document the fix in `CHANGELOG.md`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685cd28245b8833087ee5779002349de