### PR TITLE
Add inventory rarity filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.41.10] - 2025-08-18
+### Added
+- Optional rarity filter in the inventory tab.
+
 ## [0.41.9] - 2025-08-17
 ### Added
 - Recover encounter triggers after automatic retreats and appears once the hero's resources return to full.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ docs/MVP.md         - checklist for the first prototype
 #### Prototype Layout
 
 The page uses a simple header/main/footer structure. Stats and resources are kept in a left sidebar, routine controls sit in the center, and a log panel occupies the right side. The header shows the current age and provides buttons to adjust the game speed.
-A story modal appears once on the first load and another short scene triggers after thirty days pass in game time. Both modals only appear during the first life and all log messages are recorded in a scrollable container (about 300&nbsp;px high) in the right panel. Habits are quick actions found below the routines for instant resource gains. Routines themselves are triggered by clicking their progress bars; hovering shows the cost and effect. The adventure tab now displays a second progress bar beneath the location name showing how many encounters remain before the next level.
+
+A story modal appears once on the first load and another short scene triggers after thirty days pass in game time. Both modals only appear during the first life and all log messages are recorded in a scrollable container (about 300&nbsp;px high) in the right panel. Habits are quick actions found below the routines for instant resource gains. Routines themselves are triggered by clicking their progress bars; hovering shows the cost and effect. The adventure tab now displays a second progress bar beneath the location name showing how many encounters remain before the next level. The inventory tab includes a filter button to hide items below a chosen rarity.
 
 See **docs/MVP.md** for the MVP list.
 

--- a/index.html
+++ b/index.html
@@ -42,6 +42,20 @@
         </div>
     </div>
 
+    <div id="inventory-filter-modal" class="modal hidden">
+        <div class="modal-content">
+            <label><input type="checkbox" id="hide-rarity-toggle"> Hide items</label>
+            <label>below rarity:
+                <select id="hide-rarity-select">
+                    <option value="rare">rare</option>
+                    <option value="epic">epic</option>
+                    <option value="legendary">legendary</option>
+                </select>
+            </label>
+            <button id="inventory-filter-close">Close</button>
+        </div>
+    </div>
+
     <main id="app">
         <div id="left" class="panel">
             <section id="stats">
@@ -90,6 +104,7 @@
                     </div>
                     <div class="tab-content hidden" data-tab="inventory">
                         <h2 data-i18n="Inventory">Inventory</h2>
+                        <button id="inventory-filter-btn">Hide Items</button>
                         <div id="inventory-slots" class="slots"></div>
                     </div>
                     <div class="tab-content hidden" data-tab="automation">

--- a/js/items.js
+++ b/js/items.js
@@ -122,8 +122,13 @@ const Inventory = {
             if (ra !== rb) return ra - rb;
             return a.name.localeCompare(b.name);
         });
+        let result = items;
+        if (State.hideRarityEnabled) {
+            const threshold = RARITY_CLASSES.indexOf(State.hideBelowRarity);
+            result = items.filter(it => RARITY_CLASSES.indexOf(it.rarity) >= threshold);
+        }
 
-        return items;
+        return result;
     },
     hasItem(id) {
         return State.inventory[id] && State.inventory[id].quantity > 0;

--- a/js/main.js
+++ b/js/main.js
@@ -232,6 +232,12 @@ const SaveSystem = {
                 if (State.darkMode === undefined) {
                     State.darkMode = true;
                 }
+                if (State.hideRarityEnabled === undefined) {
+                    State.hideRarityEnabled = false;
+                }
+                if (!State.hideBelowRarity) {
+                    State.hideBelowRarity = 'rare';
+                }
                 if (!State.language) {
                     State.language = 'en';
                 }
@@ -794,6 +800,30 @@ async function init() {
     if (settingsClose) {
         settingsClose.addEventListener('click', closeSettings);
     }
+    const filterBtn = document.getElementById('inventory-filter-btn');
+    if (filterBtn) {
+        filterBtn.addEventListener('click', openInventoryFilter);
+    }
+    const filterClose = document.getElementById('inventory-filter-close');
+    if (filterClose) {
+        filterClose.addEventListener('click', closeInventoryFilter);
+    }
+    const hideToggle = document.getElementById('hide-rarity-toggle');
+    if (hideToggle) {
+        hideToggle.addEventListener('change', () => {
+            State.hideRarityEnabled = hideToggle.checked;
+            InventoryUI.update();
+            SaveSystem.save();
+        });
+    }
+    const raritySelect = document.getElementById('hide-rarity-select');
+    if (raritySelect) {
+        raritySelect.addEventListener('change', () => {
+            State.hideBelowRarity = raritySelect.value;
+            InventoryUI.update();
+            SaveSystem.save();
+        });
+    }
     const darkToggle = document.getElementById('dark-mode-toggle');
     if (darkToggle) {
         darkToggle.addEventListener('change', () => {
@@ -878,4 +908,16 @@ function openSettings() {
 
 function closeSettings() {
     document.getElementById('settings-modal').classList.add('hidden');
+}
+
+function openInventoryFilter() {
+    document.getElementById('inventory-filter-modal').classList.remove('hidden');
+    const chk = document.getElementById('hide-rarity-toggle');
+    const sel = document.getElementById('hide-rarity-select');
+    if (chk) chk.checked = State.hideRarityEnabled;
+    if (sel) sel.value = State.hideBelowRarity;
+}
+
+function closeInventoryFilter() {
+    document.getElementById('inventory-filter-modal').classList.add('hidden');
 }

--- a/js/state.js
+++ b/js/state.js
@@ -117,6 +117,8 @@ const State = {
     autoProgress: true,
     darkMode: true,
     language: 'en',
+    hideRarityEnabled: false,
+    hideBelowRarity: 'rare',
 };
 
 for (let i = 0; i < State.slotCount; i++) {


### PR DESCRIPTION
## Summary
- add filter button in Inventory tab
- include modal to hide items below a chosen rarity
- store rarity filter state and apply during item retrieval
- document feature and update changelog

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_685f18f5a2888330af05e02d69f02488