### PR TITLE
Fix recover timing on retreat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.41.14] - 2025-06-28
+### Fixed
+- Recover encounter triggers instantly on retreat instead of after waiting for resources.
+
 ## [0.41.13] - 2025-06-28
 ### Fixed
 - Recover encounter now automatically starts after retreats and is removed from the random pool.

--- a/js/main.js
+++ b/js/main.js
@@ -273,6 +273,21 @@ const AdventureEngine = {
     waitResource: null,
     recovering: false,
     startSlot(i = 0) {
+        if (this.recovering) {
+            const rec = EncounterGenerator.getRecoverEncounter();
+            if (rec) {
+                const slot = State.adventureSlots[i];
+                slot.encounter = rec;
+                slot.duration = rec.getDuration();
+                slot.progress = 0;
+                slot.active = true;
+                this.activeIndex = i;
+                this.recovering = false;
+                updateAdventureSlotUI(i);
+                return;
+            }
+        }
+
         if (this.waitResource) {
             const res = State.resources[this.waitResource];
             if (res && res.value < ResourceSystem.max(res)) {
@@ -280,20 +295,6 @@ const AdventureEngine = {
                 return;
             }
             this.waitResource = null;
-            if (this.recovering) {
-                const rec = EncounterGenerator.getRecoverEncounter();
-                if (rec) {
-                    const slot = State.adventureSlots[i];
-                    slot.encounter = rec;
-                    slot.duration = rec.getDuration();
-                    slot.progress = 0;
-                    slot.active = true;
-                    this.activeIndex = i;
-                    this.recovering = false;
-                    updateAdventureSlotUI(i);
-                    return;
-                }
-            }
         }
         const encounter = EncounterGenerator.randomEncounter();
         const slot = State.adventureSlots[i];


### PR DESCRIPTION
## Summary
- trigger the Recover encounter immediately when a retreat occurs
- document the fix in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f92fdbb3c8330a1c7ee394ce7c6f8