### PR TITLE
Implement StorySystem and data-driven modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [0.41.43] - 2025-07-06
+### Added
+- Story events load from `data/story_events.json` via new `StorySystem`.
+- Chip upgrades can unlock tabs and trigger story events.
+
 
 ## [0.41.42] - 2025-07-06
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,18 @@
 # Changelog
+## [0.41.47] - 2025-07-07
+### Added
+- Story events are now included when the Telegram upload bot scans for missing images.
+- `scripts/simple_server.py` starts a local HTTP server for testing the game.
+## [0.41.46] - 2025-07-07
+### Added
+- Inventory publishes `item:added` and `item:consumed` events for game systems.
+## [0.41.45] - 2025-07-06
+### Added
+- PubSub events for unlockables and modal visibility.
+## [0.41.44] - 2025-07-06
+### Added
+- Basic `PubSub` module enables publish/subscribe messaging between systems.
+
 ## [0.41.43] - 2025-07-06
 ### Added
 - Story events load from `data/story_events.json` via new `StorySystem`.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 | Story System | Loads narrative events from `data/story_events.json` and triggers modals with unlocks |
 | Automation   | Enables actions to loop with or without conditions |
 | Bonus Engine | Centralizes additive, multiplicative, and exponential bonuses for stats and resources, including cost divisors |
+| PubSub       | Lightweight event bus so modules can publish and subscribe to messages. Unlockables and modals broadcast events via `unlock:*` and `modal:*` channels. Items notify `item:added` and `item:consumed` when inventory changes |
 | Engine       | Calculates deltas with multipliers and drives the main tick loop |
 | UI           | Interface for selecting tasks, viewing stats/resources, and managing slots. Includes a settings panel with dark mode and language options |
 | UI Handler   | Dynamically builds stat/resource lists and tab layout from JSON definitions |
@@ -139,10 +140,22 @@ page weight. Future updates will extend the scripts to automatically resize and
 compress generated images so existing assets do not require manual replacement.
 See `docs/image_optimization.md` for details.
 
+#### Local Server
+
+Run `scripts/simple_server.py` to launch a small HTTP server for testing the
+game locally:
+
+```bash
+python scripts/simple_server.py --port 8000
+```
+
+Open `http://localhost:8000` in your browser to play without deploying.
+
 #### Telegram Upload Bot
 
 For manual asset contributions a small Telegram bot can collect images and
 automate pull requests. The bot lists unresolved entries from the data files,
+including story events,
 accepts an uploaded image, commits the change and opens (or updates) a PR. See
 `docs/telegram_upload_bot.md` for a full overview.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 | Magic System | Simplified crafting and consumption system for magical items               |
 | Belongings   | Manages player's resource quantities, home selection, and magical components                |
 | Chips        | One-time unlockables that grant bonuses or new content |
+| Story System | Loads narrative events from `data/story_events.json` and triggers modals with unlocks |
 | Automation   | Enables actions to loop with or without conditions |
 | Bonus Engine | Centralizes additive, multiplicative, and exponential bonuses for stats and resources, including cost divisors |
 | Engine       | Calculates deltas with multipliers and drives the main tick loop |
@@ -115,7 +116,7 @@ The page uses a simple header/main/footer structure. Stats and resources are kep
 
 Resources appear as horizontal bars whose colors match each type (red for health, yellow for energy, blue for focus).
 
- A story modal appears once on the first load and another short scene triggers after thirty days pass in game time. Both modals only appear during the first life and all log messages are recorded in a scrollable container (about 300&nbsp;px high) in the right panel. Habits are quick actions found below the routines for instant resource gains. Routines themselves are triggered by clicking their progress bars; hovering shows the cost and effect. The adventure tab now displays a second progress bar beneath the location name showing how many encounters remain before the next level. The Belongings tab includes a filter button to hide items below a chosen rarity. A new Home section now lets you choose a dwelling above the item list. The home slot uses the larger encounter slot formatting to showcase the current home's image, while a Furniture section provides action-style slots that will hold unlockable furniture objects.
+ Story modals are defined in `data/story_events.json` and triggered by the `StorySystem`. The intro plays once on first load while another short scene fires after thirty days pass in game time. All modals only appear during the first life and log messages are recorded in a scrollable container (about 300&nbsp;px high) in the right panel. Habits are quick actions found below the routines for instant resource gains. Routines themselves are triggered by clicking their progress bars; hovering shows the cost and effect. The adventure tab now displays a second progress bar beneath the location name showing how many encounters remain before the next level. The Belongings tab includes a filter button to hide items below a chosen rarity. A new Home section now lets you choose a dwelling above the item list. The home slot uses the larger encounter slot formatting to showcase the current home's image, while a Furniture section provides action-style slots that will hold unlockable furniture objects.
 
 See **docs/MVP.md** for the MVP list.
 

