### PR TITLE
Implement updates tab and remove max level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.41.0] - 2025-07-30
+### Added
+- New "Updates" tab with draggable one-time unlockables.
+### Changed
+- Removed `maxLevel` filtering from encounters to support the new progression system.
+
 ## [0.40.0] - 2025-07-29
 ### Added
 - New common items from analytics data including water flasks, iron ore and more.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 | Resources    | Consumables needed to perform actions; managed separately by `ResourceSystem` |
 | Magic System | Simplified crafting and consumption system for magical items               |
 | Inventory    | Manages player's resource quantities and magical components                |
+| Updates      | One-time unlockables that grant bonuses or new content |
 | Automation   | Enables actions to loop with or without conditions |
 | Bonus Engine | Centralizes additive, multiplicative, and exponential bonuses for stats and resources, including cost divisors |
 | Engine       | Calculates deltas with multipliers and drives the main tick loop |

--- a/data/encounters.json
+++ b/data/encounters.json
@@ -19,8 +19,7 @@
     },
     "loot": {
       "herb": 1
-    },
-    "maxLevel": 5
+    }
   },
   {
     "id": "rabbitHunt",
@@ -41,8 +40,7 @@
       "wolf_pelt": 0.05,
       "feather": 0.2
     },
-    "loot": {},
-    "maxLevel": 8
+    "loot": {}
   },
   {
     "id": "wolfAmbush",
@@ -61,8 +59,7 @@
     "items": {
       "wolf_pelt": 0.5
     },
-    "loot": {},
-    "maxLevel": 15
+    "loot": {}
   },
   {
     "id": "chopWood",
@@ -82,8 +79,7 @@
     },
     "loot": {
       "wood_log": 0.1
-    },
-    "maxLevel": 12
+    }
   },
   {
     "id": "collectStones",
@@ -103,8 +99,7 @@
       "ore_chunk": 0.05,
       "iron_ore": 0.2
     },
-    "loot": {},
-    "maxLevel": 18
+    "loot": {}
   },
   {
     "id": "overseeLumberTeam",
@@ -124,8 +119,7 @@
     },
     "loot": {
       "wood_log": 0.1
-    },
-    "maxLevel": 25
+    }
   },
   {
     "id": "gatherWater",
@@ -145,8 +139,7 @@
     },
     "loot": {
       "water_flask": 1
-    },
-    "maxLevel": 5
+    }
   },
   {
     "id": "digClay",
@@ -166,8 +159,7 @@
     },
     "loot": {
       "clay": 1
-    },
-    "maxLevel": 12
+    }
   },
   {
     "id": "berryPicking",
@@ -187,8 +179,7 @@
     },
     "loot": {
       "berries": 1
-    },
-    "maxLevel": 5
+    }
   },
   {
     "id": "fishingTrip",
@@ -208,8 +199,7 @@
     },
     "loot": {
       "cooked_fish": 1
-    },
-    "maxLevel": 10
+    }
   },
   {
     "id": "abandonedCamp",
@@ -231,8 +221,7 @@
     },
     "loot": {
       "money": 1
-    },
-    "maxLevel": 15
+    }
   },
   {
     "id": "boarHunt",
@@ -252,8 +241,7 @@
       "boar_tusk": 0.7,
       "herb": 0.3
     },
-    "loot": {},
-    "maxLevel": 25
+    "loot": {}
   },
   {
     "id": "findOre",
@@ -272,8 +260,7 @@
       "ore_chunk": 0.6,
       "iron_ore": 0.3
     },
-    "loot": {},
-    "maxLevel": 45
+    "loot": {}
   },
   {
     "id": "banditsAmbush",
@@ -296,8 +283,7 @@
       "iron_sword": 1,
       "wooden_shield": 1,
       "leather_armor": 1
-    },
-    "maxLevel": 100
+    }
   },
   {
     "id": "ancientVault",
@@ -319,7 +305,6 @@
       "leather_armor": 0.2,
       "gem": 0.2
     },
-    "loot": {},
-    "maxLevel": 60
+    "loot": {}
   }
 ]

--- a/data/updates.json
+++ b/data/updates.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "townHall",
+    "name": "Rebuild Town Hall",
+    "description": "Restores the town center and unlocks new opportunities.",
+    "duration": 30,
+    "resourceConsumption": {"money": 50, "wood_log": 5},
+    "state": "locked",
+    "bonus": {"stats": {"charisma": 5}},
+    "unlocks": {"encounters": ["townMeeting"]}
+  }
+]

--- a/index.html
+++ b/index.html
@@ -95,6 +95,12 @@
                         <h2 data-i18n="Control">Control</h2>
                         <p>Crafting and Automation go here.</p>
                     </div>
+                    <div class="tab-content hidden" data-tab="updates">
+                        <h2 data-i18n="Updates">Updates</h2>
+                        <ul id="update-list"></ul>
+                        <h2 data-i18n="Update Slots">Update Slots</h2>
+                        <div id="update-slots" class="slots"></div>
+                    </div>
                 </div>
             </div>
         </div>
