### PR TITLE
Add PubSub events for unlockables and modals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.41.45] - 2025-07-06
+### Added
+- PubSub events for unlockables and modal visibility.
 ## [0.41.44] - 2025-07-06
 ### Added
 - Basic `PubSub` module enables publish/subscribe messaging between systems.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## [0.41.47] - 2025-07-07
+### Added
+- Story events are now included when the Telegram upload bot scans for missing images.
+- `scripts/simple_server.py` starts a local HTTP server for testing the game.
+## [0.41.46] - 2025-07-07
+### Added
+- Inventory publishes `item:added` and `item:consumed` events for game systems.
 ## [0.41.45] - 2025-07-06
 ### Added
 - PubSub events for unlockables and modal visibility.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 | Story System | Loads narrative events from `data/story_events.json` and triggers modals with unlocks |
 | Automation   | Enables actions to loop with or without conditions |
 | Bonus Engine | Centralizes additive, multiplicative, and exponential bonuses for stats and resources, including cost divisors |
-| PubSub       | Lightweight event bus so modules can publish and subscribe to messages |
+| PubSub       | Lightweight event bus so modules can publish and subscribe to messages. Unlockables and modals broadcast events via `unlock:*` and `modal:*` channels |
 | Engine       | Calculates deltas with multipliers and drives the main tick loop |
 | UI           | Interface for selecting tasks, viewing stats/resources, and managing slots. Includes a settings panel with dark mode and language options |
 | UI Handler   | Dynamically builds stat/resource lists and tab layout from JSON definitions |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 | Story System | Loads narrative events from `data/story_events.json` and triggers modals with unlocks |
 | Automation   | Enables actions to loop with or without conditions |
 | Bonus Engine | Centralizes additive, multiplicative, and exponential bonuses for stats and resources, including cost divisors |
-| PubSub       | Lightweight event bus so modules can publish and subscribe to messages. Unlockables and modals broadcast events via `unlock:*` and `modal:*` channels |
+| PubSub       | Lightweight event bus so modules can publish and subscribe to messages. Unlockables and modals broadcast events via `unlock:*` and `modal:*` channels. Items notify `item:added` and `item:consumed` when inventory changes |
 | Engine       | Calculates deltas with multipliers and drives the main tick loop |
 | UI           | Interface for selecting tasks, viewing stats/resources, and managing slots. Includes a settings panel with dark mode and language options |
 | UI Handler   | Dynamically builds stat/resource lists and tab layout from JSON definitions |
@@ -140,10 +140,22 @@ page weight. Future updates will extend the scripts to automatically resize and
 compress generated images so existing assets do not require manual replacement.
 See `docs/image_optimization.md` for details.
 
+#### Local Server
+
+Run `scripts/simple_server.py` to launch a small HTTP server for testing the
+game locally:
+
+```bash
+python scripts/simple_server.py --port 8000
+```
+
+Open `http://localhost:8000` in your browser to play without deploying.
+
 #### Telegram Upload Bot
 
 For manual asset contributions a small Telegram bot can collect images and
 automate pull requests. The bot lists unresolved entries from the data files,
+including story events,
 accepts an uploaded image, commits the change and opens (or updates) a PR. See
 `docs/telegram_upload_bot.md` for a full overview.
 

--- a/docs/telegram_upload_bot.md
+++ b/docs/telegram_upload_bot.md
@@ -4,8 +4,8 @@ This bot helps contributors add images directly through Telegram. It performs
 these steps:
 
 1. **Repository Pull** – executes `git pull origin main` and reports failures.
-2. **Parse & Filter** – scans JSON files for entries with missing image paths and
-   verifies the image files are present.
+2. **Parse & Filter** – scans item, encounter, home and story event JSON files
+   for entries with missing image paths and verifies the image files are present.
 3. **Present Options** – shows unresolved items in batches of ten for selection.
 4. **Receive Upload** – validates the uploaded file size and type before saving
    to `assets/user_uploaded/`.

