### PR TITLE
Implement inventory sorting and grid layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.41.8] - 2025-08-16
+### Changed
+- Inventory grid now caps at six columns and falls back to three on small screens.
+- Items are sorted by rarity in the inventory tab.
+
 ## [0.41.7] - 2025-08-15
 ### Added
 - Inline comments across JS modules explaining game flow and module chain.

--- a/css/styles.css
+++ b/css/styles.css
@@ -183,6 +183,11 @@ body.left-collapsed #left {
     display: flex;
 }
 
+#inventory-slots {
+    display: grid;
+    grid-template-columns: repeat(6, 1fr);
+}
+
 
 #encounter-location {
     font-style: italic;
@@ -343,6 +348,9 @@ body.left-collapsed #left {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
         gap: 0.5rem;
+    }
+    #inventory-slots {
+        grid-template-columns: repeat(3, 1fr);
     }
     #adventure-slots {
         display: flex;

--- a/js/items.js
+++ b/js/items.js
@@ -102,7 +102,7 @@ const Inventory = {
         }
     },
     getItems() {
-        return Object.entries(State.inventory).map(([id, data]) => {
+        const items = Object.entries(State.inventory).map(([id, data]) => {
             const itemData = ItemGenerator.itemList.find(i => i.id === id) || {};
             return {
                 id,
@@ -114,6 +114,16 @@ const Inventory = {
                 effect: itemData.getEffectDescription ? itemData.getEffectDescription() : ''
             };
         });
+
+        const rarityOrder = RARITY_CLASSES.slice().reverse();
+        items.sort((a, b) => {
+            const ra = rarityOrder.indexOf(a.rarity);
+            const rb = rarityOrder.indexOf(b.rarity);
+            if (ra !== rb) return ra - rb;
+            return a.name.localeCompare(b.name);
+        });
+
+        return items;
     },
     hasItem(id) {
         return State.inventory[id] && State.inventory[id].quantity > 0;


### PR DESCRIPTION
## Summary
- show up to 6 inventory columns on desktop and 3 on mobile
- sort inventory items by rarity before displaying
- update changelog with details of new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685eea9067748330b595861285744b0b