### PR TITLE
Fix translation fallback for UI sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.41.39] - 2025-07-05
+### Fixed
+- English UI now defaults to the base text when no translation exists.
+
 ## [0.41.38] - 2025-07-05
 ### Fixed
 - Resource cap multipliers no longer stack each reload.

--- a/js/lang.js
+++ b/js/lang.js
@@ -40,8 +40,8 @@ const Lang = {
     },
     translateUI() {
         document.querySelectorAll('[data-i18n]').forEach(el => {
-            const text = this.ui(el.dataset.i18n);
-            if (!text) return;
+            let text = this.ui(el.dataset.i18n);
+            if (!text) text = el.dataset.i18n;
             if (el.childNodes.length > 1 && el.childNodes[0].nodeType === Node.TEXT_NODE) {
                 el.childNodes[0].textContent = text;
             } else {


### PR DESCRIPTION
## Summary
- default UI translation uses English when a localization is missing
- document fallback behaviour in changelog

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_6869662ca56883309e332d2df84a4ffc