### PR TITLE
Fix: reset encounter level on prestige

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.41.21] - 2025-06-28
+### Changed
+- Encounter level now resets to 1 when prestiging
+- Action slots remain filled after prestige
+
 ## [0.41.20] - 2025-06-28
 ### Changed
 - Prestige block now appears once any prestige points are earned.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 * Prestige triggers when age exceeds the max and converts current stats into
   prestige points
 * Prestige points boost future stat gains and raise stat caps while preserving
-  action levels
+  action levels. Encounter progress resets to level 1 while your action slots
+  remain filled
 
 #### 4. Key Modules
 

--- a/js/main.js
+++ b/js/main.js
@@ -287,12 +287,8 @@ const SaveSystem = {
         State.adventureSlots = State.adventureSlots.map(() => ({
             text: '', progress: 0, duration: 1, encounter: null, active: false
         }));
-        State.slots.forEach(s => {
-            s.actionId = null;
-            s.progress = 0;
-            s.blocked = false;
-            s.text = '';
-        });
+        State.encounterLevel = 1;
+        State.encounterStreak = 0;
         Object.entries(preserved).forEach(([id, data]) => {
             if (actions[id]) Object.assign(actions[id], data);
         });

--- a/tests/test_prestige.py
+++ b/tests/test_prestige.py
@@ -43,3 +43,17 @@ def test_encounter_level_default_one():
     with open(os.path.join('js', 'main.js')) as f:
         mtext = f.read()
     assert 'State.encounterLevel = 1' in mtext
+
+
+def test_prestige_resets_encounter_level():
+    path = os.path.join('js', 'main.js')
+    with open(path) as f:
+        text = f.read()
+    assert text.count('State.encounterLevel = 1') >= 2
+
+
+def test_prestige_keeps_action_slots():
+    path = os.path.join('js', 'main.js')
+    with open(path) as f:
+        text = f.read()
+    assert 's.actionId = null' not in text


### PR DESCRIPTION
## Summary
- keep action slots populated after prestiging
- reset encounter level and streak when prestige occurs
- document new prestige behavior
- update changelog
- test prestige reset logic

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_686050ab5c7483308f4a27cb9b2e2471