### PR TITLE
Maintain unlocked actions and fix furniture swap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 ## [0.41.66] - 2025-07-14
 ### Changed
+- Research progress now persists through prestiges.
+- Research progress is restored after page reloads.
+- Unlocked actions now persist through reloads and prestiges.
+- Buying new furniture replaces any existing piece in that slot.
 - UI updates now subscribe to events instead of polling every 200ms.
 - Home and update lists refresh when inventory changes.
 - Chip section heading renamed to "Updates" while tab name remains.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 * Player can automate repeatable tasks
 * New slots and actions unlock over time
 * Resources can be replenished or crafted
+* Research progress persists across page reloads and prestiges
+* Unlocked actions remain available after reloads and prestiges
 * Optional prestige/reset layer for long-term scaling
 * Prestige triggers when age exceeds the max and converts current stats into
   prestige points

--- a/js/furniture.js
+++ b/js/furniture.js
@@ -30,6 +30,13 @@ const FurnitureSystem = {
         if (!item) return;
         if (!Inventory.canAfford(item.cost)) return;
         Inventory.consumeCost(item.cost);
+        const home = HomeSystem.homes.find(h => h.id === State.homeId);
+        const limit = home ? home.furnitureSlots : 0;
+        if (State.furniture.length >= limit && limit > 0) {
+            const removed = State.furniture.shift();
+            const def = this.furniture.find(f => f.id === removed.id);
+            if (def) def.unlocks.forEach(a => PubSub.publish('lock:action', a));
+        }
         pushState(['furniture'], { id: item.id, durability: item.durability });
         item.unlocks.forEach(a => PubSub.publish('unlock:action', a));
         if (typeof PubSub !== 'undefined') {

--- a/js/save_system.js
+++ b/js/save_system.js
@@ -7,7 +7,9 @@ const SaveSystem = {
                 level: a.level,
                 exp: a.exp,
                 expToNext: a.expToNext,
-                currentTier: a.currentTier
+                currentTier: a.currentTier,
+                locked: a.locked,
+                hidden: a.hidden
             };
         });
         const data = { version: VERSION, state: State, actions: actionData };
@@ -136,7 +138,6 @@ const SaveSystem = {
         setState('inventory', {});
         setState('homeId', null);
         setState('furniture', []);
-        setState('researchCompleted', []);
         setState('adventureSlots', State.adventureSlots.map(() => ({
             text: '', progress: 0, duration: 1, encounter: null, active: false
         })));

--- a/tests/test_furniture_durability.py
+++ b/tests/test_furniture_durability.py
@@ -13,3 +13,10 @@ def test_lock_action_clears_slot():
     with open(path) as f:
         text = f.read()
     assert 'State.slots.forEach' in text
+
+
+def test_purchase_replaces_existing_furniture():
+    path = os.path.join('js', 'furniture.js')
+    with open(path) as f:
+        text = f.read()
+    assert '.shift()' in text and 'furnitureSlots' in text

--- a/tests/test_prestige.py
+++ b/tests/test_prestige.py
@@ -59,3 +59,10 @@ def test_prestige_keeps_action_slots():
     assert 's.actionId = null' not in text
 
 
+def test_research_persists_through_prestige():
+    path = os.path.join('js', 'save_system.js')
+    with open(path) as f:
+        text = f.read()
+    assert text.count("setState('researchCompleted'") == 1
+
+

--- a/tests/test_save_system_module.py
+++ b/tests/test_save_system_module.py
@@ -15,3 +15,18 @@ def test_save_system_defined():
     assert 'localStorage.setItem' in text
     assert 'localStorage.getItem' in text
     assert 'async prestige()' in text
+
+
+def test_research_list_initialized_on_load():
+    path = os.path.join('js', 'save_system.js')
+    with open(path) as f:
+        text = f.read()
+    assert "if (!Array.isArray(State.researchCompleted))" in text
+
+
+def test_action_lock_state_saved():
+    path = os.path.join('js', 'save_system.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'locked: a.locked' in text
+    assert 'hidden: a.hidden' in text


### PR DESCRIPTION
## Summary
- save and load locked/hidden state for actions so unlocks persist
- replace existing furniture if slots are full when buying new pieces
- document action persistence and furniture replacement
- verify save system and furniture changes via new tests

## Testing
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_687d53ad79e083308bd88835dac642e2