--- a/data/story_events.json
+++ b/data/story_events.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": "intro",
+    "textKey": "intro",
+    "image": "assets/Intro.png",
+    "flag": "introSeen",
+    "trigger": {"type": "startup"},
+    "unlocks": {}
+  },
+  {
+    "id": "healerGone",
+    "textKey": "healerGone",
+    "image": "assets/HealerGone.png",
+    "flag": "healerGoneSeen",
+    "trigger": {"type": "age", "days": 5870},
+    "unlocks": {"tabs": ["adventure"]}
+  },
+  {
+    "id": "banditsAmbushVictory",
+    "textKey": "banditsAmbushVictory",
+    "image": "",
+    "flag": "banditsAmbushSeen",
+    "trigger": {"type": "encounterWin", "encounterId": "banditsAmbush"},
+    "unlocks": {}
+  }
+]

--- a/docs/telegram_upload_bot.md
+++ b/docs/telegram_upload_bot.md
@@ -4,8 +4,8 @@ This bot helps contributors add images directly through Telegram. It performs
 these steps:
 
 1. **Repository Pull** – executes `git pull origin main` and reports failures.
-2. **Parse & Filter** – scans JSON files for entries with missing image paths and
-   verifies the image files are present.
+2. **Parse & Filter** – scans item, encounter, home and story event JSON files
+   for entries with missing image paths and verifies the image files are present.
 3. **Present Options** – shows unresolved items in batches of ten for selection.
 4. **Receive Upload** – validates the uploaded file size and type before saving
    to `assets/user_uploaded/`.

--- a/index.html
+++ b/index.html
@@ -158,6 +158,7 @@
     <script src="js/ui_handler.js"></script>
     <script src="js/lang.js"></script>
     <script src="js/char_bg.js"></script>
+    <script src="js/story.js"></script>
     <script src="js/home.js"></script>
     <script src="js/main.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -148,6 +148,7 @@
     </footer>
     <script src="js/logger.js"></script>
     <script src="js/utils.js"></script>
+    <script src="js/pubsub.js"></script>
     <script src="js/state.js"></script>
     <script src="js/encounter.js"></script>
     <script src="js/items.js"></script>

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -197,14 +197,7 @@ const EncounterGenerator = {
                 'You survived the bandits ambush and claimed your reward.';
             Log.add(msg);
             if (!State.banditsAmbushSeen) {
-                Story.show(
-                    Lang.story('banditsAmbushVictory') || 'Bruised but victorious, you gather loot from the fallen bandits.',
-                    '',
-                    () => {
-                        State.banditsAmbushSeen = true;
-                        SaveSystem.save();
-                    }
-                );
+                StorySystem.trigger('banditsAmbushVictory');
             }
             return;
         }

