### PR TITLE
Fix chip tab unlock condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Selecting a home publishes a `home:changed` event.
 - Documented changelog update policy in `AGENTS.md` and added a section to
   `README.md` describing the process.
-- Chip tab remains locked until the bandits ambush is completed once.
+- Chip tab remains hidden until the Bandits Ambush story event is cleared.
 - Added `requirements.txt` and updated documentation on installing Python dependencies.
 - Split home, furniture and research modules into data and UI components.
 - Moved `InventoryUI` to its own script under `js/ui/` and added UI guidelines.

--- a/data/ui.json
+++ b/data/ui.json
@@ -8,6 +8,6 @@
        {"id": "belongings", "name": "Belongings", "hidden": false, "locked": false}
      ]},
     {"id": "automation", "name": "Automation", "hidden": true, "locked": false},
-    {"id": "chip", "name": "Chip", "hidden": false, "locked": true}
+    {"id": "chip", "name": "Chip", "hidden": true, "locked": false}
   ]
 }

--- a/docs/refactoring_task.md
+++ b/docs/refactoring_task.md
@@ -57,7 +57,7 @@ Version 0.41.64 switches action and adventure slot creation to the reusable `Bas
 ### Design Updates
 - Modular system for core managers and UI components.
 - PubSub events power age progression and furniture decay.
-- Chip tab locked until the bandits ambush is completed.
+- Chip tab remains hidden until the Bandits Ambush story event is cleared.
 
 ### Dependencies
 - Python packages now installed with `pip install -r requirements.txt`.

--- a/js/tab_manager.js
+++ b/js/tab_manager.js
@@ -13,6 +13,11 @@ const TabManager = {
             const adv = this.tabs.find(t => t.id === 'adventure');
             if (adv) adv.hidden = false;
         }
+        // Show the chip tab if the bandit ambush story event was cleared
+        if (State.banditsAmbushSeen) {
+            const chip = this.tabs.find(t => t.id === 'chip');
+            if (chip) chip.hidden = false;
+        }
         this.tabs.forEach(tab => {
             if (tab.hidden) return;
             this._createButton(tab);


### PR DESCRIPTION
## Summary
- hide the chip tab until the Bandits Ambush story event is cleared
- reveal chip tab if `banditsAmbushSeen` flag is set
- document the new unlock logic in refactoring notes and changelog

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687104da454c8330bf4bc4baf55d84b2