### PR TITLE
Fix #48: default Rest action for empty slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## [0.41.66] - 2025-07-14
+### Changed
+- Empty action slots now default to the Rest action.
+
 ## [0.41.65] - 2025-07-13
 ### Fixed
 - Progress bars on furniture slots now display current and maximum durability.

--- a/js/pubsub.js
+++ b/js/pubsub.js
@@ -70,7 +70,7 @@ function initPubSub() {
             updateTaskList();
             State.slots.forEach((slot, i) => {
                 if (slot.actionId === id) {
-                    slot.actionId = null;
+                    slot.actionId = State.defaultActionId;
                     slot.progress = 0;
                     slot.text = '';
                     if (typeof updateSlotUI === 'function') {

--- a/js/save_system.js
+++ b/js/save_system.js
@@ -31,6 +31,7 @@ const SaveSystem = {
                 });
                 if (Array.isArray(State.slots)) {
                     State.slots.forEach(s => {
+                        if (!s.actionId) s.actionId = State.defaultActionId;
                         if (s.text === undefined) s.text = '';
                     });
                 } else {

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -38,7 +38,7 @@ function setupSlots() {
     if (!Array.isArray(State.slots)) setState('slots', []);
     if (State.slotCount === undefined) setState('slotCount', State.slots.length);
     while (State.slots.length < State.slotCount) {
-        pushState(['slots'], { actionId: null, progress: 0, blocked: false, text: '' });
+        pushState(['slots'], { actionId: State.defaultActionId, progress: 0, blocked: false, text: '' });
     }
     if (State.slots.length > State.slotCount) {
         setState('slots', State.slots.slice(0, State.slotCount));
@@ -126,12 +126,7 @@ function updateSlotUI(i) {
     const labelEl = slotEl.querySelector('.label');
     slotEl.classList.toggle('blocked', slot.blocked);
     if (!slot.actionId) {
-        progressEl.value = 0;
-        progressEl.max = 1;
-        labelEl.textContent = slot.text || '';
-        slotEl.style.backgroundImage = 'none';
-        slotEl.dataset.tooltip = 'Drag an action here';
-        return;
+        slot.actionId = State.defaultActionId;
     }
     const action = actions[slot.actionId];
     progressEl.max = 1;

--- a/js/state.js
+++ b/js/state.js
@@ -129,6 +129,7 @@ function mergeState(obj) {
 
 let STAT_KEYS = [];
 let RESOURCE_KEYS = [];
+const DEFAULT_ACTION_ID = 'rest';
 // Mapping from base stats to their prestige equivalents
 const PRESTIGE_MAP = {
     strength: 'constitution',
@@ -167,10 +168,11 @@ const State = {
     language: 'en',
     hideRarityEnabled: false,
     hideBelowRarity: 'rare',
+    defaultActionId: DEFAULT_ACTION_ID,
 };
 
 for (let i = 0; i < State.slotCount; i++) {
-    State.slots.push({ actionId: null, progress: 0, blocked: false, text: '' });
+    State.slots.push({ actionId: DEFAULT_ACTION_ID, progress: 0, blocked: false, text: '' });
 }
 
 for (let i = 0; i < State.adventureSlotCount; i++) {
@@ -222,6 +224,7 @@ if (typeof module !== 'undefined') {
         RESOURCE_KEYS,
         PRESTIGE_MAP,
         PRESTIGE_KEYS,
+        DEFAULT_ACTION_ID,
     };
 }
 


### PR DESCRIPTION
## Summary
- default empty slots to the Rest action
- keep Rest on locked actions
- export `DEFAULT_ACTION_ID` and add `defaultActionId` to `State`
- update changelog

## Testing
- `pip install -r requirements.txt`
- `pip install pytest pytest-cov`
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_6875594fa0dc8330b382712ebf3e9862