### PR TITLE
Refactor age handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## [0.41.63] - 2025-07-09
+### Added
+- Dedicated age system module with pub/sub events.
+### Changed
+- Furniture decay and prestige triggers listen to age events.
+- formatCost moved to Utils and used by home and furniture modules.
+
 ## [0.41.62] - 2025-07-09
 ### Changed
 - Split major systems into separate scripts.

--- a/index.html
+++ b/index.html
@@ -155,6 +155,7 @@
     <script src="js/slot.js"></script>
     <script src="js/pubsub.js"></script>
     <script src="js/state.js"></script>
+    <script src="js/age_system.js"></script>
     <script src="js/encounter.js"></script>
     <script src="js/items.js"></script>
     <script src="js/updates.js"></script>

--- a/js/age_system.js
+++ b/js/age_system.js
@@ -1,0 +1,22 @@
+const AgeSystem = {
+    daysPerYear: 365,
+    addDays(days) {
+        State.age.days += days;
+        if (State.age.days >= this.daysPerYear) {
+            State.age.years += Math.floor(State.age.days / this.daysPerYear);
+            State.age.days = State.age.days % this.daysPerYear;
+        }
+        if (typeof PubSub !== 'undefined') {
+            PubSub.publish('age:advanced', days);
+        }
+        if (!State.prestiging && State.age.years >= State.age.max) {
+            if (typeof PubSub !== 'undefined') {
+                PubSub.publish('age:maxReached');
+            }
+        }
+    }
+};
+
+if (typeof module !== 'undefined') {
+    module.exports = { AgeSystem };
+}

--- a/js/furniture.js
+++ b/js/furniture.js
@@ -12,16 +12,6 @@ class Furniture {
     }
 }
 
-function formatCost(cost = {}) {
-    return Object.entries(cost)
-        .map(([id, qty]) => {
-            const item = ItemGenerator.itemList.find(i => i.id === id);
-            const name = item ? item.name : id;
-            return `${qty}x ${name}`;
-        })
-        .join(', ');
-}
-
 const FurnitureSystem = {
     furniture: [],
     listEl: null,
@@ -46,7 +36,7 @@ const FurnitureSystem = {
         this.furniture.forEach(f => {
             const li = document.createElement('li');
             li.textContent = f.name;
-            li.dataset.tooltip = `${f.description}\nCost: ${formatCost(f.cost)}`;
+            li.dataset.tooltip = `${f.description}\nCost: ${Utils.formatCost(f.cost)}`;
             li.addEventListener('click', () => this.purchase(f.id));
             this.listEl.appendChild(li);
         });

--- a/js/home.js
+++ b/js/home.js
@@ -10,16 +10,6 @@ class Home {
     }
 }
 
-function formatCost(cost = {}) {
-    return Object.entries(cost)
-        .map(([id, qty]) => {
-            const item = ItemGenerator.itemList.find(i => i.id === id);
-            const name = item ? item.name : id;
-            return `${qty}x ${name}`;
-        })
-        .join(', ');
-}
-
 const HomeSystem = {
     homes: [],
     listEl: null,
@@ -45,7 +35,7 @@ const HomeSystem = {
             const li = document.createElement('li');
             li.textContent = h.name;
             li.dataset.homeId = h.id;
-            li.dataset.tooltip = `${h.description}\nCost: ${formatCost(h.cost)}`;
+            li.dataset.tooltip = `${h.description}\nCost: ${Utils.formatCost(h.cost)}`;
             li.setAttribute('draggable', 'true');
             li.addEventListener('dragstart', e => {
                 li.classList.add('dragging');
@@ -98,7 +88,7 @@ const HomeSystem = {
         } else {
             slotEl.style.backgroundImage = 'none';
         }
-        slotEl.dataset.tooltip = `${home.description}\nCost: ${formatCost(home.cost)}`;
+        slotEl.dataset.tooltip = `${home.description}\nCost: ${Utils.formatCost(home.cost)}`;
         RARITY_CLASSES.forEach(r => slotEl.classList.remove(`rarity-${r}`));
         slotEl.classList.add(`rarity-${home.rarity}`);
         this.updateFurnitureSlots(home.furnitureSlots);

--- a/js/main.js
+++ b/js/main.js
@@ -41,30 +41,23 @@ function setupPubSub() {
         const enc = EncounterGenerator.encounters.find(e => e.id === id);
         if (enc) enc.locked = false;
     });
+    PubSub.subscribe('age:advanced', days => {
+        if (typeof FurnitureSystem !== 'undefined' && FurnitureSystem.decay) {
+            FurnitureSystem.decay(days);
+        }
+    });
+    PubSub.subscribe('age:maxReached', () => {
+        if (!State.prestiging) {
+            State.prestiging = true;
+            SaveSystem.prestige();
+        }
+    });
 }
 
 
 
 
 
-
-const AgeSystem = {
-    daysPerYear: 365,
-    addDays(days) {
-        State.age.days += days;
-        if (State.age.days >= this.daysPerYear) {
-            State.age.years += Math.floor(State.age.days / this.daysPerYear);
-            State.age.days = State.age.days % this.daysPerYear;
-        }
-        if (typeof FurnitureSystem !== 'undefined' && FurnitureSystem.decay) {
-            FurnitureSystem.decay(days);
-        }
-        if (!State.prestiging && State.age.years >= State.age.max) {
-            State.prestiging = true;
-            SaveSystem.prestige();
-        }
-    }
-};
 
 function applyPrestigeBonuses() {
     STAT_KEYS.forEach(k => {

--- a/js/utils.js
+++ b/js/utils.js
@@ -15,6 +15,23 @@ const Utils = {
             if (r <= 0) return items[i];
         }
         return items[items.length - 1];
+    },
+
+    /**
+     * Format a cost object into a readable string.
+     * @param {Object} cost
+     * @returns {string}
+     */
+    formatCost(cost = {}) {
+        return Object.entries(cost)
+            .map(([id, qty]) => {
+                const item = typeof ItemGenerator !== 'undefined' && ItemGenerator.itemList
+                    ? ItemGenerator.itemList.find(i => i.id === id)
+                    : null;
+                const name = item ? item.name : id;
+                return `${qty}x ${name}`;
+            })
+            .join(', ');
     }
 };
 

--- a/tests/test_age_system.py
+++ b/tests/test_age_system.py
@@ -1,0 +1,10 @@
+import os
+
+
+def test_age_system_events():
+    path = os.path.join('js', 'age_system.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'const AgeSystem' in text
+    assert "age:advanced" in text
+    assert "age:maxReached" in text

--- a/tests/test_format_cost.py
+++ b/tests/test_format_cost.py
@@ -1,0 +1,15 @@
+import os
+
+
+def test_format_cost_util():
+    with open(os.path.join('js', 'utils.js')) as f:
+        text = f.read()
+    assert 'formatCost' in text
+    with open(os.path.join('js', 'home.js')) as f:
+        home_text = f.read()
+    assert 'Utils.formatCost' in home_text
+    assert 'function formatCost' not in home_text
+    with open(os.path.join('js', 'furniture.js')) as f:
+        furn_text = f.read()
+    assert 'Utils.formatCost' in furn_text
+    assert 'function formatCost' not in furn_text


### PR DESCRIPTION
## Summary
- create `AgeSystem` module emitting age events
- hook furniture decay and prestige actions to pub/sub
- consolidate duplicated `formatCost` helper into `Utils`
- update modules to use the shared utility
- test new age system and cost utility

## Testing
- `python3 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e92d9fdf48330b4d3eca62e708b3d