### PR TITLE
Fix #78: persist owned homes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Purchase buttons highlight when an item is affordable.
 - Furniture durability values increased 100x so furnishings last longer before breaking.
 - Action tooltips now list resource costs and effects for each action.
+- Owned homes persist across reloads and the default hut is applied automatically.
 - Hut in the Woods now loads automatically and no longer shows in the available homes list.
 - Update, research and furniture buttons share the drag-and-drop style and appear in flexible columns.
 - Furniture highlights refresh on inventory changes, early furniture costs use wood instead of money,

--- a/js/home.js
+++ b/js/home.js
@@ -24,14 +24,27 @@ const HomeSystem = {
         const defaultHome = this.homes.find(h => h.default);
         if (!State.homeId && defaultHome) {
             setState('homeId', defaultHome.id);
+            if (!Array.isArray(State.homesOwned)) {
+                setState('homesOwned', []);
+            }
+            if (!State.homesOwned.includes(defaultHome.id)) {
+                pushState('homesOwned', defaultHome.id);
+            }
             SaveSystem.save();
         }
     },
     setHome(id) {
         const home = this.homes.find(h => h.id === id);
         if (!home) return;
-        if (!Inventory.canAfford(home.cost)) return;
-        Inventory.consumeCost(home.cost);
+        const owned = Array.isArray(State.homesOwned) && State.homesOwned.includes(id);
+        if (!owned) {
+            if (!Inventory.canAfford(home.cost)) return;
+            Inventory.consumeCost(home.cost);
+            if (!Array.isArray(State.homesOwned)) {
+                setState('homesOwned', []);
+            }
+            pushState('homesOwned', id);
+        }
         setState('homeId', id);
         SaveSystem.save();
         if (typeof PubSub !== 'undefined') {

--- a/js/save_system.js
+++ b/js/save_system.js
@@ -89,6 +89,9 @@ const SaveSystem = {
                 if (!Array.isArray(State.researchCompleted)) {
                     setState('researchCompleted', []);
                 }
+                if (!Array.isArray(State.homesOwned)) {
+                    setState('homesOwned', []);
+                }
                 if (!State.language) {
                     setState('language', 'en');
                 }

--- a/js/state.js
+++ b/js/state.js
@@ -157,6 +157,7 @@ const State = {
     inventorySlotCount: 8,
     inventory: {},
     homeId: null,
+    homesOwned: [],
     furniture: [],
     researchCompleted: [],
     time: 1,

--- a/tests/test_home_system_module.py
+++ b/tests/test_home_system_module.py
@@ -1,0 +1,20 @@
+import os
+
+
+def test_homes_owned_state_defined():
+    with open(os.path.join('js', 'state.js')) as f:
+        text = f.read()
+    assert 'homesOwned:' in text
+
+
+def test_save_system_initializes_homes_owned():
+    with open(os.path.join('js', 'save_system.js')) as f:
+        text = f.read()
+    assert "setState('homesOwned', []" in text
+
+
+def test_home_system_tracks_purchase():
+    with open(os.path.join('js', 'home.js')) as f:
+        text = f.read()
+    assert "pushState('homesOwned'" in text
+


### PR DESCRIPTION
## Summary
- save owned homes and default hut
- track home purchases in HomeSystem
- ensure homesOwned is initialized on load
- test for homesOwned support

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_6880dc92daa8833094f28eb9b0a2a5bb