### PR TITLE
Add local server and extend upload bot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.41.47] - 2025-07-07
+### Added
+- Story events are now included when the Telegram upload bot scans for missing images.
+- `scripts/simple_server.py` starts a local HTTP server for testing the game.
 ## [0.41.46] - 2025-07-07
 ### Added
 - Inventory publishes `item:added` and `item:consumed` events for game systems.

--- a/README.md
+++ b/README.md
@@ -140,10 +140,22 @@ page weight. Future updates will extend the scripts to automatically resize and
 compress generated images so existing assets do not require manual replacement.
 See `docs/image_optimization.md` for details.
 
+#### Local Server
+
+Run `scripts/simple_server.py` to launch a small HTTP server for testing the
+game locally:
+
+```bash
+python scripts/simple_server.py --port 8000
+```
+
+Open `http://localhost:8000` in your browser to play without deploying.
+
 #### Telegram Upload Bot
 
 For manual asset contributions a small Telegram bot can collect images and
 automate pull requests. The bot lists unresolved entries from the data files,
+including story events,
 accepts an uploaded image, commits the change and opens (or updates) a PR. See
 `docs/telegram_upload_bot.md` for a full overview.
 

--- a/docs/telegram_upload_bot.md
+++ b/docs/telegram_upload_bot.md
@@ -4,8 +4,8 @@ This bot helps contributors add images directly through Telegram. It performs
 these steps:
 
 1. **Repository Pull** – executes `git pull origin main` and reports failures.
-2. **Parse & Filter** – scans JSON files for entries with missing image paths and
-   verifies the image files are present.
+2. **Parse & Filter** – scans item, encounter, home and story event JSON files
+   for entries with missing image paths and verifies the image files are present.
 3. **Present Options** – shows unresolved items in batches of ten for selection.
 4. **Receive Upload** – validates the uploaded file size and type before saving
    to `assets/user_uploaded/`.

--- a/scripts/simple_server.py
+++ b/scripts/simple_server.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Run a basic HTTP server for local testing."""
+import http.server
+import socketserver
+import argparse
+import os
+
+
+def run(port: int = 8000) -> None:
+    os.chdir(os.path.dirname(os.path.dirname(__file__)))
+    handler = http.server.SimpleHTTPRequestHandler
+    with socketserver.TCPServer(("", port), handler) as httpd:
+        print(f"Serving at http://localhost:{port}")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("Shutting down...")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Launch local server")
+    parser.add_argument("--port", type=int, default=8000, help="Port to bind")
+    args = parser.parse_args()
+    run(args.port)

--- a/scripts/telegram_upload_bot.py
+++ b/scripts/telegram_upload_bot.py
@@ -25,6 +25,7 @@ DATA_FILES = [
     os.path.join('data', 'items.json'),
     os.path.join('data', 'encounters.json'),
     os.path.join('data', 'homes.json'),
+    os.path.join('data', 'story_events.json'),
 ]
 IMAGES_DIR = os.path.join('assets', 'user_uploaded')
 BRANCH_NAME = 'bot/assets-upload'

--- a/tests/test_simple_server.py
+++ b/tests/test_simple_server.py
@@ -1,0 +1,10 @@
+import importlib.util
+import os
+
+
+def test_simple_server_importable():
+    path = os.path.join('scripts', 'simple_server.py')
+    spec = importlib.util.spec_from_file_location('simple_server', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert hasattr(module, 'run')

--- a/tests/test_upload_bot_extended.py
+++ b/tests/test_upload_bot_extended.py
@@ -1,0 +1,60 @@
+import json
+import importlib.util
+import types
+import os
+import sys
+import subprocess
+import shutil
+
+
+spec = importlib.util.spec_from_file_location(
+    "telegram_upload_bot",
+    os.path.join("scripts", "telegram_upload_bot.py"),
+)
+telegram = types.ModuleType("telegram")
+telegram.Update = object
+telegram.InlineKeyboardButton = object
+telegram.InlineKeyboardMarkup = object
+telegram.ext = types.ModuleType("telegram.ext")
+for name in [
+    "ApplicationBuilder",
+    "CallbackQueryHandler",
+    "CommandHandler",
+    "ConversationHandler",
+    "MessageHandler",
+]:
+    setattr(telegram.ext, name, object())
+telegram.ext.ContextTypes = types.SimpleNamespace(DEFAULT_TYPE=object())
+telegram.ext.filters = types.SimpleNamespace(ALL=object())
+sys.modules["telegram"] = telegram
+sys.modules["telegram.ext"] = telegram.ext
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+class Dummy:
+    def __init__(self):
+        self.stdout = ""
+
+
+def test_find_unresolved_includes_story(tmp_path, monkeypatch):
+    items = tmp_path / "items.json"
+    story = tmp_path / "story_events.json"
+    json.dump([{"id": "i1", "name": "Item", "image": ""}], items.open("w"))
+    json.dump([{"id": "s1", "name": "Story", "image": ""}], story.open("w"))
+    monkeypatch.setattr(module, "DATA_FILES", [str(items), str(story)])
+    unresolved = module.find_unresolved()
+    assert (str(story), "s1", "Story") in unresolved
+    assert (str(items), "i1", "Item") in unresolved
+
+
+def test_commit_and_pr_runs_gh(monkeypatch):
+    calls = []
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(cmd)
+        return Dummy()
+
+    monkeypatch.setattr(subprocess, 'run', fake_run)
+    monkeypatch.setattr(shutil, 'which', lambda x: '/usr/bin/gh')
+    module.commit_and_pr('img.png', 'data.json', 'id1')
+    assert any(cmd[0] == 'gh' for cmd in calls)


### PR DESCRIPTION
## Summary
- include `story_events.json` when scanning for missing images
- add a simple HTTP server for local testing
- document the new features
- test upload bot helpers and server module

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_686bf428e4308330a688e467e85fdde7