@@ -116,6 +122,7 @@
     <script src="js/utils.js"></script>
     <script src="js/encounter.js"></script>
     <script src="js/items.js"></script>
+    <script src="js/updates.js"></script>
     <script src="js/bonus.js"></script>
     <script src="js/engine.js"></script>
     <script src="js/ui.js"></script>

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -8,7 +8,6 @@ class Encounter {
         this.category = data.category || 'strength';
         this.baseDuration = data.baseDuration || 5;
         this.minLevel = data.minLevel || 0;
-        this.maxLevel = data.maxLevel;
         this.storyLevel = data.storyLevel;
         this.resourceConsumption = data.resourceConsumption || {};
         this.items = data.items || null;
@@ -143,7 +142,6 @@ const EncounterGenerator = {
 
         const pool = this.encounters.filter(e => {
             if ((e.minLevel || 0) > this.level) return false;
-            if (e.maxLevel !== undefined && this.level > e.maxLevel) return false;
             return true;
         });
         if (!pool.length) return null;

--- a/js/main.js
+++ b/js/main.js
@@ -219,6 +219,7 @@ const TabManager = {
         { id: 'adventure', name: 'Adventure', hidden: true, locked: false },
         { id: 'inventory', name: 'Inventory', hidden: false, locked: false },
         { id: 'automation', name: 'Automation', hidden: false, locked: false },
+        { id: 'updates', name: 'Updates', hidden: false, locked: false },
     ],
     init() {
         this.header = document.getElementById('tab-headers');
@@ -832,6 +833,7 @@ async function init() {
     });
     await EncounterGenerator.load();
     await ItemGenerator.load();
+    await UpdateSystem.load();
     Lang.applyToActions(actions);
     Lang.applyToItems(ItemGenerator.itemList);
     Lang.applyToEncounters(EncounterGenerator.encounters);
@@ -841,6 +843,7 @@ async function init() {
     ResourcesUI.init();
     MasteryUI.init();
     InventoryUI.init();
+    UpdateSystem.init();
     if (typeof CharacterBackground !== 'undefined') {
         CharacterBackground.init();
     }
@@ -913,6 +916,7 @@ async function init() {
     setInterval(() => {
         ActionEngine.tick(LOGIC_TICK_MS / 1000);
         AdventureEngine.tick(LOGIC_TICK_MS / 1000);
+        UpdateSystem.tick(LOGIC_TICK_MS / 1000);
     }, LOGIC_TICK_MS);
     setInterval(() => {
         updateTaskList();

--- a/js/updates.js
+++ b/js/updates.js
@@ -1,0 +1,163 @@
+class Update {
+    constructor(data) {
+        this.id = data.id;
+        this.name = data.name;
+        this.description = data.description || '';
+        this.image = data.image || null;
+        this.duration = data.duration || 1;
+        this.resourceConsumption = data.resourceConsumption || {};
+        this.state = data.state || 'locked';
+        this.bonus = data.bonus || {};
+        this.unlocks = data.unlocks || { actions: [], encounters: [] };
+        this.progress = 0;
+    }
+}
+
+const UpdateSystem = {
+    updates: [],
+    slots: [],
+    slotCount: 1,
+    async load() {
+        try {
+            const res = await fetch('data/updates.json');
+            const json = await res.json();
+            this.updates = json.map(u => new Update(u));
+        } catch (e) {
+            console.error('Failed to load updates', e);
+            this.updates = [];
+        }
+    },
+    init() {
+        this.listEl = document.getElementById('update-list');
+        this.slotContainer = document.getElementById('update-slots');
+        if (!this.listEl || !this.slotContainer) return;
+        this.updates.forEach(u => {
+            const li = document.createElement('li');
+            li.textContent = u.name;
+            li.dataset.updateId = u.id;
+            li.dataset.tooltip = u.description;
+            if (u.state === 'locked') {
+                li.classList.add('locked');
+            } else {
+                li.setAttribute('draggable', 'true');
+                li.addEventListener('dragstart', e => {
+                    li.classList.add('dragging');
+                    e.dataTransfer.setData('text/plain', u.id);
+                });
+                li.addEventListener('dragend', () => li.classList.remove('dragging'));
+            }
+            this.listEl.appendChild(li);
+        });
+        while (this.slots.length < this.slotCount) {
+            this.slots.push({ updateId: null, progress: 0, active: false });
+        }
+        for (let i = 0; i < this.slotCount; i++) {
+            const slotEl = document.createElement('div');
+            slotEl.className = 'slot';
+            slotEl.dataset.slot = i;
+            const label = document.createElement('span');
+            label.className = 'label';
+            slotEl.appendChild(label);
+            const wrapper = document.createElement('div');
+            wrapper.className = 'progress-wrapper';
+            const prog = document.createElement('progress');
+            prog.value = 0;
+            prog.max = 1;
+            wrapper.appendChild(prog);
+            slotEl.appendChild(wrapper);
+            slotEl.addEventListener('dragover', e => e.preventDefault());
+            slotEl.addEventListener('drop', e => {
+                e.preventDefault();
+                const id = e.dataTransfer.getData('text/plain');
+                const index = parseInt(slotEl.dataset.slot, 10);
+                UpdateSystem.start(index, id);
+            });
+            this.slotContainer.appendChild(slotEl);
+            this.updateSlotUI(i);
+        }
+    },
+    start(index, id) {
+        const slot = this.slots[index];
+        const update = this.updates.find(u => u.id === id && u.state === 'available');
+        if (!update) return;
+        slot.updateId = id;
+        slot.progress = 0;
+        slot.active = true;
+        update.state = 'inProgress';
+        this.updateListUI();
+        this.updateSlotUI(index);
+    },
+    updateSlotUI(i) {
+        const slot = this.slots[i];
+        const slotEl = this.slotContainer.querySelector(`.slot[data-slot="${i}"]`);
+        if (!slotEl) return;
+        const progressEl = slotEl.querySelector('progress');
+        const labelEl = slotEl.querySelector('.label');
+        if (!slot.updateId) {
+            progressEl.value = 0;
+            progressEl.max = 1;
+            labelEl.textContent = '';
+            slotEl.dataset.tooltip = '';
+            return;
+        }
+        const update = this.updates.find(u => u.id === slot.updateId);
+        progressEl.max = 1;
+        progressEl.value = slot.progress;
+        labelEl.textContent = update.name;
+        slotEl.dataset.tooltip = update.description;
+    },
+    updateListUI() {
+        this.listEl.querySelectorAll('li').forEach(li => li.remove());
+        this.updates.forEach(u => {
+            const li = document.createElement('li');
+            li.textContent = u.name;
+            li.dataset.updateId = u.id;
+            li.dataset.tooltip = u.description;
+            if (u.state !== 'available') {
+                li.classList.add('locked');
+            } else {
+                li.setAttribute('draggable', 'true');
+                li.addEventListener('dragstart', e => {
+                    li.classList.add('dragging');
+                    e.dataTransfer.setData('text/plain', u.id);
+                });
+                li.addEventListener('dragend', () => li.classList.remove('dragging'));
+            }
+            this.listEl.appendChild(li);
+        });
+    },
+    tick(delta) {
+        this.slots.forEach((slot, i) => {
+            if (!slot.active) return;
+            const update = this.updates.find(u => u.id === slot.updateId);
+            if (!update) return;
+            slot.progress += delta / update.duration;
+            this.updateSlotUI(i);
+            if (slot.progress >= 1) {
+                slot.active = false;
+                slot.updateId = null;
+                slot.progress = 0;
+                update.state = 'done';
+                this.applyUpdate(update);
+                this.updateListUI();
+                this.updateSlotUI(i);
+            }
+        });
+    },
+    applyUpdate(update) {
+        if (update.bonus && update.bonus.stats) {
+            for (const [k, v] of Object.entries(update.bonus.stats)) {
+                BonusEngine.statAdditions[k] = (BonusEngine.statAdditions[k] || 0) + v;
+            }
+        }
+        if (update.unlocks && update.unlocks.actions) {
+            update.unlocks.actions.forEach(id => {
+                if (actions[id]) actions[id].locked = false;
+            });
+        }
+    }
+};
+
+if (typeof module !== 'undefined') {
+    module.exports = { UpdateSystem, Update };
+}

--- a/tests/test_encounters.py
+++ b/tests/test_encounters.py
@@ -25,9 +25,6 @@ def test_encounter_fields():
         for qty in enc['loot'].values():
             assert isinstance(qty, (int, float))
             assert qty >= 0
-        assert 'maxLevel' in enc
-        assert isinstance(enc['maxLevel'], (int, float))
-        assert enc['maxLevel'] >= enc.get('minLevel', 0)
 
 
 def test_story_encounter():
@@ -46,26 +43,12 @@ def test_story_encounter():
     assert story['loot'] == expected_loot
 
 
-def test_max_level_filtering():
+def test_no_max_level_property():
     path = os.path.join('data', 'encounters.json')
     with open(path) as f:
         data = json.load(f)
 
-    def filter_pool(level):
-        pool = []
-        for e in data:
-            if e.get('minLevel', 0) > level:
-                continue
-            if 'maxLevel' in e and level > e['maxLevel']:
-                continue
-            pool.append(e['id'])
-        return pool
-
-    low_pool = filter_pool(0)
-    high_pool = filter_pool(20)
-
-    assert 'foragingHerbs' in low_pool
-    assert 'foragingHerbs' not in high_pool
+    assert all('maxLevel' not in e for e in data)
 
 
 def test_loot_yield_constant_present():


### PR DESCRIPTION
## Summary
- add new Updates tab to UI with draggable unlockables
- introduce UpdateSystem module and update data
- remove obsolete max level from encounters
- update tests and docs

## Testing
- `pytest -q`
- `pytest --cov=.`


------
https://chatgpt.com/codex/tasks/task_e_685d2523241483309fbe0f1029735140