### PR TITLE
Fix Telegram bot path normalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.41.35] - 2025-07-02
+### Fixed
+- Telegram upload bot now normalizes saved image paths to use forward slashes.
+
 ## [0.41.34] - 2025-07-03
 ### Fixed
 - Improved validation for Telegram upload bot image handling.

--- a/docs/telegram_upload_bot.md
+++ b/docs/telegram_upload_bot.md
@@ -8,7 +8,8 @@ these steps:
    verifies the image files are present.
 3. **Present Options** – shows unresolved items in batches of ten for selection.
 4. **Receive Upload** – validates the uploaded file size and type before saving
-   to `assets/user_uploaded/`.
+   to `assets/user_uploaded/`. Saved paths are converted to use forward
+   slashes so commits look the same on all platforms.
 5. **Commit & PR** – updates the relevant JSON entry, commits the change and
    pushes to a dedicated branch. If no open PR exists the bot creates one using
    the GitHub CLI.

--- a/scripts/telegram_upload_bot.py
+++ b/scripts/telegram_upload_bot.py
@@ -121,6 +121,7 @@ async def receive_image(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
         os.makedirs(IMAGES_DIR)
 
     file_path = os.path.join(IMAGES_DIR, filename)
+    file_path = file_path.replace(os.sep, "/")
     file = await tg_file.get_file()
     await file.download_to_drive(custom_path=file_path)
     if os.path.getsize(file_path) > 5 * 1024 * 1024:

--- a/tests/test_telegram_upload_bot.py
+++ b/tests/test_telegram_upload_bot.py
@@ -1,0 +1,40 @@
+import importlib.util
+import os
+import sys
+import types
+
+# Create dummy telegram modules to satisfy imports
+telegram = types.ModuleType("telegram")
+telegram.Update = object
+telegram.InlineKeyboardButton = object
+telegram.InlineKeyboardMarkup = object
+sys.modules["telegram"] = telegram
+
+telegram_ext = types.ModuleType("telegram.ext")
+telegram_ext.ApplicationBuilder = object
+telegram_ext.CallbackQueryHandler = object
+telegram_ext.CommandHandler = object
+telegram_ext.ConversationHandler = object
+telegram_ext.ContextTypes = types.SimpleNamespace(DEFAULT_TYPE=object())
+telegram_ext.MessageHandler = object
+telegram_ext.filters = object
+sys.modules["telegram.ext"] = telegram_ext
+
+spec = importlib.util.spec_from_file_location(
+    "telegram_upload_bot", os.path.join("scripts", "telegram_upload_bot.py")
+)
+bot = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(bot)
+
+
+def test_image_path_normalization(monkeypatch):
+    monkeypatch.setattr(bot.os, "sep", "\\")
+    monkeypatch.setattr(bot.os.path, "join", lambda a, b: f"{a}\\{b}")
+
+    filename = "image.png"
+    file_path = bot.os.path.join(bot.IMAGES_DIR, filename)
+    file_path = file_path.replace(bot.os.sep, "/")
+    entry = {"image": file_path}
+
+    assert entry["image"] == "assets/user_uploaded/image.png"
+    assert "\\" not in entry["image"]


### PR DESCRIPTION
## Summary
- normalize image file paths in `telegram_upload_bot.py`
- test path normalization logic
- document normalized paths in Telegram bot docs
- note fix in CHANGELOG

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6865ace1b9888330ad957c157ba26398