### PR TITLE
Show prestige gain preview and rename resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.41.22] - 2025-06-28
+### Added
+- Potential prestige gain display with Constitution and Wisdom prestige
+  currencies replacing Strength and Intelligence
+
 ## [0.41.21] - 2025-06-28
 ### Changed
 - Encounter level now resets to 1 when prestiging

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 * Prestige points boost future stat gains and raise stat caps while preserving
   action levels. Encounter progress resets to level 1 while your action slots
   remain filled
+* Prestige currencies **Constitution** and **Wisdom** replace Strength and
+  Intelligence in the prestige layer. Potential prestige gains are displayed in
+  the UI before resetting
 
 #### 4. Key Modules
 

--- a/data/resources.json
+++ b/data/resources.json
@@ -10,8 +10,8 @@
         "health": {"value": 1, "baseMax": 10}
     },
     "prestige": {
-        "strength": 0,
-        "intelligence": 0,
+        "constitution": 0,
+        "wisdom": 0,
         "creativity": 0
     }
 }

--- a/index.html
+++ b/index.html
@@ -65,8 +65,8 @@
                 <section id="prestige-block">
                     <h3 data-i18n="Prestige">Prestige</h3>
                     <ul>
-                        <li>Strength: <span id="prestige-strength">0</span></li>
-                        <li>Intelligence: <span id="prestige-intelligence">0</span></li>
+                        <li>Constitution: <span id="prestige-constitution">0</span> <span id="prestige-constitution-gain" class="delta">(+0)</span></li>
+                        <li>Wisdom: <span id="prestige-wisdom">0</span> <span id="prestige-wisdom-gain" class="delta">(+0)</span></li>
                     </ul>
                 </section>
             </section>

--- a/js/main.js
+++ b/js/main.js
@@ -270,11 +270,12 @@ const SaveSystem = {
         const prestigeGain = {};
         STAT_KEYS.forEach(k => {
             const val = State.stats[k] ? State.stats[k].value : 0;
-            prestigeGain[k] = Math.floor(Math.log10(val + 1));
+            const pKey = PRESTIGE_MAP[k];
+            prestigeGain[pKey] = Math.floor(Math.log10(val + 1));
         });
 
         await loadBaseData();
-        STAT_KEYS.forEach(k => {
+        PRESTIGE_KEYS.forEach(k => {
             State.prestige[k] = (State.prestige[k] || 0) + (prestigeGain[k] || 0);
         });
 
@@ -314,7 +315,8 @@ const AgeSystem = {
 
 function applyPrestigeBonuses() {
     STAT_KEYS.forEach(k => {
-        const p = State.prestige[k] || 0;
+        const pKey = PRESTIGE_MAP[k];
+        const p = State.prestige[pKey] || 0;
         if (State.stats[k]) {
             State.stats[k].maxMultipliers.push(1 + p * 0.02);
         }

--- a/js/state.js
+++ b/js/state.js
@@ -92,6 +92,13 @@ function ensureStat(name, value, max) {
 
 let STAT_KEYS = [];
 let RESOURCE_KEYS = [];
+// Mapping from base stats to their prestige equivalents
+const PRESTIGE_MAP = {
+    strength: 'constitution',
+    intelligence: 'wisdom',
+    creativity: 'creativity'
+};
+const PRESTIGE_KEYS = Object.values(PRESTIGE_MAP);
 const RARITY_CLASSES = ['common', 'rare', 'epic', 'legendary', 'story'];
 
 const State = {
@@ -162,6 +169,8 @@ if (typeof module !== 'undefined') {
         loadBaseData,
         STAT_KEYS,
         RESOURCE_KEYS,
+        PRESTIGE_MAP,
+        PRESTIGE_KEYS,
     };
 }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -42,7 +42,7 @@ const StatsUI = {
 const PrestigeUI = {
     list: [],
     init() {
-        this.list = STAT_KEYS.filter(k => k !== 'charisma' && k !== 'creativity');
+        this.list = PRESTIGE_KEYS.filter(k => k !== 'creativity');
         this.container = document.getElementById('prestige-block');
         this.update();
     },
@@ -51,8 +51,12 @@ const PrestigeUI = {
         let show = false;
         this.list.forEach(key => {
             const val = State.prestige[key] || 0;
+            const stat = Object.keys(PRESTIGE_MAP).find(k => PRESTIGE_MAP[k] === key);
+            const gain = stat ? Math.floor(Math.log10(State.stats[stat].value + 1)) : 0;
             const el = document.getElementById(`prestige-${key}`);
+            const gainEl = document.getElementById(`prestige-${key}-gain`);
             if (el) el.textContent = val;
+            if (gainEl) gainEl.textContent = `(+${gain})`;
             if (val > 0) show = true;
         });
         this.container.style.display = show ? 'block' : 'none';


### PR DESCRIPTION
## Summary
- rename prestige resources to Constitution and Wisdom
- display potential prestige gain based on current stats
- document the new prestige resource names

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68606bcb1b14833092a8398a93305032