### PR TITLE
Fix furniture and update logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - Furniture durability values increased 100x so furnishings last longer before breaking.
 - Hut in the Woods now loads automatically and no longer shows in the available homes list.
 - Update, research and furniture buttons share the drag-and-drop style and appear in flexible columns.
+- Furniture highlights refresh on inventory changes, early furniture costs use wood instead of money,
+  completed updates disappear from the list, and locked encounters are skipped when choosing battles.
 
 ## [0.41.65] - 2025-07-13
 ### Fixed

--- a/data/furniture.json
+++ b/data/furniture.json
@@ -4,7 +4,7 @@
     "name": "Wooden Table",
     "image": "assets/furniture/wooden_table.png",
     "description": "A sturdy table for daily chores.",
-    "cost": {"money": 100},
+    "cost": {"wood_log": 10},
     "durability": 1000,
     "unlocks": ["woodworking"]
   },
@@ -13,7 +13,7 @@
     "name": "Comfy Bed",
     "image": "assets/furniture/comfy_bed.png",
     "description": "Rest well to recover faster.",
-    "cost": {"money": 200},
+    "cost": {"wood_log": 15},
     "durability": 2000,
     "unlocks": ["sleep"]
   }

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -153,6 +153,7 @@ const EncounterGenerator = {
         if (story) return story;
 
         const pool = this.encounters.filter(e => {
+            if (e.locked) return false;
             if ((e.minLevel || 0) > this.level) return false;
             // Recover is only triggered after retreats and should not be random
             if (e.id === 'recover') return false;

--- a/js/ui/furniture.js
+++ b/js/ui/furniture.js
@@ -6,6 +6,8 @@ const FurnitureUI = {
         this.render();
         if (typeof PubSub !== 'undefined') {
             PubSub.subscribe('furniture:updated', () => this.render());
+            // Re-render when inventory changes so affordable items highlight
+            PubSub.subscribe('inventory:changed', () => this.render());
         }
     },
     render() {

--- a/js/ui/updates.js
+++ b/js/ui/updates.js
@@ -17,6 +17,7 @@ const UpdateUI = {
     renderList() {
         this.listEl.innerHTML = '';
         UpdateSystem.updates.forEach(u => {
+            if (u.state === 'done') return; // hide completed upgrades
             const li = document.createElement('li');
             li.textContent = u.name;
             li.dataset.updateId = u.id;

--- a/tests/test_encounter_lock.py
+++ b/tests/test_encounter_lock.py
@@ -1,0 +1,6 @@
+import os
+
+def test_random_encounter_checks_locked():
+    with open(os.path.join('js', 'encounter.js')) as f:
+        text = f.read()
+    assert 'e.locked' in text

--- a/tests/test_pubsub_usage.py
+++ b/tests/test_pubsub_usage.py
@@ -23,3 +23,9 @@ def test_inventory_ui_subscribes_to_changes():
     with open(os.path.join('js', 'ui', 'inventory.js')) as f:
         text = f.read()
     assert "inventory:changed" in text
+
+
+def test_furniture_ui_updates_on_inventory_change():
+    with open(os.path.join('js', 'ui', 'furniture.js')) as f:
+        text = f.read()
+    assert "inventory:changed" in text


### PR DESCRIPTION
## Summary
- refresh furniture list when inventory changes to highlight affordable items
- skip locked encounters when generating random encounters
- hide finished updates from the updates list
- adjust early furniture costs to require wood instead of money
- test that furniture ui reacts to inventory and encounters check locked flag

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876dcf97a1083309589266c214d21c9