### PR TITLE
Fix #104: restore Encounter objects after load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [0.41.58] - 2025-07-08
+### Fixed
+- Saved adventure encounters are now restored as `Encounter` objects when loading the game.
+
 ## [0.41.57] - 2025-07-08
 ### Fixed
 - Alert now appears whenever resource data fails to load, not just from the `file:` protocol.

--- a/js/main.js
+++ b/js/main.js
@@ -276,6 +276,9 @@ const SaveSystem = {
                 if (Array.isArray(State.adventureSlots)) {
                     State.adventureSlots.forEach(s => {
                         if (s.active === undefined) s.active = false;
+                        if (s.encounter && typeof s.encounter.getLootChance !== 'function') {
+                            s.encounter = new Encounter(s.encounter);
+                        }
                     });
                 }
                 if (State.inventorySlotCount === undefined) {


### PR DESCRIPTION
## Summary
- rehydrate saved encounters so tooltips work
- update changelog

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686d9c06f57c83309cc5c53e68daade9