### PR TITLE
Fix #140: prestige cap display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.41.27] - 2025-06-29
+### Fixed
+- Prestige stat caps now account for bonuses and display the correct values in the UI.
+
 ## [0.41.26] - 2025-06-29
 ### Fixed
 - Automatic prestige now triggers when reaching maximum age.

--- a/js/main.js
+++ b/js/main.js
@@ -82,6 +82,9 @@ const SoftCapSystem = {
         for (const s in this.statCaps) {
             if (State.stats[s]) {
                 State.stats[s].baseMax = this.statCaps[s];
+                // statCaps should reflect prestige multipliers for UI and
+                // softcap calculations
+                this.statCaps[s] = StatSystem.max(State.stats[s]);
             }
         }
     },


### PR DESCRIPTION
## Summary
- ensure SoftCapSystem calculates final stat caps using prestige multipliers
- show increased caps in the UI
- document the fix in `CHANGELOG.md`

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68615701d5788330ad30c067367b3801