### PR TITLE
Add stats/resources JSON loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.42.0] - 2025-07-30
+### Added
+- Separated stats and resources into `data/stats.json` and `data/resources.json`.
+- Game now loads base values from these files at startup.
+
 ## [0.41.2] - 2025-07-30
 ### Added
 - Translation support for log messages.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ css/styles.css      - page styling
 js/main.js          - core game logic
 assets/             - images and static assets
 data/actions.json   - action definitions
+data/stats.json     - base stat values
+data/resources.json - base resource values
 docs/MVP.md         - checklist for the first prototype
 ```
 

--- a/data/resources.json
+++ b/data/resources.json
@@ -1,0 +1,6 @@
+[
+  { "id": "energy", "baseValue": 10, "baseMax": 10 },
+  { "id": "focus", "baseValue": 10, "baseMax": 10 },
+  { "id": "health", "baseValue": 1, "baseMax": 10 },
+  { "id": "money", "baseValue": 0, "baseMax": 100 }
+]

--- a/data/stats.json
+++ b/data/stats.json
@@ -1,0 +1,5 @@
+[
+  { "id": "strength", "baseValue": 0, "baseMax": 50 },
+  { "id": "intelligence", "baseValue": 0, "baseMax": 50 },
+  { "id": "creativity", "baseValue": 0, "baseMax": 50 }
+]

--- a/js/engine.js
+++ b/js/engine.js
@@ -1,5 +1,5 @@
-const statDeltas = { strength: 0, intelligence: 0, creativity: 0 };
-const resourceDeltas = { energy: 0, focus: 0, health: 0, money: 0 };
+const statDeltas = {};
+const resourceDeltas = {};
 let ageDelta = 0;
 const expDeltas = {};
 const encounterProgressDeltas = [];

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,6 +1,6 @@
 
 const StatsUI = {
-    list: ['strength', 'intelligence', 'creativity'],
+    list: STAT_KEYS,
     init() {
         const listEl = document.getElementById('stats-list');
         this.list.forEach(key => {
@@ -34,7 +34,7 @@ const StatsUI = {
 };
 
 const ResourcesUI = {
-    list: ["energy", "focus", "health", "money"],
+    list: RESOURCE_KEYS,
     init() {
         const listEl = document.getElementById("resources-list");
         this.list.forEach(key => {

--- a/tests/test_stats_resources.py
+++ b/tests/test_stats_resources.py
@@ -1,0 +1,30 @@
+import json
+import os
+
+
+def test_stats_fields():
+    path = os.path.join('data', 'stats.json')
+    with open(path) as f:
+        data = json.load(f)
+    assert isinstance(data, list)
+    for s in data:
+        assert 'id' in s
+        assert 'baseValue' in s
+        assert 'baseMax' in s
+        assert isinstance(s['baseValue'], (int, float))
+        assert isinstance(s['baseMax'], (int, float))
+        assert s['baseMax'] >= s['baseValue']
+
+
+def test_resources_fields():
+    path = os.path.join('data', 'resources.json')
+    with open(path) as f:
+        data = json.load(f)
+    assert isinstance(data, list)
+    for r in data:
+        assert 'id' in r
+        assert 'baseValue' in r
+        assert 'baseMax' in r
+        assert isinstance(r['baseValue'], (int, float))
+        assert isinstance(r['baseMax'], (int, float))
+        assert r['baseMax'] >= r['baseValue']


### PR DESCRIPTION
## Summary
- store base stat and resource values in new `stats.json` and `resources.json`
- load these files at startup and build `State` dynamically
- adjust `SaveSystem` and UI helpers for dynamic lists
- update documentation and changelog
- add tests for new data files

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_685e5ef589b08330827015e1db6ae426