### PR TITLE
Decouple inventory logic from UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.64] - 2025-07-09
 ### Changed
+- Inventory updates now publish events instead of calling UI modules directly.
 - Furniture slots now show durability progress and related actions consume it.
 - Actions tied to destroyed furniture are removed from active slots.
 - Fixed invalid image fields in `actions.json` that prevented initialization.

--- a/js/items.js
+++ b/js/items.js
@@ -98,10 +98,6 @@ const Inventory = {
             updateState(['inventory', item.id, 'quantity'], q => q + 1);
         }
         SoftCapSystem.recalculateCaps(State.inventory);
-        InventoryUI.update();
-        if (typeof CharacterBackground !== 'undefined') {
-            CharacterBackground.update();
-        }
         if (typeof PubSub !== 'undefined') {
             PubSub.publish('item:added', item.id);
             PubSub.publish('inventory:changed', State.inventory);
@@ -113,10 +109,6 @@ const Inventory = {
         updateState(['inventory', id, 'quantity'], q => q - qty);
         if (State.inventory[id].quantity <= 0) deleteState(['inventory', id]);
         SoftCapSystem.recalculateCaps(State.inventory);
-        InventoryUI.update();
-        if (typeof CharacterBackground !== 'undefined') {
-            CharacterBackground.update();
-        }
         if (typeof PubSub !== 'undefined') {
             PubSub.publish('item:consumed', { id, quantity: qty });
             PubSub.publish('inventory:changed', State.inventory);

--- a/js/ui/char_bg.js
+++ b/js/ui/char_bg.js
@@ -8,6 +8,9 @@ const CharacterBackground = {
     container: null,
     init() {
         this.container = document.getElementById('left');
+        if (typeof PubSub !== 'undefined') {
+            PubSub.subscribe('inventory:changed', () => this.update());
+        }
         this.update();
     },
     update() {

--- a/js/ui/inventory.js
+++ b/js/ui/inventory.js
@@ -3,6 +3,9 @@
 const InventoryUI = {
     init() {
         this.container = document.getElementById('inventory-slots');
+        if (typeof PubSub !== 'undefined') {
+            PubSub.subscribe('inventory:changed', () => this.update());
+        }
         this.update();
     },
     update() {

--- a/tests/test_pubsub_usage.py
+++ b/tests/test_pubsub_usage.py
@@ -17,3 +17,9 @@ def test_pubsub_item_events_present():
     with open(os.path.join('js', 'items.js')) as f:
         text = f.read()
     assert "item:added" in text and "item:consumed" in text
+
+
+def test_inventory_ui_subscribes_to_changes():
+    with open(os.path.join('js', 'ui', 'inventory.js')) as f:
+        text = f.read()
+    assert "inventory:changed" in text


### PR DESCRIPTION
## Summary
- trigger `inventory:changed` events in inventory module
- update UI modules to listen for inventory changes
- test that inventory UI subscribes to events
- document decoupling in changelog

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_6872b42ff1b48330b49151ce63cb498a