### PR TITLE
Fix server path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.41.48] - 2025-07-07
+### Fixed
+- `scripts/simple_server.py` resolves the repository path using `os.path.abspath`.
 ## [0.41.47] - 2025-07-07
 ### Added
 - Story events are now included when the Telegram upload bot scans for missing images.

--- a/scripts/simple_server.py
+++ b/scripts/simple_server.py
@@ -7,7 +7,8 @@ import os
 
 
 def run(port: int = 8000) -> None:
-    os.chdir(os.path.dirname(os.path.dirname(__file__)))
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    os.chdir(repo_root)
     handler = http.server.SimpleHTTPRequestHandler
     with socketserver.TCPServer(("", port), handler) as httpd:
         print(f"Serving at http://localhost:{port}")


### PR DESCRIPTION
## Summary
- fix simple_server os.chdir path resolution using abspath
- document the fix in CHANGELOG

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686bff5d642c8330be42f3d42eab893d