### PR TITLE
Hide creativity stat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.41.15] - 2025-06-28
+### Changed
+- Creativity stat hidden from the UI pending future unlock.
+- Updated documentation to note the temporary removal.
+
 ## [0.41.14] - 2025-06-28
 ### Fixed
 - Recover encounter triggers instantly on retreat instead of after waiting for resources.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 
 | Module       | Description                                                                |
 | ------------ | -------------------------------------------------------------------------- |
-| Stats        | Tracks numeric values like Strength, Intelligence, Creativity via `StatSystem` |
+| Stats        | Tracks numeric values like Strength and Intelligence via `StatSystem` (additional stats unlock later) |
 | State        | Holds persistent game data and initialization helpers |
 | Tasks        | Defines repeatable actions, their costs, outputs, and execution logic      |
 | Time System  | Governs tick-based or interval-based progression                           |

--- a/index.html
+++ b/index.html
@@ -67,7 +67,6 @@
                     <ul>
                         <li>Strength: <span id="prestige-strength">0</span></li>
                         <li>Intelligence: <span id="prestige-intelligence">0</span></li>
-                        <li>Creativity: <span id="prestige-creativity">0</span></li>
                     </ul>
                 </section>
             </section>

--- a/js/ui.js
+++ b/js/ui.js
@@ -5,8 +5,9 @@
 const StatsUI = {
     list: [],
     init() {
-        // Exclude hidden stats such as charisma from the UI
-        this.list = STAT_KEYS.filter(k => k !== 'charisma');
+        // Exclude hidden stats such as charisma and creativity from the UI.
+        // Creativity will be unlocked in a later update.
+        this.list = STAT_KEYS.filter(k => k !== 'charisma' && k !== 'creativity');
         const listEl = document.getElementById('stats-list');
         this.list.forEach(key => {
             const li = document.createElement('li');


### PR DESCRIPTION
## Summary
- hide Creativity stat from UI and documentation
- remove prestige display for Creativity
- document the change

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_685fe553f5e88330b1e8f49faded9c9d