### PR TITLE
Fix story IDs and homes in upload bot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.41.51] - 2025-07-07
+### Added
+- Telegram upload bot displays story event IDs when listing unresolved entries and
+  supports adding images for homes.
 ## [0.41.50] - 2025-07-07
 ### Added
 - Resource names in retreat logs now respect language translations.

--- a/README.md
+++ b/README.md
@@ -156,8 +156,9 @@ Open `http://localhost:8000` in your browser to play without deploying.
 
 For manual asset contributions a small Telegram bot can collect images and
 automate pull requests. The bot lists unresolved entries from the data files,
-including story events,
-accepts an uploaded image, commits the change and opens (or updates) a PR. See
+including homes and story events, displaying the entry name or identifier so
+missing assets are easy to find. After selecting an entry the bot accepts an
+uploaded image, commits the change and opens (or updates) a PR. See
 `docs/telegram_upload_bot.md` for a full overview.
 
 #### 12. Future Extensions

--- a/docs/telegram_upload_bot.md
+++ b/docs/telegram_upload_bot.md
@@ -6,7 +6,8 @@ these steps:
 1. **Repository Pull** – executes `git pull origin main` and reports failures.
 2. **Parse & Filter** – scans item, encounter, home and story event JSON files
    for entries with missing image paths and verifies the image files are present.
-3. **Present Options** – shows unresolved items in batches of ten for selection.
+3. **Present Options** – shows unresolved items in batches of ten for selection,
+   using the entry name or ID so story events without a name remain identifiable.
 4. **Receive Upload** – validates the uploaded file size and type before saving
    to `assets/user_uploaded/`.
    The saved path is normalized to use forward slashes so JSON entries remain

--- a/scripts/telegram_upload_bot.py
+++ b/scripts/telegram_upload_bot.py
@@ -58,7 +58,13 @@ def find_unresolved() -> List[Tuple[str, str, str]]:
         for entry in entries:
             img = entry.get('image')
             if not img or not os.path.exists(img):
-                unresolved.append((path, entry.get('id', ''), entry.get('name', 'Unnamed')))
+                name = (
+                    entry.get('name')
+                    or entry.get('textKey')
+                    or entry.get('text')
+                    or entry.get('id', 'Unnamed')
+                )
+                unresolved.append((path, entry.get('id', ''), name))
     return unresolved
 
 

--- a/tests/test_upload_bot_extended.py
+++ b/tests/test_upload_bot_extended.py
@@ -58,3 +58,23 @@ def test_commit_and_pr_runs_gh(monkeypatch):
     monkeypatch.setattr(shutil, 'which', lambda x: '/usr/bin/gh')
     module.commit_and_pr('img.png', 'data.json', 'id1')
     assert any(cmd[0] == 'gh' for cmd in calls)
+
+
+def test_find_unresolved_story_uses_fallback(tmp_path, monkeypatch):
+    story = tmp_path / "story_events.json"
+    json.dump([
+        {"id": "s2", "textKey": "storyKey", "image": ""}
+    ], story.open("w"))
+    monkeypatch.setattr(module, "DATA_FILES", [str(story)])
+    unresolved = module.find_unresolved()
+    assert (str(story), "s2", "storyKey") in unresolved
+
+
+def test_find_unresolved_includes_homes(tmp_path, monkeypatch):
+    homes = tmp_path / "homes.json"
+    json.dump([
+        {"id": "h1", "name": "Home", "image": ""}
+    ], homes.open("w"))
+    monkeypatch.setattr(module, "DATA_FILES", [str(homes)])
+    unresolved = module.find_unresolved()
+    assert (str(homes), "h1", "Home") in unresolved


### PR DESCRIPTION
## Summary
- show story event IDs when their images are missing
- extend Telegram upload bot docs
- clarify README description of the upload bot
- test that the bot handles homes and unnamed story events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686c5c7543848330b10c81805ec8e412