### PR TITLE
Add JSON-based resource initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.41.4] - 2025-07-30
+### Added
+- Base stats and resources now loaded from `data/resources.json`.
+- BonusEngine initializes dynamically for new resource keys.
+
 ## [0.41.3] - 2025-07-30
 ### Added
 - Introduced `state.js` module and updated dependencies.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ js/main.js          - core game logic
 js/state.js         - global state and helper functions
 assets/             - images and static assets
 data/actions.json   - action definitions
+data/resources.json - base stats and resources
 docs/MVP.md         - checklist for the first prototype
 ```
 

--- a/data/resources.json
+++ b/data/resources.json
@@ -1,0 +1,18 @@
+{
+    "stats": {
+        "strength": {"value": 0, "baseMax": 50},
+        "intelligence": {"value": 0, "baseMax": 50},
+        "creativity": {"value": 0, "baseMax": 50}
+    },
+    "resources": {
+        "energy": {"value": 10, "baseMax": 10},
+        "focus": {"value": 10, "baseMax": 10},
+        "health": {"value": 1, "baseMax": 10},
+        "money": {"value": 0, "baseMax": 100}
+    },
+    "prestige": {
+        "strength": 0,
+        "intelligence": 0,
+        "creativity": 0
+    }
+}

--- a/js/bonus.js
+++ b/js/bonus.js
@@ -1,10 +1,29 @@
 const BonusEngine = {
-    statAdditions: { strength: 0, intelligence: 0, creativity: 0 },
-    statMultipliers: { strength: 1, intelligence: 1, creativity: 1 },
-    statPowers: { strength: 1, intelligence: 1, creativity: 1 },
-    resourceAdditions: { energy: 0, focus: 0, health: 0, money: 0 },
-    resourceMultipliers: { energy: 1, focus: 1, health: 1, money: 1 },
-    resourceDividers: { energy: 1, focus: 1, health: 1, money: 1 },
+    statAdditions: {},
+    statMultipliers: {},
+    statPowers: {},
+    resourceAdditions: {},
+    resourceMultipliers: {},
+    resourceDividers: {},
+
+    initialize(statKeys = [], resourceKeys = []) {
+        this.statAdditions = {};
+        this.statMultipliers = {};
+        this.statPowers = {};
+        statKeys.forEach(k => {
+            this.statAdditions[k] = 0;
+            this.statMultipliers[k] = 1;
+            this.statPowers[k] = 1;
+        });
+        this.resourceAdditions = {};
+        this.resourceMultipliers = {};
+        this.resourceDividers = {};
+        resourceKeys.forEach(k => {
+            this.resourceAdditions[k] = 0;
+            this.resourceMultipliers[k] = 1;
+            this.resourceDividers[k] = 1;
+        });
+    },
 
     applyStat(delta, key) {
         const add = this.statAdditions[key] || 0;

--- a/js/main.js
+++ b/js/main.js
@@ -180,13 +180,14 @@ const SaveSystem = {
             if (data.version !== VERSION) return null;
             if (data.state) {
                 Object.assign(State, data.state);
-                ensureResource("energy", 10, 10);
-                ensureResource("focus", 10, 10);
-                ensureResource("health", 1, 10);
-                ensureResource("money", 0, 100);
-                ensureStat("strength", 0, 50);
-                ensureStat("intelligence", 0, 50);
-                ensureStat("creativity", 0, 50);
+                RESOURCE_KEYS.forEach(k => {
+                    const def = State.resources[k] || { value: 0, baseMax: 0 };
+                    ensureResource(k, def.value, def.baseMax);
+                });
+                STAT_KEYS.forEach(k => {
+                    const def = State.stats[k] || { value: 0, baseMax: 0 };
+                    ensureStat(k, def.value, def.baseMax);
+                });
                 if (Array.isArray(State.slots)) {
                     State.slots.forEach(s => {
                         if (s.text === undefined) s.text = '';
@@ -688,6 +689,7 @@ function updateUI() {
 }
 
 async function init() {
+    await loadBaseData();
     const loadedActions = SaveSystem.load();
     await Lang.load(State.language);
     Log.init();

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,7 +1,8 @@
 
 const StatsUI = {
-    list: ['strength', 'intelligence', 'creativity'],
+    list: [],
     init() {
+        this.list = STAT_KEYS.slice();
         const listEl = document.getElementById('stats-list');
         this.list.forEach(key => {
             const li = document.createElement('li');
@@ -34,8 +35,9 @@ const StatsUI = {
 };
 
 const ResourcesUI = {
-    list: ["energy", "focus", "health", "money"],
+    list: [],
     init() {
+        this.list = RESOURCE_KEYS.slice();
         const listEl = document.getElementById("resources-list");
         this.list.forEach(key => {
             const li = document.createElement("li");

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,18 @@
+import json
+import os
+
+def test_resources_structure():
+    path = os.path.join('data', 'resources.json')
+    with open(path) as f:
+        data = json.load(f)
+    assert 'stats' in data
+    assert 'resources' in data
+    assert 'prestige' in data
+    for section in ['stats', 'resources']:
+        assert isinstance(data[section], dict)
+        for entry in data[section].values():
+            assert 'value' in entry and 'baseMax' in entry
+            assert isinstance(entry['value'], (int, float))
+            assert isinstance(entry['baseMax'], (int, float))
+            assert entry['baseMax'] >= entry['value']
+    assert isinstance(data['prestige'], dict)


### PR DESCRIPTION
## Summary
- load stats and resources from new `data/resources.json`
- initialize BonusEngine dynamically
- update UI modules to use dynamic lists
- ensure saves handle dynamic resources
- document new file in README
- add tests for `resources.json`

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_685e64983820833090f010bbe4f9304d