### PR TITLE
Add prestige aging mechanics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.41.19] - 2025-06-28
+### Added
+- Prestige now triggers automatically at max age converting stats to prestige
+  points that enhance future growth.
+
+## [0.41.18] - 2025-06-28
+### Added
+- Prestige reset preserves action levels while clearing stats and resources.
+
 ## [0.41.17] - 2025-06-28
 ### Changed
 - Story images now load lazily to reduce initial load time.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 * New slots and actions unlock over time
 * Resources can be replenished or crafted
 * Optional prestige/reset layer for long-term scaling
+* Prestige triggers when age exceeds the max and converts current stats into
+  prestige points
+* Prestige points boost future stat gains and raise stat caps while preserving
+  action levels
 
 #### 4. Key Modules
 

--- a/index.html
+++ b/index.html
@@ -132,6 +132,7 @@
         <button id="save-btn" data-i18n="Save">Save</button>
         <button id="load-btn" data-i18n="Load">Load</button>
         <button id="settings-btn" data-i18n="Settings">Settings</button>
+        <button id="prestige-btn" data-i18n="Prestige">Prestige</button>
         <button id="reset-btn" data-i18n="Reset">Reset</button>
     </footer>
     <script src="js/logger.js"></script>

--- a/js/state.js
+++ b/js/state.js
@@ -103,6 +103,7 @@ const State = {
     stats: {},
     resources: {},
     prestige: {},
+    prestiging: false,
     // number of available action slots
     slotCount: 6,
     slots: [],

--- a/tests/test_prestige.py
+++ b/tests/test_prestige.py
@@ -1,0 +1,28 @@
+import os
+
+def test_prestige_button_exists():
+    with open('index.html') as f:
+        html = f.read()
+    assert 'id="prestige-btn"' in html
+
+
+def test_prestige_function_defined():
+    path = os.path.join('js', 'main.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'prestige()' in text
+
+
+def test_age_triggers_prestige():
+    path = os.path.join('js', 'main.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'State.age.max' in text
+    assert 'SaveSystem.prestige()' in text
+
+
+def test_prestige_bonus_applied():
+    path = os.path.join('js', 'main.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'applyPrestigeBonuses()' in text


### PR DESCRIPTION
## Summary
- trigger prestige reset when max age is reached
- convert stats into prestige points and apply bonuses
- boost stat gains and caps based on prestige
- document updated prestige system
- note automatic prestige in changelog

## Testing
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_686035d363ec8330922a1c197e51adc1