### PR TITLE
Fix prestige reset issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.41.26] - 2025-06-29
+### Fixed
+- Automatic prestige now triggers when reaching maximum age.
+- Prestige resource totals increment correctly after each reset.
+
 ## [0.41.25] - 2025-06-29
 ### Removed
 - Plus buttons and prestige cost labels from the UI.

--- a/js/main.js
+++ b/js/main.js
@@ -274,9 +274,10 @@ const SaveSystem = {
             prestigeGain[pKey] = Math.floor(Math.log10(val + 1));
         });
 
+        const previousPrestige = { ...State.prestige };
         await loadBaseData();
         PRESTIGE_KEYS.forEach(k => {
-            State.prestige[k] = (State.prestige[k] || 0) + (prestigeGain[k] || 0);
+            State.prestige[k] = (previousPrestige[k] || 0) + (prestigeGain[k] || 0);
         });
 
         applyPrestigeBonuses();
@@ -293,6 +294,7 @@ const SaveSystem = {
         Object.entries(preserved).forEach(([id, data]) => {
             if (actions[id]) Object.assign(actions[id], data);
         });
+        State.prestiging = false;
         SaveSystem.save();
         window.location.reload();
     }


### PR DESCRIPTION
## Summary
- ensure prestige resources accumulate by preserving existing totals before reset
- reset `State.prestiging` flag so automatic prestige triggers again
- document fix in changelog

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68614a7b4e8883309c07e1b54d9ebe9f