### PR TITLE
Implement furniture durability bar and slot clearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## [0.41.64] - 2025-07-09
 ### Changed
+- Furniture slots now show durability progress and related actions consume it.
+- Actions tied to destroyed furniture are removed from active slots.
 - Fixed invalid image fields in `actions.json` that prevented initialization.
 - Docs: update module responsibilities in README.md
 - Added unit tests for `SaveSystem`, `SoftCapSystem` and `TabManager` to keep

--- a/js/furniture.js
+++ b/js/furniture.js
@@ -45,6 +45,7 @@ const FurnitureSystem = {
             if (!def) return false;
             if (def.unlocks.includes(actionId)) {
                 f.durability -= seconds * DURABILITY_USE_RATE;
+                if (f.durability < 0) f.durability = 0;
             }
             if (f.durability > 0) return true;
             changed = true;
@@ -52,9 +53,12 @@ const FurnitureSystem = {
             return false;
         });
         setState('furniture', updated);
-        if (changed && typeof PubSub !== 'undefined') {
-            removedUnlocks.forEach(a => PubSub.publish('lock:action', a));
-            PubSub.publish('furniture:updated');
+        if (typeof PubSub !== 'undefined') {
+            PubSub.publish('furniture:durabilityChanged');
+            if (changed) {
+                removedUnlocks.forEach(a => PubSub.publish('lock:action', a));
+                PubSub.publish('furniture:updated');
+            }
         }
     }
 };

--- a/js/pubsub.js
+++ b/js/pubsub.js
@@ -68,6 +68,16 @@ function initPubSub() {
             actions[id].locked = true;
             if (selectedActionId === id) selectedActionId = null;
             updateTaskList();
+            State.slots.forEach((slot, i) => {
+                if (slot.actionId === id) {
+                    slot.actionId = null;
+                    slot.progress = 0;
+                    slot.text = '';
+                    if (typeof updateSlotUI === 'function') {
+                        updateSlotUI(i);
+                    }
+                }
+            });
         }
     });
     PubSub.subscribe('unlock:encounter', id => {

--- a/js/ui/home.js
+++ b/js/ui/home.js
@@ -2,6 +2,7 @@ const HomeUI = {
     listEl: null,
     slotContainer: null,
     furnitureContainer: null,
+    furnitureSlots: [],
     init() {
         this.listEl = document.getElementById('home-list');
         this.slotContainer = document.getElementById('home-slot');
@@ -13,6 +14,7 @@ const HomeUI = {
         if (typeof PubSub !== 'undefined') {
             PubSub.subscribe('home:changed', () => this.updateSlot());
             PubSub.subscribe('furniture:updated', () => this.updateSlot());
+            PubSub.subscribe('furniture:durabilityChanged', () => this.updateDurability());
         }
     },
     renderList() {
@@ -74,8 +76,10 @@ const HomeUI = {
     updateFurnitureSlots(count = 0) {
         if (!this.furnitureContainer) return;
         this.furnitureContainer.innerHTML = '';
+        this.furnitureSlots = [];
         for (let i = 0; i < count; i++) {
             const slot = new BaseSlot();
+            this.furnitureSlots.push(slot);
             const data = State.furniture[i];
             if (data) {
                 const furn = FurnitureSystem.furniture.find(f => f.id === data.id);
@@ -83,10 +87,31 @@ const HomeUI = {
                     slot.setLabel(furn.name);
                     slot.setImage(furn.image);
                     slot.setTooltip(`${furn.description}\nDurability: ${data.durability}/${furn.durability}`);
+                    slot.setProgress(data.durability / furn.durability);
                 }
             }
             this.furnitureContainer.appendChild(slot.el);
         }
+    },
+
+    updateDurability() {
+        if (!this.furnitureContainer) return;
+        this.furnitureSlots.forEach((slot, i) => {
+            const data = State.furniture[i];
+            if (!data) {
+                slot.setProgress(0);
+                slot.setTooltip('');
+                slot.setLabel('');
+                slot.setImage(null);
+                return;
+            }
+            const furn = FurnitureSystem.furniture.find(f => f.id === data.id);
+            if (furn) {
+                const ratio = Math.max(data.durability, 0) / furn.durability;
+                slot.setProgress(ratio);
+                slot.setTooltip(`${furn.description}\nDurability: ${data.durability.toFixed(1)}/${furn.durability}`);
+            }
+        });
     }
 };
 

--- a/tests/test_furniture_durability.py
+++ b/tests/test_furniture_durability.py
@@ -1,0 +1,15 @@
+import os
+
+
+def test_furniture_durability_event():
+    path = os.path.join('js', 'furniture.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'furniture:durabilityChanged' in text
+
+
+def test_lock_action_clears_slot():
+    path = os.path.join('js', 'pubsub.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'State.slots.forEach' in text


### PR DESCRIPTION
## Summary
- update furniture durability UI so progress bars show current durability
- broadcast durability changes every tick
- clear slots when an action is locked due to broken furniture
- add tests for new event and slot clearing
- document durability logic in changelog

## Testing
- `pytest -q`
- `pytest --cov=./`

------
https://chatgpt.com/codex/tasks/task_e_68719e95e864833093bdffc987e5cce5