### PR TITLE
Fix furniture action cleanup and show durability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+## [0.41.65] - 2025-07-13
+### Fixed
+- Progress bars on furniture slots now display current and maximum durability.
+- Active actions are immediately removed if their supporting furniture breaks.
+
 ## [0.41.64] - 2025-07-09
 ### Changed
 - Inventory updates now publish events instead of calling UI modules directly.

--- a/css/styles.css
+++ b/css/styles.css
@@ -311,6 +311,20 @@ body.left-collapsed #left {
     display: block;
 }
 
+.progress-wrapper .progress-text {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    pointer-events: none;
+    color: #fff;
+}
+
 .slot .label {
     position: absolute;
     top: 0;

--- a/js/action_engine.js
+++ b/js/action_engine.js
@@ -16,8 +16,10 @@ const ActionEngine = {
             if (!slot.actionId) return;
             if (typeof FurnitureSystem !== 'undefined' && FurnitureSystem.use) {
                 FurnitureSystem.use(slot.actionId, delta * State.time);
+                if (!slot.actionId) return; // action may be locked and removed
             }
             const action = actions[slot.actionId];
+            if (!action) return;
             slot.progress = action.exp / action.expToNext;
             updateSlotUI(i);
         });

--- a/js/slot.js
+++ b/js/slot.js
@@ -12,6 +12,9 @@ class BaseSlot {
             this.progress.value = 0;
             this.progress.max = 1;
             this.progressWrapper.appendChild(this.progress);
+            this.progressText = document.createElement('span');
+            this.progressText.className = 'progress-text';
+            this.progressWrapper.appendChild(this.progressText);
             this.el.appendChild(this.progressWrapper);
         } else {
             this.progress = null;
@@ -35,8 +38,9 @@ class BaseSlot {
         this.el.dataset.tooltip = text || '';
     }
 
-    setProgress(value) {
+    setProgress(value, text) {
         if (this.progress) this.progress.value = value;
+        if (this.progressText) this.progressText.textContent = text || '';
     }
 }
 

--- a/js/ui/home.js
+++ b/js/ui/home.js
@@ -87,7 +87,8 @@ const HomeUI = {
                     slot.setLabel(furn.name);
                     slot.setImage(furn.image);
                     slot.setTooltip(`${furn.description}\nDurability: ${data.durability}/${furn.durability}`);
-                    slot.setProgress(data.durability / furn.durability);
+                    slot.setProgress(data.durability / furn.durability,
+                        `${data.durability}/${furn.durability}`);
                 }
             }
             this.furnitureContainer.appendChild(slot.el);
@@ -99,7 +100,7 @@ const HomeUI = {
         this.furnitureSlots.forEach((slot, i) => {
             const data = State.furniture[i];
             if (!data) {
-                slot.setProgress(0);
+                slot.setProgress(0, '');
                 slot.setTooltip('');
                 slot.setLabel('');
                 slot.setImage(null);
@@ -108,7 +109,8 @@ const HomeUI = {
             const furn = FurnitureSystem.furniture.find(f => f.id === data.id);
             if (furn) {
                 const ratio = Math.max(data.durability, 0) / furn.durability;
-                slot.setProgress(ratio);
+                slot.setProgress(ratio,
+                    `${data.durability.toFixed(1)}/${furn.durability}`);
                 slot.setTooltip(`${furn.description}\nDurability: ${data.durability.toFixed(1)}/${furn.durability}`);
             }
         });


### PR DESCRIPTION
## Summary
- remove active slot actions when furniture breaks during ticks
- show current/max durability on furniture progress bars
- style progress bar text overlay

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873c5985f5c83309d58e1e3e47f8eb5