### PR TITLE
Remove prestige upgrade UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.41.25] - 2025-06-29
+### Removed
+- Plus buttons and prestige cost labels from the UI.
+
 ## [0.41.24] - 2025-06-29
 ### Fixed
 - Prestige resources and upgrades now persist correctly between prestiges.

--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 * Prestige currencies **Constitution** and **Wisdom** replace Strength and
   Intelligence in the prestige layer. Potential prestige gains are displayed in
   the UI before resetting
-* Prestige points can now be spent to upgrade their bonuses. The first level
-  costs 50 points and each subsequent level costs double plus an additional
-  5% per existing level.
-* Prestige points and purchased upgrades persist through multiple prestiges.
 
 #### 4. Key Modules
 

--- a/index.html
+++ b/index.html
@@ -65,8 +65,8 @@
                 <section id="prestige-block">
                     <h3 data-i18n="Prestige">Prestige</h3>
                     <ul>
-                        <li>Constitution: <span id="prestige-constitution">0</span> <span id="prestige-constitution-gain" class="delta">(+0)</span> <button class="prestige-up" data-type="constitution">+</button> <span id="prestige-constitution-cost">50</span></li>
-                        <li>Wisdom: <span id="prestige-wisdom">0</span> <span id="prestige-wisdom-gain" class="delta">(+0)</span> <button class="prestige-up" data-type="wisdom">+</button> <span id="prestige-wisdom-cost">50</span></li>
+                        <li>Constitution: <span id="prestige-constitution">0</span> <span id="prestige-constitution-gain" class="delta">(+0)</span></li>
+                        <li>Wisdom: <span id="prestige-wisdom">0</span> <span id="prestige-wisdom-gain" class="delta">(+0)</span></li>
                     </ul>
                 </section>
             </section>

--- a/js/main.js
+++ b/js/main.js
@@ -227,12 +227,6 @@ const SaveSystem = {
                 if (State.banditsAmbushSeen === undefined) {
                     State.banditsAmbushSeen = false;
                 }
-                if (!State.prestigeUpgrades) {
-                    State.prestigeUpgrades = {};
-                    PRESTIGE_KEYS.forEach(k => {
-                        State.prestigeUpgrades[k] = 0;
-                    });
-                }
                 if (State.autoProgress === undefined) {
                     State.autoProgress = true;
                 }
@@ -273,9 +267,6 @@ const SaveSystem = {
             };
         });
 
