### PR TITLE
Add debug logger and improve comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.41.6] - 2025-06-27
+### Added
+- Lightweight `Logger` module for optional debug output
+- Logging statements in `state.js` and image pipeline script
+- README updated with new logger info
+
 ## [0.41.5] - 2025-07-30
 ### Fixed
 - Moved `VERSION` constant into `state.js` so initialization succeeds when scripts load in `index.html`.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 * HTML, CSS, JavaScript
 * Optional: Vue or Svelte for structure
 * Save system via localStorage (later: IndexedDB)
+* Simple client-side Logger toggled through `Logger.enabled`
 
 #### 11. Project Structure
 

--- a/index.html
+++ b/index.html
@@ -120,6 +120,7 @@
         <button id="settings-btn" data-i18n="Settings">Settings</button>
         <button id="reset-btn" data-i18n="Reset">Reset</button>
     </footer>
+    <script src="js/logger.js"></script>
     <script src="js/utils.js"></script>
     <script src="js/state.js"></script>
     <script src="js/encounter.js"></script>

--- a/js/logger.js
+++ b/js/logger.js
@@ -1,0 +1,25 @@
+/**
+ * Lightweight logger for debugging purposes.
+ * Agents can enable verbose output by setting `Logger.enabled = true`.
+ * Console methods are used so disabling has minimal performance impact.
+ */
+const Logger = {
+    enabled: false,
+    debug(...args) {
+        if (this.enabled) console.debug('[DEBUG]', ...args);
+    },
+    info(...args) {
+        if (this.enabled) console.info('[INFO]', ...args);
+    },
+    warn(...args) {
+        if (this.enabled) console.warn('[WARN]', ...args);
+    },
+    error(...args) {
+        console.error('[ERROR]', ...args);
+    }
+};
+
+if (typeof module !== 'undefined') {
+    module.exports = { Logger };
+}
+

--- a/js/state.js
+++ b/js/state.js
@@ -1,4 +1,15 @@
 // Global state and helper systems
+//
+// Dependencies:
+//  - bonus.js: uses BonusEngine for multipliers
+//  - utils.js: helper methods (e.g. weighted random)
+//
+// Exports:
+//  - State: persistent game data
+//  - ResourceSystem / StatSystem: resource helpers
+//  - loadBaseData(): fetches data/resources.json
+//
+// AI Agents: inspect State object when modifying progression logic.
 
 // Game save version. Shared with main.js for compatibility checks
 const VERSION = 2;
@@ -130,8 +141,9 @@ async function loadBaseData() {
         if (typeof BonusEngine !== 'undefined' && BonusEngine.initialize) {
             BonusEngine.initialize(STAT_KEYS, RESOURCE_KEYS);
         }
+        Logger.info('Base resource data loaded');
     } catch (e) {
-        console.error('Failed to load resource data', e);
+        Logger.error('Failed to load resource data', e);
     }
 }
 


### PR DESCRIPTION
## Summary
- add lightweight Logger module
- integrate Logger with state initialization
- switch image pipeline script to use Python `logging`
- document Logger usage in README
- include new module in `index.html`
- update changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685ed80c3f088330aa646cd35dc09920