### PR TITLE
Implement default home and grid lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Updates can replace earlier encounters with improved tiers once purchased.
 - Purchase buttons highlight when an item is affordable.
 - Furniture durability values increased 100x so furnishings last longer before breaking.
+- Hut in the Woods now loads automatically and no longer shows in the available homes list.
+- Update, research and furniture buttons share the drag-and-drop style and appear in flexible columns.
 
 ## [0.41.65] - 2025-07-13
 ### Fixed

--- a/css/styles.css
+++ b/css/styles.css
@@ -193,9 +193,15 @@ body.left-collapsed #left {
     padding: 0;
 }
 
-#home-list {
+#home-list,
+#furniture-list,
+#research-list,
+#chip-list {
     list-style: none;
     padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    gap: 0.5rem;
 }
 
 #task-list li {
@@ -206,7 +212,10 @@ body.left-collapsed #left {
     border-radius: 4px;
 }
 
-#home-list li {
+#home-list li,
+#furniture-list li,
+#research-list li,
+#chip-list li {
     background: var(--task-bg);
     margin-bottom: 0.5rem;
     padding: 0.5rem;
@@ -218,7 +227,8 @@ body.left-collapsed #left {
     opacity: 0.5;
 }
 
-#home-list li.dragging {
+#home-list li.dragging,
+#chip-list li.dragging {
     opacity: 0.5;
 }
 

--- a/data/homes.json
+++ b/data/homes.json
@@ -3,6 +3,7 @@
     "id": "hut",
     "name": "Hut in the Woods",
     "rarity": "common",
+    "default": true,
     "image": "assets/homes/camp.png",
     "description": "A simple hut hidden among the trees.",
     "furnitureSlots": 1,

--- a/js/home.js
+++ b/js/home.js
@@ -21,6 +21,10 @@ const HomeSystem = {
             console.error('Failed to load homes', e);
             this.homes = [];
         }
+        const defaultHome = this.homes.find(h => h.default);
+        if (!State.homeId && defaultHome) {
+            setState('homeId', defaultHome.id);
+        }
     },
     setHome(id) {
         const home = this.homes.find(h => h.id === id);

--- a/js/ui/furniture.js
+++ b/js/ui/furniture.js
@@ -17,6 +17,9 @@ const FurnitureUI = {
             li.dataset.tooltip = `${f.description}\nCost: ${Utils.formatCost(f.cost)}`;
             if (Inventory.canAfford(f.cost)) li.classList.add('affordable');
             li.addEventListener('click', () => FurnitureSystem.purchase(f.id));
+            li.setAttribute('draggable', 'true');
+            li.addEventListener('dragstart', () => li.classList.add('dragging'));
+            li.addEventListener('dragend', () => li.classList.remove('dragging'));
             this.listEl.appendChild(li);
         });
     }

--- a/js/ui/home.js
+++ b/js/ui/home.js
@@ -20,6 +20,7 @@ const HomeUI = {
     renderList() {
         this.listEl.innerHTML = '';
         HomeSystem.homes.forEach(h => {
+            if (h.default) return;
             const li = document.createElement('li');
             li.textContent = h.name;
             li.dataset.homeId = h.id;

--- a/js/ui/research.js
+++ b/js/ui/research.js
@@ -20,6 +20,9 @@ const ResearchUI = {
                 li.classList.add('locked');
             } else {
                 li.addEventListener('click', () => ResearchSystem.purchase(r.id));
+                li.setAttribute('draggable', 'true');
+                li.addEventListener('dragstart', () => li.classList.add('dragging'));
+                li.addEventListener('dragend', () => li.classList.remove('dragging'));
             }
             this.listEl.appendChild(li);
         });


### PR DESCRIPTION
## Summary
- hide the hut home from the list and load it automatically
- style furniture, research and update lists like other draggable lists
- layout home, update, research and furniture items in flexible columns

## Testing
- `pytest -q`
- `pytest --cov=./`

------
https://chatgpt.com/codex/tasks/task_e_6876c71368908330b1f40d79976cb358