### PR TITLE
Refactor UI update polling into event-driven model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.66] - 2025-07-14
 ### Changed
+- UI updates now subscribe to events instead of polling every 200ms.
 - Home and update lists refresh when inventory changes.
 - Chip section heading renamed to "Updates" while tab name remains.
 - Empty action slots now default to the Rest action.

--- a/js/action_engine.js
+++ b/js/action_engine.js
@@ -23,7 +23,6 @@ const ActionEngine = {
             slot.progress = action.exp / action.expToNext;
             updateSlotUI(i);
         });
-        StorySystem.check();
         SoftCapSystem.apply();
         checkHealth();
         SaveSystem.save();

--- a/js/action_utils.js
+++ b/js/action_utils.js
@@ -66,6 +66,8 @@ function applyYield(base, mult, delta) {
 
 function gainExp(action, amount) {
     action.exp += amount;
+    const beforeLevel = action.level;
+    const beforeMastery = State.masteryPoints;
     while (action.exp >= action.expToNext) {
         action.exp -= action.expToNext;
         const oldTier = getActionTier(action.level);
@@ -75,6 +77,14 @@ function gainExp(action, amount) {
         if (newTier !== oldTier) {
             State.masteryPoints += 1;
             action.currentTier = newTier;
+        }
+    }
+    if (typeof PubSub !== 'undefined') {
+        if (action.level !== beforeLevel) {
+            PubSub.publish('action:levelUp', { id: action.id, level: action.level });
+        }
+        if (State.masteryPoints !== beforeMastery) {
+            PubSub.publish('mastery:changed', State.masteryPoints);
         }
     }
 }

--- a/js/adventure_engine.js
+++ b/js/adventure_engine.js
@@ -50,10 +50,14 @@ const AdventureEngine = {
             return;
         }
         if (slot.progress >= 1) {
+            const completedId = slot.encounter.id;
             EncounterGenerator.resolve(slot.encounter);
             slot.active = false;
             slot.encounter = null;
             slot.progress = 0;
+            if (typeof PubSub !== 'undefined') {
+                PubSub.publish('encounter:complete', completedId);
+            }
             updateState('encounterStreak', s => s + 1);
             EncounterGenerator.updateProgressBar();
             updateAdventureSlotUI(this.activeIndex);

--- a/js/engine.js
+++ b/js/engine.js
@@ -69,21 +69,27 @@ const DeltaEngine = {
     },
 
     apply(deltaSeconds, mult = 1) {
+        let statsChanged = false;
+        let resourcesChanged = false;
         STAT_KEYS.forEach(k => {
             const base = statDeltas[k] * deltaSeconds * mult;
             const delta = typeof BonusEngine !== 'undefined' ?
                 BonusEngine.applyStat(base, k) : base;
+            const before = State.stats[k].value;
             StatSystem.add(State.stats[k], delta);
+            if (State.stats[k].value !== before) statsChanged = true;
         });
         RESOURCE_KEYS.forEach(k => {
             const base = resourceDeltas[k] * deltaSeconds * mult;
             const change = typeof BonusEngine !== 'undefined' ?
                 BonusEngine.applyResource(base, k) : base;
+            const before = State.resources[k].value;
             if (change >= 0) {
                 ResourceSystem.add(State.resources[k], change);
             } else {
                 ResourceSystem.consume(State.resources[k], -change);
             }
+            if (State.resources[k].value !== before) resourcesChanged = true;
         });
         AgeSystem.addDays(ageDelta * deltaSeconds * mult);
         for (const id in expDeltas) {
@@ -93,6 +99,10 @@ const DeltaEngine = {
             if (!slot.active || !slot.encounter) return;
             slot.progress += encounterProgressDeltas[i] * deltaSeconds * mult;
         });
+        if (typeof PubSub !== 'undefined') {
+            if (statsChanged) PubSub.publish('stats:updated');
+            if (resourcesChanged) PubSub.publish('resources:updated');
+        }
     }
 };
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,5 @@
 // Progress Realm main orchestrator
 const LOGIC_TICK_MS = 100;
-const UI_UPDATE_MS = 200;
 const TICKS_PER_SECOND = 1000 / LOGIC_TICK_MS;
 
 let actions = {};
@@ -158,6 +157,9 @@ async function init() {
             for (let i = 0; i < State.adventureSlotCount; i++) updateAdventureSlotUI(i);
             EncounterGenerator.updateName();
             InventoryUI.update();
+            if (typeof PubSub !== 'undefined') {
+                PubSub.publish('lang:changed');
+            }
             SaveSystem.save();
         });
     }
@@ -179,15 +181,19 @@ async function init() {
     }
     applyDarkMode();
     updateUI();
+    if (typeof PubSub !== 'undefined') {
+        PubSub.subscribe('resources:updated', updateUI);
+        PubSub.subscribe('stats:updated', updateUI);
+        PubSub.subscribe('mastery:changed', updateUI);
+        PubSub.subscribe('age:advanced', updateUI);
+        PubSub.subscribe('action:levelUp', updateTaskList);
+        PubSub.subscribe('lang:changed', updateTaskList);
+    }
     setInterval(() => {
         ActionEngine.tick(LOGIC_TICK_MS / 1000);
         AdventureEngine.tick(LOGIC_TICK_MS / 1000);
         UpdateSystem.tick(LOGIC_TICK_MS / 1000);
     }, LOGIC_TICK_MS);
-    setInterval(() => {
-        updateTaskList();
-        updateUI();
-    }, UI_UPDATE_MS);
 }
 
 init();

--- a/js/story.js
+++ b/js/story.js
@@ -28,6 +28,14 @@ const StorySystem = {
     },
     init() {
         this.check();
+        if (typeof PubSub !== 'undefined') {
+            const ageFn = () => this.check();
+            const encFn = () => this.check();
+            PubSub.subscribe('age:advanced', ageFn);
+            PubSub.subscribe('encounter:complete', encFn);
+            this._ageFn = ageFn;
+            this._encFn = encFn;
+        }
     },
     trigger(id) {
         const event = this.events.find(e => e.id === id);

--- a/tests/test_pubsub_usage.py
+++ b/tests/test_pubsub_usage.py
@@ -29,3 +29,9 @@ def test_furniture_ui_updates_on_inventory_change():
     with open(os.path.join('js', 'ui', 'furniture.js')) as f:
         text = f.read()
     assert "inventory:changed" in text
+
+
+def test_engine_publishes_update_events():
+    with open(os.path.join('js', 'engine.js')) as f:
+        text = f.read()
+    assert "resources:updated" in text and "stats:updated" in text


### PR DESCRIPTION
## Summary
- wire `DeltaEngine` to publish `stats:updated` and `resources:updated`
- publish `action:levelUp`, `mastery:changed` and `encounter:complete`
- subscribe to events in `StorySystem` and `main`
- remove 200ms UI polling interval
- update changelog and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68797a0569f88330aff2e904059723ae