### PR TITLE
Refactor slot setup to use BaseSlot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [0.41.64] - 2025-07-09
+### Changed
+- Action and adventure slot creation now uses the `BaseSlot` class.
+- Selecting a home publishes a `home:changed` event.
+
 ## [0.41.63] - 2025-07-09
 ### Added
 - Dedicated age system module with pub/sub events.

--- a/docs/refactoring_task.md
+++ b/docs/refactoring_task.md
@@ -25,3 +25,4 @@ This incremental approach will gradually reduce the size of `main.js` and clarif
 
 ### Progress
 As of version 0.17.0, the `engine.js` module also manages aging and experience generation. `DeltaEngine` computes per-second changes for stats, resources, age and action experience, applying them with a multiplier so game speed modifiers can adjust progression. Version 0.18.0 extends this system to encounter progress so all time based systems share a single timing engine. Version 0.20.0 introduces a dedicated `state.js` module that defines the global `State` object and helper functions. Version 0.19.0 introduces a `bonus.js` module that centralizes additive, multiplicative and exponential modifiers for stats and resources and allows cost divisors for consumptions.
+Version 0.41.64 switches action and adventure slot creation to the reusable `BaseSlot` class and emits a `home:changed` event when selecting a dwelling.

--- a/js/home.js
+++ b/js/home.js
@@ -66,6 +66,9 @@ const HomeSystem = {
         State.homeId = id;
         this.updateSlot();
         SaveSystem.save();
+        if (typeof PubSub !== 'undefined') {
+            PubSub.publish('home:changed', id);
+        }
     },
     updateSlot() {
         if (!this.slotContainer) return;

--- a/js/main.js
+++ b/js/main.js
@@ -322,23 +322,10 @@ function setupSlots() {
         State.slots = State.slots.slice(0, State.slotCount);
     }
     for (let i = 0; i < State.slotCount; i++) {
-        const slotEl = document.createElement('div');
-        slotEl.className = 'slot';
+        const slot = new BaseSlot();
+        const slotEl = slot.el;
         slotEl.dataset.slot = i;
         slotEl.dataset.tooltip = 'Drag an action here';
-
-        const label = document.createElement('span');
-        label.className = 'label';
-        slotEl.appendChild(label);
-
-        const wrapper = document.createElement('div');
-        wrapper.className = 'progress-wrapper';
-        const prog = document.createElement('progress');
-        prog.value = 0;
-        prog.max = 100;
-        wrapper.appendChild(prog);
-        slotEl.appendChild(wrapper);
-
         container.appendChild(slotEl);
         updateSlotUI(i);
     }
@@ -358,22 +345,9 @@ function setupAdventureSlots() {
     }
     for (let i = 0; i < State.adventureSlotCount; i++) {
         if (State.adventureSlots[i].active === undefined) State.adventureSlots[i].active = false;
-        const slotEl = document.createElement('div');
-        slotEl.className = 'slot';
+        const slot = new BaseSlot();
+        const slotEl = slot.el;
         slotEl.dataset.slot = i;
-
-        const label = document.createElement('span');
-        label.className = 'label';
-        slotEl.appendChild(label);
-
-        const wrapper = document.createElement('div');
-        wrapper.className = 'progress-wrapper';
-        const prog = document.createElement('progress');
-        prog.value = 0;
-        prog.max = 1;
-        wrapper.appendChild(prog);
-        slotEl.appendChild(wrapper);
-
         container.appendChild(slotEl);
         updateAdventureSlotUI(i);
     }


### PR DESCRIPTION
## Summary
- reuse `BaseSlot` when building action and adventure slots
- emit a `home:changed` event from `HomeSystem`
- note refactor in docs and changelog

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_686e98c2a8e88330ae5b19a411dae7fa