### PR TITLE
Add architecture guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,18 @@
 - Prefer descriptive variable and function names
 - Keep code modular and comment important sections
 - When creatimg new keys in json files do not reuse existing image sources
+
 - Prefer using `UIHandler` for new UI sections instead of manual DOM creation
+
+## Architecture Guidelines
+- Separate game logic, UI, and data into dedicated modules.
+- Place game logic modules in `js/` as single-purpose files and export them for testing.
+- Communicate across modules using the `PubSub` event bus rather than direct references.
+- Modify the global `State` object only through helper functions in `state.js` or system APIs.
+- UI modules should read state and publish events but avoid altering `State` directly.
+- Load gameplay values from JSON files under `data/` instead of hardcoding them.
+- Add unit tests in `tests/` when introducing or changing modules to keep coverage above 80%.
+
 
 ## Testing Protocols
 

--- a/data/AGENTS.md
+++ b/data/AGENTS.md
@@ -1,0 +1,8 @@
+# Data File Guidelines
+
+- Use JSON format with 4 spaces for indentation and double quotes for all keys and strings.
+- Keys are written in lowerCamelCase.
+- When adding new entries with an `image` field, provide a unique asset path in `assets/` and do not reuse existing images.
+- Update translation files under `data/lang/` for any new `name` or `description` fields.
+- Keep JSON entries purely declarative; do not mix code or comments.
+- Avoid trailing commas and keep the structure consistent with existing files.

--- a/js/AGENTS.md
+++ b/js/AGENTS.md
@@ -1,0 +1,10 @@
+# JavaScript Guidelines
+
+- Each file should define a single module focused on one system (e.g. AgeSystem, SaveSystem).
+- Use object literals or classes and export them with `module.exports` when running under Node so tests can import them.
+- Document dependencies and exported functions at the top of the file.
+- Interact with other modules via the `PubSub` event bus. Avoid global variables other than the `State` object.
+- Non-UI modules must not manipulate the DOM directly; UI logic lives in `ui.js`, `ui_handler.js`, or other UI modules.
+- Keep functions short and prefer pure functions where possible.
+- Use 4-space indentation, semicolons, and camelCase naming for variables and functions.
+- Include or update tests in `tests/` whenever modules change.


### PR DESCRIPTION
## Summary
- define architecture guidelines in main AGENTS.md
- add js/AGENTS.md for module conventions
- add data/AGENTS.md for JSON data rules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686fb3d85c148330946aa54c5ac9205a