### PR TITLE
Add sanitized file naming for uploaded images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.41.37] - 2025-07-03
+### Changed
+- Uploaded images via Telegram bot are renamed using the entry ID for consistent filenames.
+
 ## [0.41.36] - 2025-07-03
 ### Changed
 - Telegram bot skips pull request creation when the `gh` CLI is unavailable.

--- a/docs/telegram_upload_bot.md
+++ b/docs/telegram_upload_bot.md
@@ -10,7 +10,8 @@ these steps:
 4. **Receive Upload** – validates the uploaded file size and type before saving
    to `assets/user_uploaded/`.
    The saved path is normalized to use forward slashes so JSON entries remain
-   consistent across platforms.
+   consistent across platforms. Uploaded files are renamed using the entry ID so
+   new assets follow a readable, consistent naming scheme.
 5. **Commit & PR** – updates the relevant JSON entry, commits the change and
    pushes to a dedicated branch. If no open PR exists the bot creates one using
    the GitHub CLI. If the `gh` command isn't available the bot logs a message

--- a/scripts/telegram_upload_bot.py
+++ b/scripts/telegram_upload_bot.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import shutil
 import logging
+import re
 from typing import List, Tuple
 
 logging.basicConfig(level=logging.INFO)
@@ -29,6 +30,13 @@ IMAGES_DIR = os.path.join('assets', 'user_uploaded')
 BRANCH_NAME = 'bot/assets-upload'
 
 SELECT_ITEM, RECEIVE_IMAGE = range(2)
+
+
+def sanitize_filename(entry_id: str, original_name: str) -> str:
+    """Return a lowercase filename based on the entry id."""
+    name = re.sub(r"[^a-z0-9]+", "_", entry_id.lower()).strip("_")
+    ext = os.path.splitext(original_name)[1].lower() or ".png"
+    return f"{name}{ext}"
 
 
 def git_pull() -> Tuple[bool, str]:
@@ -124,6 +132,8 @@ async def receive_image(update: Update, context: ContextTypes.DEFAULT_TYPE) -> i
     if not os.path.isdir(IMAGES_DIR):
         os.makedirs(IMAGES_DIR)
 
+    data_file, entry_id, entry_name = context.user_data.get('selected')
+    filename = sanitize_filename(entry_id or entry_name, filename)
     file_path = os.path.join(IMAGES_DIR, filename)
     file_path = file_path.replace(os.sep, "/")
     file = await tg_file.get_file()

--- a/tests/test_upload_bot_path.py
+++ b/tests/test_upload_bot_path.py
@@ -1,4 +1,7 @@
 import os
+import importlib.util
+import types
+import sys
 
 IMAGES_DIR = os.path.join('assets', 'user_uploaded')
 
@@ -9,4 +12,36 @@ def test_uploaded_image_path_uses_forward_slashes():
     file_path = file_path.replace(os.sep, "/")
     assert "/" in file_path
     assert "\\" not in file_path
+
+
+def load_bot():
+    spec = importlib.util.spec_from_file_location(
+        "telegram_upload_bot",
+        os.path.join("scripts", "telegram_upload_bot.py"),
+    )
+    telegram = types.ModuleType("telegram")
+    telegram.Update = object
+    telegram.InlineKeyboardButton = object
+    telegram.InlineKeyboardMarkup = object
+    telegram.ext = types.ModuleType("telegram.ext")
+    for name in [
+        "ApplicationBuilder",
+        "CallbackQueryHandler",
+        "CommandHandler",
+        "ConversationHandler",
+        "MessageHandler",
+    ]:
+        setattr(telegram.ext, name, object())
+    telegram.ext.ContextTypes = types.SimpleNamespace(DEFAULT_TYPE=object())
+    telegram.ext.filters = types.SimpleNamespace(ALL=object())
+    sys.modules["telegram"] = telegram
+    sys.modules["telegram.ext"] = telegram.ext
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_sanitized_filename():
+    module = load_bot()
+    assert module.sanitize_filename("Stone Spear", "img.JPG") == "stone_spear.jpg"
 


### PR DESCRIPTION
## Summary
- name uploaded files with entry IDs using a new helper
- document renaming in upload bot instructions
- test filename sanitization

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866d6ecd7a88330bff2eecaf01ddb70