### PR TITLE
Fix prestige persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.41.24] - 2025-06-29
+### Fixed
+- Prestige resources and upgrades now persist correctly between prestiges.
+
+## [0.41.23] - 2025-06-29
+### Added
+- Prestige upgrade system with scaling costs and bonuses
+
 ## [0.41.22] - 2025-06-28
 ### Added
 - Potential prestige gain display with Constitution and Wisdom prestige

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 * Prestige currencies **Constitution** and **Wisdom** replace Strength and
   Intelligence in the prestige layer. Potential prestige gains are displayed in
   the UI before resetting
+* Prestige points can now be spent to upgrade their bonuses. The first level
+  costs 50 points and each subsequent level costs double plus an additional
+  5% per existing level.
+* Prestige points and purchased upgrades persist through multiple prestiges.
 
 #### 4. Key Modules
 

--- a/index.html
+++ b/index.html
@@ -65,8 +65,8 @@
                 <section id="prestige-block">
                     <h3 data-i18n="Prestige">Prestige</h3>
                     <ul>
-                        <li>Constitution: <span id="prestige-constitution">0</span> <span id="prestige-constitution-gain" class="delta">(+0)</span></li>
-                        <li>Wisdom: <span id="prestige-wisdom">0</span> <span id="prestige-wisdom-gain" class="delta">(+0)</span></li>
+                        <li>Constitution: <span id="prestige-constitution">0</span> <span id="prestige-constitution-gain" class="delta">(+0)</span> <button class="prestige-up" data-type="constitution">+</button> <span id="prestige-constitution-cost">50</span></li>
+                        <li>Wisdom: <span id="prestige-wisdom">0</span> <span id="prestige-wisdom-gain" class="delta">(+0)</span> <button class="prestige-up" data-type="wisdom">+</button> <span id="prestige-wisdom-cost">50</span></li>
                     </ul>
                 </section>
             </section>

--- a/js/state.js
+++ b/js/state.js
@@ -110,6 +110,7 @@ const State = {
     stats: {},
     resources: {},
     prestige: {},
+    prestigeUpgrades: {},
     prestiging: false,
     // number of available action slots
     slotCount: 6,
@@ -152,6 +153,10 @@ async function loadBaseData() {
             State.resources[k] = ResourceSystem.create(def.value, def.baseMax);
         });
         State.prestige = { ...json.prestige };
+        State.prestigeUpgrades = {};
+        PRESTIGE_KEYS.forEach(k => {
+            State.prestigeUpgrades[k] = 0;
+        });
         if (typeof BonusEngine !== 'undefined' && BonusEngine.initialize) {
             BonusEngine.initialize(STAT_KEYS, RESOURCE_KEYS);
         }
@@ -171,6 +176,7 @@ if (typeof module !== 'undefined') {
         RESOURCE_KEYS,
         PRESTIGE_MAP,
         PRESTIGE_KEYS,
+        prestigeUpgrades: State.prestigeUpgrades,
     };
 }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -51,12 +51,15 @@ const PrestigeUI = {
         let show = false;
         this.list.forEach(key => {
             const val = State.prestige[key] || 0;
+            const lvl = State.prestigeUpgrades[key] || 0;
             const stat = Object.keys(PRESTIGE_MAP).find(k => PRESTIGE_MAP[k] === key);
             const gain = stat ? Math.floor(Math.log10(State.stats[stat].value + 1)) : 0;
             const el = document.getElementById(`prestige-${key}`);
             const gainEl = document.getElementById(`prestige-${key}-gain`);
+            const costEl = document.getElementById(`prestige-${key}-cost`);
             if (el) el.textContent = val;
             if (gainEl) gainEl.textContent = `(+${gain})`;
+            if (costEl) costEl.textContent = PrestigeSystem.getCost(key);
             if (val > 0) show = true;
         });
         this.container.style.display = show ? 'block' : 'none';

--- a/tests/test_prestige.py
+++ b/tests/test_prestige.py
@@ -57,3 +57,26 @@ def test_prestige_keeps_action_slots():
     with open(path) as f:
         text = f.read()
     assert 's.actionId = null' not in text
+
+
+def test_prestige_upgrade_buttons():
+    with open('index.html') as f:
+        html = f.read()
+    assert 'prestige-constitution-cost' in html
+    assert 'class="prestige-up"' in html
+
+
+def test_prestige_system_defined():
+    path = os.path.join('js', 'main.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'PrestigeSystem' in text
+    assert 'upgrade(key)' in text
+
+
+def test_prestige_preserves_points():
+    path = os.path.join('js', 'main.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'prevPrestige' in text
+    assert 'prevUpgrades' in text


### PR DESCRIPTION
## Summary
- ensure prestige points and upgrades persist when prestiging
- note persistence in README and changelog
- test for presence of new logic

## Testing
- `pytest -q`
- `pytest --cov=./ -q`


------
https://chatgpt.com/codex/tasks/task_e_686071f3974083309956f274c93681da