### PR TITLE
Add Home section under Belongings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.41.28] - 2025-06-29
+### Added
+- Renamed Inventory tab to Belongings and added a Home section inside it.
+
 ## [0.41.27] - 2025-06-29
 ### Fixed
 - Prestige stat caps now account for bonuses and display the correct values in the UI.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 | Task Slots   | Limited number of concurrent tasks; unlockable and upgradable              |
 | Resources    | Consumables needed to perform actions; managed separately by `ResourceSystem` |
 | Magic System | Simplified crafting and consumption system for magical items               |
-| Inventory    | Manages player's resource quantities and magical components                |
+| Belongings   | Manages player's resource quantities and magical components                |
 | Chips        | One-time unlockables that grant bonuses or new content |
 | Automation   | Enables actions to loop with or without conditions |
 | Bonus Engine | Centralizes additive, multiplicative, and exponential bonuses for stats and resources, including cost divisors |
@@ -113,7 +113,7 @@ The page uses a simple header/main/footer structure. Stats and resources are kep
 
 Resources appear as horizontal bars whose colors match each type (red for health, yellow for energy, blue for focus).
 
-A story modal appears once on the first load and another short scene triggers after thirty days pass in game time. Both modals only appear during the first life and all log messages are recorded in a scrollable container (about 300&nbsp;px high) in the right panel. Habits are quick actions found below the routines for instant resource gains. Routines themselves are triggered by clicking their progress bars; hovering shows the cost and effect. The adventure tab now displays a second progress bar beneath the location name showing how many encounters remain before the next level. The inventory tab includes a filter button to hide items below a chosen rarity.
+ A story modal appears once on the first load and another short scene triggers after thirty days pass in game time. Both modals only appear during the first life and all log messages are recorded in a scrollable container (about 300&nbsp;px high) in the right panel. Habits are quick actions found below the routines for instant resource gains. Routines themselves are triggered by clicking their progress bars; hovering shows the cost and effect. The adventure tab now displays a second progress bar beneath the location name showing how many encounters remain before the next level. The Belongings tab includes a filter button to hide items below a chosen rarity. A new Home section now appears inside the Belongings tab above the item list.
 
 See **docs/MVP.md** for the MVP list.
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -366,6 +366,21 @@ body.left-collapsed #left {
     display: none;
 }
 
