### PR TITLE
Implement prestige visibility and encounter level baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.41.20] - 2025-06-28
+### Changed
+- Prestige block now appears once any prestige points are earned.
+- Encounter generator starts at level 1.
+
 ## [0.41.19] - 2025-06-28
 ### Added
 - Prestige now triggers automatically at max age converting stats to prestige

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -50,7 +50,7 @@ class Encounter {
 const EncounterGenerator = {
     encounters: [],
     container: null,
-    level: 0,
+    level: 1,
     milestones: [],
     rarityWeights: {
         common: 1,
@@ -119,12 +119,12 @@ const EncounterGenerator = {
     },
 
     decrementLevel() {
-        if (this.level > 0) {
+        if (this.level > 1) {
             this.level -= 1;
-            State.encounterLevel = this.level;
-            this.updateName();
-            this.updateProgressBar();
         }
+        State.encounterLevel = this.level;
+        this.updateName();
+        this.updateProgressBar();
     },
 
     resetProgress() {
@@ -139,7 +139,7 @@ const EncounterGenerator = {
     init() {
         this.container = document.getElementById('adventure-slots');
         if (!this.container) return;
-        this.level = State.encounterLevel || 0;
+        this.level = State.encounterLevel || 1;
         this.updateName();
         this.updateProgressBar();
         this.populateSlots();

--- a/js/main.js
+++ b/js/main.js
@@ -205,7 +205,7 @@ const SaveSystem = {
                     State.slotCount = Array.isArray(State.slots) ? State.slots.length : 0;
                 }
                 if (State.encounterLevel === undefined) {
-                    State.encounterLevel = 0;
+                    State.encounterLevel = 1;
                 }
                 if (State.encounterStreak === undefined) {
                     State.encounterStreak = 0;
@@ -770,6 +770,7 @@ function updateUI() {
     StatsUI.update();
     ResourcesUI.update();
     MasteryUI.update();
+    PrestigeUI.update();
     document.getElementById('age-years').textContent = State.age.years;
     document.getElementById('age-days').textContent = Math.floor(State.age.days);
     document.getElementById('max-age').textContent = State.age.max;
@@ -835,6 +836,7 @@ async function init() {
     StatsUI.init();
     ResourcesUI.init();
     MasteryUI.init();
+    PrestigeUI.init();
     InventoryUI.init();
     UpdateSystem.init();
     if (typeof CharacterBackground !== 'undefined') {

--- a/js/state.js
+++ b/js/state.js
@@ -113,7 +113,7 @@ const State = {
     inventory: {},
     time: 1,
     masteryPoints: 0,
-    encounterLevel: 0,
+    encounterLevel: 1,
     encounterStreak: 0,
     autoProgress: true,
     darkMode: true,

--- a/js/ui.js
+++ b/js/ui.js
@@ -39,6 +39,26 @@ const StatsUI = {
     }
 };
 
+const PrestigeUI = {
+    list: [],
+    init() {
+        this.list = STAT_KEYS.filter(k => k !== 'charisma' && k !== 'creativity');
+        this.container = document.getElementById('prestige-block');
+        this.update();
+    },
+    update() {
+        if (!this.container) return;
+        let show = false;
+        this.list.forEach(key => {
+            const val = State.prestige[key] || 0;
+            const el = document.getElementById(`prestige-${key}`);
+            if (el) el.textContent = val;
+            if (val > 0) show = true;
+        });
+        this.container.style.display = show ? 'block' : 'none';
+    }
+};
+
 const ResourcesUI = {
     list: [],
     init() {

--- a/tests/test_prestige.py
+++ b/tests/test_prestige.py
@@ -26,3 +26,20 @@ def test_prestige_bonus_applied():
     with open(path) as f:
         text = f.read()
     assert 'applyPrestigeBonuses()' in text
+
+
+def test_prestige_ui_defined():
+    path = os.path.join('js', 'ui.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'PrestigeUI' in text
+    assert 'prestige-block' in text
+
+
+def test_encounter_level_default_one():
+    with open(os.path.join('js', 'state.js')) as f:
+        text = f.read()
+    assert 'encounterLevel: 1' in text
+    with open(os.path.join('js', 'main.js')) as f:
+        mtext = f.read()
+    assert 'State.encounterLevel = 1' in mtext


### PR DESCRIPTION
## Summary
- show prestige block after earning any points
- start encounter generator at level 1 and prevent dropping below it
- update tests for new UI object and default level
- update changelog

## Testing
- `python3 -m pytest -q`
- `python3 -m pytest --cov=./ -q`


------
https://chatgpt.com/codex/tasks/task_e_686049d903848330af84b1fb3b91f525