### PR TITLE
Add progress bar for encounter streak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.41.3] - 2025-07-31
+### Added
+- Progress bar under encounter location shows streak toward next level.
+
 ## [0.41.2] - 2025-07-30
 ### Added
 - Translation support for log messages.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ docs/MVP.md         - checklist for the first prototype
 #### Prototype Layout
 
 The page uses a simple header/main/footer structure. Stats and resources are kept in a left sidebar, routine controls sit in the center, and a log panel occupies the right side. The header shows the current age and provides buttons to adjust the game speed.
-A story modal appears once on the first load and another short scene triggers after thirty days pass in game time. Both modals only appear during the first life and all log messages are recorded in a scrollable container (about 300&nbsp;px high) in the right panel. Habits are quick actions found below the routines for instant resource gains. Routines themselves are triggered by clicking their progress bars; hovering shows the cost and effect.
+A story modal appears once on the first load and another short scene triggers after thirty days pass in game time. Both modals only appear during the first life and all log messages are recorded in a scrollable container (about 300&nbsp;px high) in the right panel. Habits are quick actions found below the routines for instant resource gains. Routines themselves are triggered by clicking their progress bars; hovering shows the cost and effect. The adventure tab now displays a second progress bar beneath the location name showing how many encounters remain before the next level.
 
 See **docs/MVP.md** for the MVP list.
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -189,6 +189,13 @@ body.left-collapsed #left {
     margin-top: 0.5rem;
 }
 
+#encounter-level-progress {
+    width: 100%;
+    height: 0.5rem;
+    margin-top: 0.25rem;
+    display: block;
+}
+
 #adventure-controls {
     display: flex;
     align-items: center;

--- a/index.html
+++ b/index.html
@@ -81,6 +81,7 @@
                     <div class="tab-content hidden" data-tab="adventure">
                         <h2 data-i18n="Adventure">Adventure</h2>
                         <p id="encounter-location"></p>
+                        <progress id="encounter-level-progress" value="0" max="10"></progress>
                         <div id="adventure-controls">
                             <button id="return-btn" data-i18n="Return">Return</button>
                             <label><input type="checkbox" id="autoprogress-toggle" checked> <span data-i18n="Autoprogress">Autoprogress</span></label>

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -97,12 +97,22 @@ const EncounterGenerator = {
         if (el) {
             el.textContent = `${name} (Level ${this.level})`;
         }
+        this.updateProgressBar();
+    },
+
+    updateProgressBar() {
+        const bar = document.getElementById('encounter-level-progress');
+        if (bar) {
+            bar.max = 10;
+            bar.value = Math.min(State.encounterStreak || 0, 10);
+        }
     },
 
     incrementLevel() {
         this.level += 1;
         State.encounterLevel = this.level;
         this.updateName();
+        this.updateProgressBar();
     },
 
     decrementLevel() {
@@ -110,12 +120,14 @@ const EncounterGenerator = {
             this.level -= 1;
             State.encounterLevel = this.level;
             this.updateName();
+            this.updateProgressBar();
         }
     },
 
     resetProgress() {
         this.populateSlots();
         State.encounterStreak = 0;
+        this.updateProgressBar();
         if (typeof AdventureEngine !== 'undefined') {
             AdventureEngine.startSlot(0);
         }
@@ -126,6 +138,7 @@ const EncounterGenerator = {
         if (!this.container) return;
         this.level = State.encounterLevel || 0;
         this.updateName();
+        this.updateProgressBar();
         this.populateSlots();
     },
 

--- a/js/main.js
+++ b/js/main.js
@@ -412,13 +412,16 @@ const AdventureEngine = {
             slot.encounter = null;
             slot.progress = 0;
             State.encounterStreak += 1;
+            EncounterGenerator.updateProgressBar();
             updateAdventureSlotUI(this.activeIndex);
             if (State.encounterStreak >= 10) {
                 if (State.autoProgress) {
                     EncounterGenerator.incrementLevel();
                     State.encounterStreak = 0;
+                    EncounterGenerator.updateProgressBar();
                 } else {
                     State.encounterStreak = 10;
+                    EncounterGenerator.updateProgressBar();
                 }
             }
             this.startSlot(this.activeIndex);


### PR DESCRIPTION
## Summary
- show progress bar for encounter levels
- track progress by encounter streak in JS
- style new progress bar in CSS
- document progress bar in README and CHANGELOG

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_685e5eb05cd083309b2edbd6cf1d5685