+.tab-section.hidden {
+    display: none;
+}
+
+.section-headers {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.section-headers button.active {
+    background: #333;
+    color: #fff;
+}
+
 .delta {
     color: #666;
     font-size: 0.8rem;

--- a/data/lang/uk.json
+++ b/data/lang/uk.json
@@ -6,6 +6,8 @@
     "Available Actions": "Доступні дії",
     "Action Slots": "Слоти дій",
     "Adventure": "Пригода",
+    "Home": "Дім",
+    "Belongings": "Речі",
     "Inventory": "Інвентар",
     "Routines": "Рутини",
     "Automation": "Автоматизація",

--- a/docs/MVP.md
+++ b/docs/MVP.md
@@ -10,5 +10,6 @@ Use this list to verify the first playable prototype of **Progress Realm**:
 - [x] Leveled actions with experience and tiers
 - [x] Multiple action slots with drag-and-drop
 - [x] Introductory story modal and log panel
-- [x] Inventory tab with basic item generator
+ - [x] Belongings tab with basic item generator
+ - [x] Home section inside the Belongings tab
 - [x] Character background art updates when equipped with starter gear

--- a/index.html
+++ b/index.html
@@ -102,9 +102,16 @@
                         <div id="adventure-slots" class="slots"></div>
                     </div>
                     <div class="tab-content hidden" data-tab="inventory">
-                        <h2 data-i18n="Inventory">Inventory</h2>
-                        <button id="inventory-filter-btn">Hide Items</button>
-                        <div id="inventory-slots" class="slots"></div>
+                        <div class="section-headers" data-parent="inventory"></div>
+                        <div class="tab-section" data-section="home">
+                            <h2 data-i18n="Home">Home</h2>
+                            <p>Welcome home.</p>
+                        </div>
+                        <div class="tab-section" data-section="belongings">
+                            <h2 data-i18n="Belongings">Belongings</h2>
+                            <button id="inventory-filter-btn">Hide Items</button>
+                            <div id="inventory-slots" class="slots"></div>
+                        </div>
                     </div>
                     <div class="tab-content hidden" data-tab="automation">
                         <h2 data-i18n="Control">Control</h2>

--- a/js/main.js
+++ b/js/main.js
@@ -110,11 +110,21 @@ const TabManager = {
     tabs: [
         { id: 'routines', name: 'Routines', hidden: false, locked: false },
         { id: 'adventure', name: 'Adventure', hidden: true, locked: false },
-        { id: 'inventory', name: 'Inventory', hidden: false, locked: false },
+        {
+            id: 'inventory',
+            name: 'Belongings',
+            hidden: false,
+            locked: false,
+            sections: [
+                { id: 'home', name: 'Home' },
+                { id: 'belongings', name: 'Belongings' }
+            ]
+        },
         { id: 'automation', name: 'Automation', hidden: true, locked: false },
         { id: 'chip', name: 'Chip', hidden: false, locked: false },
     ],
     buttons: {},
+    activeSections: {},
     init() {
         this.header = document.getElementById('tab-headers');
         if (State.healerGoneSeen) {
@@ -140,6 +150,7 @@ const TabManager = {
         if (tab.locked) btn.disabled = true;
         this.header.appendChild(btn);
         this._updateButton(tab);
+        this._initSections(tab);
     },
     _updateButton(tab) {
         const btn = this.buttons[tab.id];
@@ -157,12 +168,50 @@ const TabManager = {
         tab.hidden = false;
         this._createButton(tab);
     },
+    _initSections(tab) {
+        if (!tab.sections) return;
+        const content = document.querySelector(`.tab-content[data-tab="${tab.id}"]`);
+        if (!content) return;
+        const header = content.querySelector('.section-headers');
+        if (!header) return;
+        header.innerHTML = '';
+        tab.sections.forEach(sec => {
+            const btn = document.createElement('button');
+            btn.dataset.tab = tab.id;
+            btn.dataset.section = sec.id;
+            btn.dataset.i18n = sec.name;
+            header.appendChild(btn);
+        });
+        header.addEventListener('click', e => {
+            if (!e.target.dataset.section) return;
+            this.showSection(tab.id, e.target.dataset.section);
+        });
+        this.showSection(tab.id, tab.sections[0].id);
+    },
     showTab(id) {
         document.querySelectorAll('.tab-content').forEach(el => {
             el.classList.toggle('hidden', el.dataset.tab !== id);
         });
         document.querySelectorAll('#tab-headers button').forEach(btn => {
             btn.classList.toggle('active', btn.dataset.tab === id);
+        });
+        const tab = this.tabs.find(t => t.id === id);
+        if (tab && tab.sections) {
+            const current = this.activeSections[id] || tab.sections[0].id;
+            this.showSection(id, current);
+        }
+    }
+    ,showSection(tabId, sectionId) {
+        this.activeSections[tabId] = sectionId;
+        const content = document.querySelector(`.tab-content[data-tab="${tabId}"]`);
+        if (!content) return;
+        content.querySelectorAll('.tab-section').forEach(sec => {
+            sec.classList.toggle('hidden', sec.dataset.section !== sectionId);
+        });
+        const header = content.querySelector('.section-headers');
+        if (!header) return;
+        header.querySelectorAll('button').forEach(btn => {
+            btn.classList.toggle('active', btn.dataset.section === sectionId);
         });
     }
 };


### PR DESCRIPTION
## Summary
- restructure inventory tab to include a Home section
- extend TabManager with section management
- update styles for section headers
- document new layout and update changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68616fe925a48330a7ee957716500cc8