--- a/js/items.js
+++ b/js/items.js
@@ -100,6 +100,26 @@ const Inventory = {
         if (typeof CharacterBackground !== 'undefined') {
             CharacterBackground.update();
         }
+        if (typeof PubSub !== 'undefined') {
+            PubSub.publish('item:added', item.id);
+            PubSub.publish('inventory:changed', State.inventory);
+        }
+    },
+    consume(id, qty = 1) {
+        const record = State.inventory[id];
+        if (!record || record.quantity < qty) return false;
+        record.quantity -= qty;
+        if (record.quantity <= 0) delete State.inventory[id];
+        SoftCapSystem.recalculateCaps(State.inventory);
+        InventoryUI.update();
+        if (typeof CharacterBackground !== 'undefined') {
+            CharacterBackground.update();
+        }
+        if (typeof PubSub !== 'undefined') {
+            PubSub.publish('item:consumed', { id, quantity: qty });
+            PubSub.publish('inventory:changed', State.inventory);
+        }
+        return true;
     },
     getItems() {
         const items = Object.entries(State.inventory).map(([id, data]) => {

--- a/js/main.js
+++ b/js/main.js
@@ -21,6 +21,28 @@ function capitalize(str) {
     return str.charAt(0).toUpperCase() + str.slice(1);
 }
 
+function setupPubSub() {
+    PubSub.subscribe('modal:open', id => {
+        const el = document.getElementById(id);
+        if (el) el.classList.remove('hidden');
+    });
+    PubSub.subscribe('modal:close', id => {
+        const el = document.getElementById(id);
+        if (el) el.classList.add('hidden');
+    });
+    PubSub.subscribe('unlock:tab', id => TabManager.unlockTab(id));
+    PubSub.subscribe('unlock:action', id => {
+        if (actions[id]) {
+            actions[id].locked = false;
+            updateTaskList();
+        }
+    });
+    PubSub.subscribe('unlock:encounter', id => {
+        const enc = EncounterGenerator.encounters.find(e => e.id === id);
+        if (enc) enc.locked = false;
+    });
+}
+
 
 
 const SoftCapSystem = {
@@ -802,6 +824,7 @@ function updateUI() {
 }
 
 async function init() {
+    setupPubSub();
     await loadBaseData();
     const loadedActions = SaveSystem.load();
     await StorySystem.load();
@@ -989,15 +1012,15 @@ function applyDarkMode() {
 }
 
 function openSettings() {
-    document.getElementById('settings-modal').classList.remove('hidden');
+    PubSub.publish('modal:open', 'settings-modal');
 }
 
 function closeSettings() {
-    document.getElementById('settings-modal').classList.add('hidden');
+    PubSub.publish('modal:close', 'settings-modal');
 }
 
 function openInventoryFilter() {
-    document.getElementById('inventory-filter-modal').classList.remove('hidden');
+    PubSub.publish('modal:open', 'inventory-filter-modal');
     const chk = document.getElementById('hide-rarity-toggle');
     const sel = document.getElementById('hide-rarity-select');
     if (chk) chk.checked = State.hideRarityEnabled;
@@ -1005,5 +1028,5 @@ function openInventoryFilter() {
 }
 
 function closeInventoryFilter() {
-    document.getElementById('inventory-filter-modal').classList.add('hidden');
+    PubSub.publish('modal:close', 'inventory-filter-modal');
 }

--- a/js/story.js
+++ b/js/story.js
@@ -29,8 +29,14 @@ const Story = {
             imageEl.appendChild(img);
         }
         modal.classList.remove('hidden');
+        if (typeof PubSub !== 'undefined') {
+            PubSub.publish('modal:open', 'story-modal');
+        }
         const close = () => {
             modal.classList.add('hidden');
+            if (typeof PubSub !== 'undefined') {
+                PubSub.publish('modal:close', 'story-modal');
+            }
             document.getElementById('story-close').removeEventListener('click', close);
             this.active = false;
             Log.add(text);
@@ -72,17 +78,32 @@ const StorySystem = {
     applyUnlocks(unlocks) {
         if (!unlocks) return;
         if (unlocks.tabs) {
-            unlocks.tabs.forEach(id => TabManager.unlockTab(id));
+            unlocks.tabs.forEach(id => {
+                TabManager.unlockTab(id);
+                if (typeof PubSub !== 'undefined') {
+                    PubSub.publish('unlock:tab', id);
+                }
+            });
         }
         if (unlocks.actions) {
             unlocks.actions.forEach(id => {
-                if (actions[id]) actions[id].locked = false;
+                if (actions[id]) {
+                    actions[id].locked = false;
+                    if (typeof PubSub !== 'undefined') {
+                        PubSub.publish('unlock:action', id);
+                    }
+                }
             });
         }
         if (unlocks.encounters) {
             unlocks.encounters.forEach(id => {
                 const enc = EncounterGenerator.encounters.find(e => e.id === id);
-                if (enc) enc.locked = false;
+                if (enc) {
+                    enc.locked = false;
+                    if (typeof PubSub !== 'undefined') {
+                        PubSub.publish('unlock:encounter', id);
+                    }
+                }
             });
         }
     },

--- a/js/updates.js
+++ b/js/updates.js
@@ -155,11 +155,21 @@ const UpdateSystem = {
         }
         if (update.unlocks && update.unlocks.actions) {
             update.unlocks.actions.forEach(id => {
-                if (actions[id]) actions[id].locked = false;
+                if (actions[id]) {
+                    actions[id].locked = false;
+                    if (typeof PubSub !== 'undefined') {
+                        PubSub.publish('unlock:action', id);
+                    }
+                }
             });
         }
         if (update.unlocks && update.unlocks.tabs) {
-            update.unlocks.tabs.forEach(id => TabManager.unlockTab(id));
+            update.unlocks.tabs.forEach(id => {
+                TabManager.unlockTab(id);
+                if (typeof PubSub !== 'undefined') {
+                    PubSub.publish('unlock:tab', id);
+                }
+            });
         }
         if (update.unlocks && update.unlocks.storyEvents) {
             update.unlocks.storyEvents.forEach(id => StorySystem.trigger(id));

--- a/scripts/simple_server.py
+++ b/scripts/simple_server.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Run a basic HTTP server for local testing."""
+import http.server
+import socketserver
+import argparse
+import os
+
+
+def run(port: int = 8000) -> None:
+    os.chdir(os.path.dirname(os.path.dirname(__file__)))
+    handler = http.server.SimpleHTTPRequestHandler
+    with socketserver.TCPServer(("", port), handler) as httpd:
+        print(f"Serving at http://localhost:{port}")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("Shutting down...")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Launch local server")
+    parser.add_argument("--port", type=int, default=8000, help="Port to bind")
+    args = parser.parse_args()
+    run(args.port)

--- a/scripts/telegram_upload_bot.py
+++ b/scripts/telegram_upload_bot.py
@@ -25,6 +25,7 @@ DATA_FILES = [
     os.path.join('data', 'items.json'),
     os.path.join('data', 'encounters.json'),
     os.path.join('data', 'homes.json'),
+    os.path.join('data', 'story_events.json'),
 ]
 IMAGES_DIR = os.path.join('assets', 'user_uploaded')
 BRANCH_NAME = 'bot/assets-upload'

--- a/tests/test_pubsub_usage.py
+++ b/tests/test_pubsub_usage.py
@@ -11,3 +11,9 @@ def test_pubsub_modal_events_present():
     with open(os.path.join('js', 'main.js')) as f:
         text = f.read()
     assert "modal:open" in text and "modal:close" in text
+
+
+def test_pubsub_item_events_present():
+    with open(os.path.join('js', 'items.js')) as f:
+        text = f.read()
+    assert "item:added" in text and "item:consumed" in text

--- a/tests/test_pubsub_usage.py
+++ b/tests/test_pubsub_usage.py
@@ -1,0 +1,13 @@
+import os
+
+
+def test_pubsub_unlock_events_present():
+    with open(os.path.join('js', 'story.js')) as f:
+        text = f.read()
+    assert "PubSub.publish('unlock:" in text
+
+
+def test_pubsub_modal_events_present():
+    with open(os.path.join('js', 'main.js')) as f:
+        text = f.read()
+    assert "modal:open" in text and "modal:close" in text

--- a/tests/test_simple_server.py
+++ b/tests/test_simple_server.py
@@ -1,0 +1,10 @@
+import importlib.util
+import os
+
+
+def test_simple_server_importable():
+    path = os.path.join('scripts', 'simple_server.py')
+    spec = importlib.util.spec_from_file_location('simple_server', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert hasattr(module, 'run')

--- a/tests/test_upload_bot_extended.py
+++ b/tests/test_upload_bot_extended.py
@@ -1,0 +1,60 @@
+import json
+import importlib.util
+import types
+import os
+import sys
+import subprocess
+import shutil
+
+
+spec = importlib.util.spec_from_file_location(
+    "telegram_upload_bot",
+    os.path.join("scripts", "telegram_upload_bot.py"),
+)
+telegram = types.ModuleType("telegram")
+telegram.Update = object
+telegram.InlineKeyboardButton = object
+telegram.InlineKeyboardMarkup = object
+telegram.ext = types.ModuleType("telegram.ext")
+for name in [
+    "ApplicationBuilder",
+    "CallbackQueryHandler",
+    "CommandHandler",
+    "ConversationHandler",
+    "MessageHandler",
+]:
+    setattr(telegram.ext, name, object())
+telegram.ext.ContextTypes = types.SimpleNamespace(DEFAULT_TYPE=object())
+telegram.ext.filters = types.SimpleNamespace(ALL=object())
+sys.modules["telegram"] = telegram
+sys.modules["telegram.ext"] = telegram.ext
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class Dummy:
+    def __init__(self):
+        self.stdout = ""
+
+
+def test_find_unresolved_includes_story(tmp_path, monkeypatch):
+    items = tmp_path / "items.json"
+    story = tmp_path / "story_events.json"
+    json.dump([{"id": "i1", "name": "Item", "image": ""}], items.open("w"))
+    json.dump([{"id": "s1", "name": "Story", "image": ""}], story.open("w"))
+    monkeypatch.setattr(module, "DATA_FILES", [str(items), str(story)])
+    unresolved = module.find_unresolved()
+    assert (str(story), "s1", "Story") in unresolved
+    assert (str(items), "i1", "Item") in unresolved
+
+
+def test_commit_and_pr_runs_gh(monkeypatch):
+    calls = []
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(cmd)
+        return Dummy()
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    monkeypatch.setattr(shutil, 'which', lambda x: '/usr/bin/gh')
+    module.commit_and_pr('img.png', 'data.json', 'id1')
+    assert any(cmd[0] == 'gh' for cmd in calls)


### PR DESCRIPTION
## Summary
- emit `modal:*` events when story or UI modals toggle
- publish `unlock:*` events from StorySystem and UpdateSystem
- handle `unlock` and `modal` events in `setupPubSub`
- document event channels in README
- note new event types in CHANGELOG
- test for event strings in code

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686ae1287e888330807e35e9fb88f92d