### PR TITLE
Docs: clarify changelog update policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,8 @@
 - Update `CHANGELOG.md` with a short note describing each change
 - Add new entries to the **top** of the changelog so the latest changes appear first
 - Use the current date in `YYYY-MM-DD` format when creating new changelog entries
+- Unless a task explicitly requires a version bump, update the notes under the
+  latest version header instead of adding a new one
 
 ## Review Protocol
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### Changed
 - Action and adventure slot creation now uses the `BaseSlot` class.
 - Selecting a home publishes a `home:changed` event.
+- Documented changelog update policy in `AGENTS.md` and added a section to
+  `README.md` describing the process.
 
 ## [0.41.63] - 2025-07-09
 ### Added

--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ uploaded image, commits the change and opens (or updates) a PR. See
 * Player avatar or magical tower interface (for immersion)
 * Evaluate scripting to automatically generate new encounter JSON entries
 
+#### 13. Changelog Updates
+
+All code and documentation changes must be reflected in `CHANGELOG.md`. When
+adding notes, update the bullet list under the latest version at the top of the
+file rather than creating a new version header. Only introduce a new version
+section when an issue or task specifically calls for it. Use dates in
+`YYYY-MM-DD` format.
+
 ---
 
 Next step: expand automation and prestige mechanics.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -4,3 +4,5 @@
 - Reflect new features and progress in `README.md` and related docs.
 - Whenever documentation is updated, add a concise entry to the root `CHANGELOG.md` summarizing the change.
 - Use the current date in `YYYY-MM-DD` format when adding changelog entries.
+- Unless specifically requested, append documentation notes to the latest
+  changelog version rather than creating a new version entry.


### PR DESCRIPTION
## Summary
- document changelog update process in README
- add policy in AGENTS guidelines
- update docs/AGENTS with the same rule
- note the policy in CHANGELOG

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_686ec28ef7288330910fc108c0c0b017