### PR TITLE
Update changelog date for image optimization docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.41.17] - 2025-06-28
+### Changed
+- Story images now load lazily to reduce initial load time.
+
+## [0.41.16] - 2025-06-28
+### Added
+- Documented planned lazy loading and automatic image compression.
+
 ## [0.41.15] - 2025-06-28
 ### Changed
 - Creativity stat hidden from the UI pending future unlock.

--- a/README.md
+++ b/README.md
@@ -123,6 +123,11 @@ resulting image in `assets/generated/` before updating the JSON entry.
 Run the scripts only after setting the `OPENAI_API_KEY` environment variable and
 ensure the `openai` Python package version 1.x is installed.
 
+Images used in story events are now loaded lazily in the UI to reduce initial
+page weight. Future updates will extend the scripts to automatically resize and
+compress generated images so existing assets do not require manual replacement.
+See `docs/image_optimization.md` for details.
+
 #### 12. Future Extensions
 
 * Prestige system with meta-upgrades

--- a/docs/image_optimization.md
+++ b/docs/image_optimization.md
@@ -1,0 +1,8 @@
+# Image Optimization Plan
+
+To keep load times reasonable as the game library of assets grows, the game now lazily loads story images and will implement further optimizations:
+
+- **Lazy loading**: story images use the `loading="lazy"` attribute so they only load when visible. Additional screens may adopt the same approach.
+- **Automatic resizing and compression**: the image pipeline scripts will be extended to resize large images and save optimized files. Libraries such as Pillow or ImageMagick can handle this step so existing images don't need manual replacement.
+
+These changes will be rolled out alongside other improvements to the asset pipeline.

--- a/js/main.js
+++ b/js/main.js
@@ -36,6 +36,7 @@ const Story = {
             const img = document.createElement('img');
             img.src = image;
             img.alt = '';
+            img.loading = 'lazy';
             imageEl.appendChild(img);
         }
         modal.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- document lazy loading in README and image optimization guide
- add lazy loading attribute to story images
- log the behavior change in the changelog

## Testing
- `pytest --cov -q`

------
https://chatgpt.com/codex/tasks/task_e_685ffbcbc0bc8330a5fcbf0216763956