### PR TITLE
Fix recover encounter logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.41.13] - 2025-06-28
+### Fixed
+- Recover encounter now automatically starts after retreats and is removed from the random pool.
+- Recover encounter restores energy using negative consumption values.
+
 ## [0.41.12] - 2025-06-27
 ### Changed
 - Money resource removed.

--- a/data/encounters.json
+++ b/data/encounters.json
@@ -8,7 +8,9 @@
     "baseDuration": 1,
     "minLevel": 0,
     "image": "assets/enc/recover.png",
-    "resourceConsumption": {},
+    "resourceConsumption": {
+      "energy": -1
+    },
     "items": {},
     "loot": {}
   },

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -162,6 +162,8 @@ const EncounterGenerator = {
 
         const pool = this.encounters.filter(e => {
             if ((e.minLevel || 0) > this.level) return false;
+            // Recover is only triggered after retreats and should not be random
+            if (e.id === 'recover') return false;
             return true;
         });
         if (!pool.length) return null;

--- a/tests/test_encounters.py
+++ b/tests/test_encounters.py
@@ -14,7 +14,7 @@ def test_encounter_fields():
         assert isinstance(enc['resourceConsumption'], dict)
         for val in enc['resourceConsumption'].values():
             assert isinstance(val, (int, float))
-            assert val > 0
+            assert val != 0
         assert 'items' in enc
         assert isinstance(enc['items'], dict)
         for prob in enc['items'].values():


### PR DESCRIPTION
## Summary
- exclude `recover` from random encounters
- add negative energy consumption for the recover encounter
- allow negative costs in tests
- document behaviour in changelog

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_685f8d29a4448330b21ad889a798fb71