### PR TITLE
Fix #52: complete missing JSON fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.64] - 2025-07-09
 ### Changed
+- Fixed invalid image fields in `actions.json` that prevented initialization.
 - Docs: update module responsibilities in README.md
 - Added unit tests for `SaveSystem`, `SoftCapSystem` and `TabManager` to keep
   coverage above 80%.

--- a/data/actions.json
+++ b/data/actions.json
@@ -77,7 +77,7 @@
   {
     "id": "woodworking",
     "name": "Woodworking",
-    "image": ,
+    "image": "assets/enc/woodworking.png",
     "hidden": true,
     "level": 1,
     "exp": 0,
@@ -104,7 +104,7 @@
   {
     "id": "sleep",
     "name": "Sleep",
-    "image": ,
+    "image": "assets/enc/sleep.png",
     "hidden": true,
     "level": 1,
     "exp": 0,


### PR DESCRIPTION
## Summary
- fix syntax error in `actions.json` by adding missing image paths
- document the fix in the changelog

## Testing
- `pytest --maxfail=1 -q`
- `pytest --cov=. -q`


------
https://chatgpt.com/codex/tasks/task_e_68719ba432a8833099b16da02b5a9762