--- a/js/items.js
+++ b/js/items.js
@@ -100,6 +100,26 @@ const Inventory = {
         if (typeof CharacterBackground !== 'undefined') {
             CharacterBackground.update();
         }
+        if (typeof PubSub !== 'undefined') {
+            PubSub.publish('item:added', item.id);
+            PubSub.publish('inventory:changed', State.inventory);
+        }
+    },
+    consume(id, qty = 1) {
+        const record = State.inventory[id];
+        if (!record || record.quantity < qty) return false;
+        record.quantity -= qty;
+        if (record.quantity <= 0) delete State.inventory[id];
+        SoftCapSystem.recalculateCaps(State.inventory);
+        InventoryUI.update();
+        if (typeof CharacterBackground !== 'undefined') {
+            CharacterBackground.update();
+        }
+        if (typeof PubSub !== 'undefined') {
+            PubSub.publish('item:consumed', { id, quantity: qty });
+            PubSub.publish('inventory:changed', State.inventory);
+        }
+        return true;
     },
     getItems() {
         const items = Object.entries(State.inventory).map(([id, data]) => {

--- a/js/main.js
+++ b/js/main.js
@@ -22,34 +22,6 @@ function capitalize(str) {
 }
 
 
-const Story = {
-    active: false,
-    show(text, image, onClose) {
-        if (this.active) return;
-        this.active = true;
-        const modal = document.getElementById('story-modal');
-        const textEl = document.getElementById('story-text');
-        const imageEl = document.getElementById('story-image');
-        textEl.textContent = text;
-        imageEl.innerHTML = '';
-        if (image) {
-            const img = document.createElement('img');
-            img.src = image;
-            img.alt = '';
-            img.loading = 'lazy';
-            imageEl.appendChild(img);
-        }
-        modal.classList.remove('hidden');
-        const close = () => {
-            modal.classList.add('hidden');
-            document.getElementById('story-close').removeEventListener('click', close);
-            this.active = false;
-            Log.add(text);
-            if (onClose) onClose();
-        };
-        document.getElementById('story-close').addEventListener('click', close);
-    }
-};
 
 const SoftCapSystem = {
     baseStatCaps: { strength: 50, intelligence: 50, creativity: 50 },
@@ -531,24 +503,6 @@ function getActionTier(level) {
     return TierSystem.getTier(level);
 }
 
-function checkStoryEvents() {
-    // Trigger when the hero recovers and notices the healer is gone
-    if (!State.introSeen || State.healerGoneSeen) return;
-    const currentDays = State.age.years * AgeSystem.daysPerYear + State.age.days;
-    const triggerDays = 16 * AgeSystem.daysPerYear + 30;
-    if (currentDays > triggerDays) {
-        Story.show(
-            Lang.story('healerGone') || "The cot is cold. The fire long dead. The healer is gone — no note, no trace, just the fading scent of herbs. You rise, steadier now. The shelves are bare. Outside, a narrow road cuts through the trees. In the distance, a thin plume of smoke rises. The pendant at your neck feels heavier — as if urging you forward.",
-            'assets/HealerGone.png',
-            () => {
-                State.healerGoneSeen = true;
-                TabManager.unlockTab('adventure');
-                TabManager.showTab('adventure');
-                SaveSystem.save();
-            }
-        );
-    }
-}
 
 function scalingMultiplier(action) {
     const f = action.scaling;
@@ -614,7 +568,7 @@ const ActionEngine = {
             slot.progress = action.exp / action.expToNext;
             updateSlotUI(i);
         });
-        checkStoryEvents();
+        StorySystem.check();
         SoftCapSystem.apply();
         checkHealth();
         SaveSystem.save();
@@ -850,19 +804,11 @@ function updateUI() {
 async function init() {
     await loadBaseData();
     const loadedActions = SaveSystem.load();
+    await StorySystem.load();
     applyPrestigeBonuses();
     await Lang.load(State.language);
     Log.init();
-    if (!State.introSeen) {
-        Story.show(
-            Lang.story('intro') || "You awaken in a healer's hut, the sole survivor of a caravan ambush. Months have passed in recovery and now, with strength slowly returning, your true journey begins. The healer, an old woman with eyes like weathered stone, presses a worn pendant into your hand — the only item found with you. Its unfamiliar symbol stirs something deep and cold in your chest, but no memory surfaces.",
-            'assets/Intro.png',
-            () => {
-                State.introSeen = true;
-                SaveSystem.save();
-            }
-        );
-    }
+    StorySystem.trigger("intro");
     document.getElementById('speed-controls').addEventListener('click', e => {
         const s = e.target.dataset.speed;
         if (!s) return;
@@ -924,6 +870,7 @@ async function init() {
     Lang.translateUI();
     TabManager.translate();
     const toggleBtn = document.getElementById('toggle-left');
+    StorySystem.init();
     if (toggleBtn) {
         toggleBtn.addEventListener('click', toggleLeftPanel);
     }

--- a/js/main.js
+++ b/js/main.js
@@ -21,6 +21,28 @@ function capitalize(str) {
     return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
+function setupPubSub() {
+    PubSub.subscribe('modal:open', id => {
+        const el = document.getElementById(id);
+        if (el) el.classList.remove('hidden');
+    });
+    PubSub.subscribe('modal:close', id => {
+        const el = document.getElementById(id);
+        if (el) el.classList.add('hidden');
+    });
+    PubSub.subscribe('unlock:tab', id => TabManager.unlockTab(id));
+    PubSub.subscribe('unlock:action', id => {
+        if (actions[id]) {
+            actions[id].locked = false;
+            updateTaskList();
+        }
+    });
+    PubSub.subscribe('unlock:encounter', id => {
+        const enc = EncounterGenerator.encounters.find(e => e.id === id);
+        if (enc) enc.locked = false;
+    });
+}
+
 
 
 const SoftCapSystem = {
@@ -802,6 +824,7 @@ function updateUI() {
 }
 
 async function init() {
+    setupPubSub();
     await loadBaseData();
     const loadedActions = SaveSystem.load();
     await StorySystem.load();
@@ -989,15 +1012,15 @@ function applyDarkMode() {
 }
 
 function openSettings() {
-    document.getElementById('settings-modal').classList.remove('hidden');
+    PubSub.publish('modal:open', 'settings-modal');
 }
 
 function closeSettings() {
-    document.getElementById('settings-modal').classList.add('hidden');
+    PubSub.publish('modal:close', 'settings-modal');
 }
 
 function openInventoryFilter() {
-    document.getElementById('inventory-filter-modal').classList.remove('hidden');
+    PubSub.publish('modal:open', 'inventory-filter-modal');
     const chk = document.getElementById('hide-rarity-toggle');
     const sel = document.getElementById('hide-rarity-select');
     if (chk) chk.checked = State.hideRarityEnabled;
@@ -1005,5 +1028,5 @@ function openInventoryFilter() {
 }
 
 function closeInventoryFilter() {
-    document.getElementById('inventory-filter-modal').classList.add('hidden');
+    PubSub.publish('modal:close', 'inventory-filter-modal');
 }

--- a/js/pubsub.js
+++ b/js/pubsub.js
@@ -1,0 +1,48 @@
+// Simple publish/subscribe event bus
+// Allows decoupled modules to communicate without direct references
+const PubSub = {
+    _events: {},
+
+    /**
+     * Subscribe to an event.
+     * @param {string} name - event name
+     * @param {Function} handler - callback
+     */
+    subscribe(name, handler) {
+        if (!this._events[name]) this._events[name] = [];
+        this._events[name].push(handler);
+    },
+
+    /**
+     * Publish an event with optional data.
+     * @param {string} name - event name
+     * @param {*} data - payload
+     */
+    publish(name, data) {
+        const handlers = this._events[name];
+        if (!handlers) return;
+        handlers.slice().forEach(h => {
+            try {
+                h(data);
+            } catch (e) {
+                console.error('PubSub handler error', e);
+            }
+        });
+    },
+
+    /**
+     * Remove a subscription.
+     * @param {string} name - event name
+     * @param {Function} handler - callback to remove
+     */
+    unsubscribe(name, handler) {
+        const handlers = this._events[name];
+        if (!handlers) return;
+        const idx = handlers.indexOf(handler);
+        if (idx !== -1) handlers.splice(idx, 1);
+    }
+};
+
+if (typeof module !== 'undefined') {
+    module.exports = { PubSub };
+}

--- a/js/story.js
+++ b/js/story.js
@@ -1,0 +1,105 @@
+// Story event system loaded from data/story_events.json
+// Allows adding narrative modals via data instead of hardcoding logic.
+class StoryEvent {
+    constructor(data) {
+        this.id = data.id;
+        this.textKey = data.textKey;
+        this.image = data.image || '';
+        this.flag = data.flag || null;
+        this.trigger = data.trigger || { type: 'manual' };
+        this.unlocks = data.unlocks || {};
+    }
+}
+
+const Story = {
+    active: false,
+    show(text, image, onClose) {
+        if (this.active) return;
+        this.active = true;
+        const modal = document.getElementById('story-modal');
+        const textEl = document.getElementById('story-text');
+        const imageEl = document.getElementById('story-image');
+        textEl.textContent = text;
+        imageEl.innerHTML = '';
+        if (image) {
+            const img = document.createElement('img');
+            img.src = image;
+            img.alt = '';
+            img.loading = 'lazy';
+            imageEl.appendChild(img);
+        }
+        modal.classList.remove('hidden');
+        const close = () => {
+            modal.classList.add('hidden');
+            document.getElementById('story-close').removeEventListener('click', close);
+            this.active = false;
+            Log.add(text);
+            if (onClose) onClose();
+        };
+        document.getElementById('story-close').addEventListener('click', close);
+    }
+};
+
+const StorySystem = {
+    events: [],
+    async load() {
+        try {
+            const res = await fetch('data/story_events.json');
+            const json = await res.json();
+            this.events = json.map(e => new StoryEvent(e));
+        } catch (e) {
+            console.error('Failed to load story events', e);
+            this.events = [];
+        }
+    },
+    init() {
+        this.check();
+    },
+    trigger(id) {
+        const event = this.events.find(e => e.id === id);
+        if (!event) return;
+        if (event.flag && State[event.flag]) return;
+        this._show(event);
+    },
+    _show(event) {
+        const text = Lang.story(event.textKey) || event.textKey;
+        Story.show(text, event.image, () => {
+            if (event.flag) State[event.flag] = true;
+            this.applyUnlocks(event.unlocks);
+            SaveSystem.save();
+        });
+    },
+    applyUnlocks(unlocks) {
+        if (!unlocks) return;
+        if (unlocks.tabs) {
+            unlocks.tabs.forEach(id => TabManager.unlockTab(id));
+        }
+        if (unlocks.actions) {
+            unlocks.actions.forEach(id => {
+                if (actions[id]) actions[id].locked = false;
+            });
+        }
+        if (unlocks.encounters) {
+            unlocks.encounters.forEach(id => {
+                const enc = EncounterGenerator.encounters.find(e => e.id === id);
+                if (enc) enc.locked = false;
+            });
+        }
+    },
+    check() {
+        const days = State.age.years * AgeSystem.daysPerYear + State.age.days;
+        this.events.forEach(ev => {
+            if (ev.flag && State[ev.flag]) return;
+            const t = ev.trigger;
+            if (t.type === 'startup') {
+                this.trigger(ev.id);
+            } else if (t.type === 'age' && days >= t.days) {
+                this.trigger(ev.id);
+            }
+        });
+    }
+};
+
+if (typeof module !== 'undefined') {
+    module.exports = { StorySystem, StoryEvent, Story };
+}

--- a/js/story.js
+++ b/js/story.js
@@ -29,8 +29,14 @@ const Story = {
             imageEl.appendChild(img);
         }
         modal.classList.remove('hidden');
+        if (typeof PubSub !== 'undefined') {
+            PubSub.publish('modal:open', 'story-modal');
+        }
         const close = () => {
             modal.classList.add('hidden');
+            if (typeof PubSub !== 'undefined') {
+                PubSub.publish('modal:close', 'story-modal');
+            }
             document.getElementById('story-close').removeEventListener('click', close);
             this.active = false;
             Log.add(text);
@@ -72,17 +78,32 @@ const StorySystem = {
     applyUnlocks(unlocks) {
         if (!unlocks) return;
         if (unlocks.tabs) {
-            unlocks.tabs.forEach(id => TabManager.unlockTab(id));
+            unlocks.tabs.forEach(id => {
+                TabManager.unlockTab(id);
+                if (typeof PubSub !== 'undefined') {
+                    PubSub.publish('unlock:tab', id);
+                }
+            });
         }
         if (unlocks.actions) {
             unlocks.actions.forEach(id => {
-                if (actions[id]) actions[id].locked = false;
+                if (actions[id]) {
+                    actions[id].locked = false;
+                    if (typeof PubSub !== 'undefined') {
+                        PubSub.publish('unlock:action', id);
+                    }
+                }
             });
         }
         if (unlocks.encounters) {
             unlocks.encounters.forEach(id => {
                 const enc = EncounterGenerator.encounters.find(e => e.id === id);
-                if (enc) enc.locked = false;
+                if (enc) {
+                    enc.locked = false;
+                    if (typeof PubSub !== 'undefined') {
+                        PubSub.publish('unlock:encounter', id);
+                    }
+                }
             });
         }
     },

--- a/js/updates.js
+++ b/js/updates.js
@@ -155,11 +155,21 @@ const UpdateSystem = {
         }
         if (update.unlocks && update.unlocks.actions) {
             update.unlocks.actions.forEach(id => {
-                if (actions[id]) actions[id].locked = false;
+                if (actions[id]) {
+                    actions[id].locked = false;
+                    if (typeof PubSub !== 'undefined') {
+                        PubSub.publish('unlock:action', id);
+                    }
+                }
             });
         }
         if (update.unlocks && update.unlocks.tabs) {
-            update.unlocks.tabs.forEach(id => TabManager.unlockTab(id));
+            update.unlocks.tabs.forEach(id => {
+                TabManager.unlockTab(id);
+                if (typeof PubSub !== 'undefined') {
+                    PubSub.publish('unlock:tab', id);
+                }
+            });
         }
         if (update.unlocks && update.unlocks.storyEvents) {
             update.unlocks.storyEvents.forEach(id => StorySystem.trigger(id));

--- a/js/updates.js
+++ b/js/updates.js
@@ -158,6 +158,12 @@ const UpdateSystem = {
                 if (actions[id]) actions[id].locked = false;
             });
         }
+        if (update.unlocks && update.unlocks.tabs) {
+            update.unlocks.tabs.forEach(id => TabManager.unlockTab(id));
+        }
+        if (update.unlocks && update.unlocks.storyEvents) {
+            update.unlocks.storyEvents.forEach(id => StorySystem.trigger(id));
+        }
     }
 };
 

--- a/scripts/simple_server.py
+++ b/scripts/simple_server.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Run a basic HTTP server for local testing."""
+import http.server
+import socketserver
+import argparse
+import os
+
+
+def run(port: int = 8000) -> None:
+    os.chdir(os.path.dirname(os.path.dirname(__file__)))
+    handler = http.server.SimpleHTTPRequestHandler
+    with socketserver.TCPServer(("", port), handler) as httpd:
+        print(f"Serving at http://localhost:{port}")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("Shutting down...")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Launch local server")
+    parser.add_argument("--port", type=int, default=8000, help="Port to bind")
+    args = parser.parse_args()
+    run(args.port)

--- a/scripts/telegram_upload_bot.py
+++ b/scripts/telegram_upload_bot.py
@@ -25,6 +25,7 @@ DATA_FILES = [
     os.path.join('data', 'items.json'),
     os.path.join('data', 'encounters.json'),
     os.path.join('data', 'homes.json'),
+    os.path.join('data', 'story_events.json'),
 ]
 IMAGES_DIR = os.path.join('assets', 'user_uploaded')
 BRANCH_NAME = 'bot/assets-upload'

--- a/tests/test_pubsub.py
+++ b/tests/test_pubsub.py
@@ -1,0 +1,16 @@
+import os
+
+
+def test_pubsub_script_included():
+    with open('index.html') as f:
+        html = f.read()
+    assert 'js/pubsub.js' in html
+
+
+def test_pubsub_defined():
+    path = os.path.join('js', 'pubsub.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'const PubSub' in text
+    assert 'subscribe(' in text
+    assert 'publish(' in text

--- a/tests/test_pubsub_usage.py
+++ b/tests/test_pubsub_usage.py
@@ -1,0 +1,19 @@
+import os
+
+
+def test_pubsub_unlock_events_present():
+    with open(os.path.join('js', 'story.js')) as f:
+        text = f.read()
+    assert "PubSub.publish('unlock:" in text
+
+
+def test_pubsub_modal_events_present():
+    with open(os.path.join('js', 'main.js')) as f:
+        text = f.read()
+    assert "modal:open" in text and "modal:close" in text
+
+
+def test_pubsub_item_events_present():
+    with open(os.path.join('js', 'items.js')) as f:
+        text = f.read()
+    assert "item:added" in text and "item:consumed" in text

--- a/tests/test_simple_server.py
+++ b/tests/test_simple_server.py
@@ -1,0 +1,10 @@
+import importlib.util
+import os
+
+
+def test_simple_server_importable():
+    path = os.path.join('scripts', 'simple_server.py')
+    spec = importlib.util.spec_from_file_location('simple_server', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert hasattr(module, 'run')

--- a/tests/test_story_events.py
+++ b/tests/test_story_events.py
@@ -1,0 +1,13 @@
+import json
+import os
+
+
+def test_story_events_structure():
+    path = os.path.join('data', 'story_events.json')
+    with open(path) as f:
+        data = json.load(f)
+    for ev in data:
+        assert 'id' in ev
+        assert 'textKey' in ev
+        assert 'flag' in ev
+        assert 'trigger' in ev and isinstance(ev['trigger'], dict)

--- a/tests/test_story_system.py
+++ b/tests/test_story_system.py
@@ -1,0 +1,14 @@
+import os
+
+
+def test_story_script_included():
+    with open('index.html') as f:
+        text = f.read()
+    assert 'js/story.js' in text
+
+
+def test_story_system_defined():
+    path = os.path.join('js', 'story.js')
+    with open(path) as f:
+        content = f.read()
+    assert 'const StorySystem' in content

--- a/tests/test_upload_bot_extended.py
+++ b/tests/test_upload_bot_extended.py
@@ -1,0 +1,60 @@
+import json
+import importlib.util
+import types
+import os
+import sys
+import subprocess
+import shutil
+
+
+spec = importlib.util.spec_from_file_location(
+    "telegram_upload_bot",
+    os.path.join("scripts", "telegram_upload_bot.py"),
+)
+telegram = types.ModuleType("telegram")
+telegram.Update = object
+telegram.InlineKeyboardButton = object
+telegram.InlineKeyboardMarkup = object
+telegram.ext = types.ModuleType("telegram.ext")
+for name in [
+    "ApplicationBuilder",
+    "CallbackQueryHandler",
+    "CommandHandler",
+    "ConversationHandler",
+    "MessageHandler",
+]:
+    setattr(telegram.ext, name, object())
+telegram.ext.ContextTypes = types.SimpleNamespace(DEFAULT_TYPE=object())
+telegram.ext.filters = types.SimpleNamespace(ALL=object())
+sys.modules["telegram"] = telegram
+sys.modules["telegram.ext"] = telegram.ext
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class Dummy:
+    def __init__(self):
+        self.stdout = ""
+
+
+def test_find_unresolved_includes_story(tmp_path, monkeypatch):
+    items = tmp_path / "items.json"
+    story = tmp_path / "story_events.json"
+    json.dump([{"id": "i1", "name": "Item", "image": ""}], items.open("w"))
+    json.dump([{"id": "s1", "name": "Story", "image": ""}], story.open("w"))
+    monkeypatch.setattr(module, "DATA_FILES", [str(items), str(story)])
+    unresolved = module.find_unresolved()
+    assert (str(story), "s1", "Story") in unresolved
+    assert (str(items), "i1", "Item") in unresolved
+
+
+def test_commit_and_pr_runs_gh(monkeypatch):
+    calls = []
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(cmd)
+        return Dummy()
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    monkeypatch.setattr(shutil, 'which', lambda x: '/usr/bin/gh')
+    module.commit_and_pr('img.png', 'data.json', 'id1')
+    assert any(cmd[0] == 'gh' for cmd in calls)


### PR DESCRIPTION
## Summary
- introduce `StorySystem` module that loads events from `data/story_events.json`
- trigger story events during init, adventure resolutions and update completion
- allow chip upgrades to unlock tabs and story events
- load `js/story.js` in `index.html`
- document Story System in README
- add tests for story events and script inclusion

## Testing
- `pip install pytest-cov`
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_686a8e6d509c8330814d213352712561