### PR TITLE
Fix #123: stop prestige cap inflation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.41.38] - 2025-07-05
+### Fixed
+- Resource cap multipliers no longer stack each reload.
+
+
+
 ## [0.41.37] - 2025-07-03
 ### Changed
 - Uploaded images via Telegram bot are renamed using the entry ID for consistent filenames.

--- a/js/main.js
+++ b/js/main.js
@@ -376,10 +376,10 @@ function applyPrestigeBonuses() {
         const pKey = PRESTIGE_MAP[k];
         const p = State.prestige[pKey] || 0;
         if (State.stats[k]) {
-            State.stats[k].maxMultipliers.push(1 + p * 0.02);
+            State.stats[k].maxMultipliers = [1 + p * 0.02];
         }
         if (typeof BonusEngine !== 'undefined') {
-            BonusEngine.statMultipliers[k] = (BonusEngine.statMultipliers[k] || 1) * (1 + p * 0.05);
+            BonusEngine.statMultipliers[k] = 1 + p * 0.05;
         }
     });
 }


### PR DESCRIPTION
## Summary
- prevent prestige bonus multipliers from stacking on each load
- document fix in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869192a6a34833088210ba742189ced