-        const prevPrestige = { ...State.prestige };
-        const prevUpgrades = { ...State.prestigeUpgrades };
-
         const prestigeGain = {};
         STAT_KEYS.forEach(k => {
             const val = State.stats[k] ? State.stats[k].value : 0;
@@ -285,9 +276,7 @@ const SaveSystem = {
 
         await loadBaseData();
         PRESTIGE_KEYS.forEach(k => {
-            const gained = prestigeGain[k] || 0;
-            State.prestige[k] = (prevPrestige[k] || 0) + gained;
-            State.prestigeUpgrades[k] = prevUpgrades[k] || 0;
+            State.prestige[k] = (State.prestige[k] || 0) + (prestigeGain[k] || 0);
         });
 
         applyPrestigeBonuses();
@@ -324,43 +313,15 @@ const AgeSystem = {
     }
 };
 
-const PrestigeSystem = {
-    baseCost: 50,
-    getCost(key) {
-        const level = State.prestigeUpgrades[key] || 0;
-        let cost = this.baseCost;
-        for (let i = 1; i <= level; i++) {
-            cost *= 2 + i * 0.05;
-        }
-        return Math.ceil(cost);
-    },
-    upgrade(key) {
-        const cost = this.getCost(key);
-        if ((State.prestige[key] || 0) >= cost) {
-            State.prestige[key] -= cost;
-            State.prestigeUpgrades[key] = (State.prestigeUpgrades[key] || 0) + 1;
-            applyPrestigeBonuses();
-            SaveSystem.save();
-            return true;
-        }
-        return false;
-    }
-};
-
-function prestigeBonus(base, level) {
-    if (level <= 0) return 0;
-    return base * (level + 0.05 * level * (level - 1) / 2);
-}
-
 function applyPrestigeBonuses() {
     STAT_KEYS.forEach(k => {
         const pKey = PRESTIGE_MAP[k];
-        const lvl = State.prestigeUpgrades[pKey] || 0;
+        const p = State.prestige[pKey] || 0;
         if (State.stats[k]) {
-            State.stats[k].maxMultipliers = [1 + prestigeBonus(0.02, lvl)];
+            State.stats[k].maxMultipliers.push(1 + p * 0.02);
         }
         if (typeof BonusEngine !== 'undefined') {
-            BonusEngine.statMultipliers[k] = 1 + prestigeBonus(0.05, lvl);
+            BonusEngine.statMultipliers[k] = (BonusEngine.statMultipliers[k] || 1) * (1 + p * 0.05);
         }
     });
 }
@@ -971,14 +932,6 @@ async function init() {
     if (prestigeBtn) {
         prestigeBtn.addEventListener('click', () => SaveSystem.prestige());
     }
-    document.querySelectorAll('.prestige-up').forEach(btn => {
-        btn.addEventListener('click', () => {
-            const type = btn.dataset.type;
-            PrestigeSystem.upgrade(type);
-            PrestigeUI.update();
-            updateUI();
-        });
-    });
     applyDarkMode();
     updateUI();
     // Game logic ticked separately from UI updates so resource generation

--- a/js/state.js
+++ b/js/state.js
@@ -110,7 +110,6 @@ const State = {
     stats: {},
     resources: {},
     prestige: {},
-    prestigeUpgrades: {},
     prestiging: false,
     // number of available action slots
     slotCount: 6,
@@ -153,10 +152,6 @@ async function loadBaseData() {
             State.resources[k] = ResourceSystem.create(def.value, def.baseMax);
         });
         State.prestige = { ...json.prestige };
-        State.prestigeUpgrades = {};
-        PRESTIGE_KEYS.forEach(k => {
-            State.prestigeUpgrades[k] = 0;
-        });
         if (typeof BonusEngine !== 'undefined' && BonusEngine.initialize) {
             BonusEngine.initialize(STAT_KEYS, RESOURCE_KEYS);
         }
@@ -176,7 +171,6 @@ if (typeof module !== 'undefined') {
         RESOURCE_KEYS,
         PRESTIGE_MAP,
         PRESTIGE_KEYS,
-        prestigeUpgrades: State.prestigeUpgrades,
     };
 }
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -51,15 +51,12 @@ const PrestigeUI = {
         let show = false;
         this.list.forEach(key => {
             const val = State.prestige[key] || 0;
-            const lvl = State.prestigeUpgrades[key] || 0;
             const stat = Object.keys(PRESTIGE_MAP).find(k => PRESTIGE_MAP[k] === key);
             const gain = stat ? Math.floor(Math.log10(State.stats[stat].value + 1)) : 0;
             const el = document.getElementById(`prestige-${key}`);
             const gainEl = document.getElementById(`prestige-${key}-gain`);
-            const costEl = document.getElementById(`prestige-${key}-cost`);
             if (el) el.textContent = val;
             if (gainEl) gainEl.textContent = `(+${gain})`;
-            if (costEl) costEl.textContent = PrestigeSystem.getCost(key);
             if (val > 0) show = true;
         });
         this.container.style.display = show ? 'block' : 'none';

--- a/tests/test_prestige.py
+++ b/tests/test_prestige.py
@@ -59,24 +59,3 @@ def test_prestige_keeps_action_slots():
     assert 's.actionId = null' not in text
 
 
-def test_prestige_upgrade_buttons():
-    with open('index.html') as f:
-        html = f.read()
-    assert 'prestige-constitution-cost' in html
-    assert 'class="prestige-up"' in html
-
-
-def test_prestige_system_defined():
-    path = os.path.join('js', 'main.js')
-    with open(path) as f:
-        text = f.read()
-    assert 'PrestigeSystem' in text
-    assert 'upgrade(key)' in text
-
-
-def test_prestige_preserves_points():
-    path = os.path.join('js', 'main.js')
-    with open(path) as f:
-        text = f.read()
-    assert 'prevPrestige' in text
-    assert 'prevUpgrades' in text


### PR DESCRIPTION
## Summary
- remove prestige cost UI and upgrade buttons
- drop PrestigeSystem logic and state
- delete related tests
- update documentation and changelog

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_686086ccb11c8330979f12687aea4629