### PR TITLE
Fix load order bug with VERSION constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.41.5] - 2025-07-30
+### Fixed
+- Moved `VERSION` constant into `state.js` so initialization succeeds when scripts load in `index.html`.
+
 ## [0.41.4] - 2025-07-30
 ### Added
 - Base stats and resources now loaded from `data/resources.json`.

--- a/js/main.js
+++ b/js/main.js
@@ -1,5 +1,4 @@
 // Progress Realm prototype with leveled actions and resource consumption
-const VERSION = 2;
 // Game logic runs independently from UI updates. Logic ticks occur at a fixed
 // rate defined here and resources scale per real-time second regardless of the
 // UI refresh rate.

--- a/js/state.js
+++ b/js/state.js
@@ -1,5 +1,8 @@
 // Global state and helper systems
 
+// Game save version. Shared with main.js for compatibility checks
+const VERSION = 2;
+
 const ResourceSystem = {
     create(value, baseMax) {
         return { value: value, baseMax: baseMax, maxAdditions: [], maxMultipliers: [] };


### PR DESCRIPTION
## Summary
- move VERSION constant to `state.js` so it loads before `main.js`
- remove duplicate declaration from `main.js`
- document fix in `CHANGELOG.md`

## Testing
- `pytest --cov -q`

------
https://chatgpt.com/codex/tasks/task_e_685e7bc537ac83308848ebe6161bcf37