### PR TITLE
Update footer layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [0.41.67] - 2025-07-25
 ### Changed
 - Tab layout moved to bottom on mobile with collapsible sections via new TabContainer.
+- Tabs use icons in a fixed footer and old footer actions moved into the settings modal.
 
 ## [0.41.66] - 2025-07-14
 ### Changed

--- a/css/styles.css
+++ b/css/styles.css
@@ -23,10 +23,23 @@ header h1 {
     margin: 0;
 }
 
-header, footer {
+header {
     background: var(--header-bg);
     color: var(--header-text);
     padding: 0.5rem 1rem;
+}
+
+footer {
+    background: var(--header-bg);
+    color: var(--header-text);
+    padding: 0.5rem 1rem;
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    justify-content: space-around;
+    z-index: 20;
 }
 
 #stats {
@@ -160,11 +173,19 @@ header, footer {
     text-align: center;
 }
 
+.footer-actions {
+    margin-top: 1rem;
+    display: flex;
+    gap: 0.5rem;
+    justify-content: center;
+}
+
 main {
     display: grid;
     grid-template-columns: minmax(180px, 1fr) 2fr minmax(180px, 1fr);
     gap: 1rem;
     padding: 1rem;
+    padding-bottom: 3rem;
     align-items: start;
 }
 
@@ -411,8 +432,8 @@ li.affordable {
 .tab-headers {
     display: flex;
     gap: 0.5rem;
-    margin-top: 0.5rem;
     justify-content: space-around;
+    flex-wrap: wrap;
 }
 
 .tab-headers button.active {
@@ -460,18 +481,6 @@ li.affordable {
     #adventure-slots {
         display: flex;
         flex-direction: column;
-    }
-    .tab-headers {
-        position: fixed;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        background: var(--panel-bg);
-        padding: 0.5rem;
-        z-index: 10;
-    }
-    main {
-        padding-bottom: 3rem;
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
                 <button data-speed="10">10x</button>
             </span>
             <button id="toggle-left" data-i18n="Hide Stats">Hide Stats</button>
+            <button id="settings-btn" title="Settings">⚙️</button>
         </div>
     </header>
 
@@ -38,6 +39,12 @@
                     <option value="uk">Українська</option>
                 </select>
             </label>
+            <div class="footer-actions">
+                <button id="save-btn" data-i18n="Save">Save</button>
+                <button id="load-btn" data-i18n="Load">Load</button>
+                <button id="prestige-btn" data-i18n="Prestige">Prestige</button>
+                <button id="reset-btn" data-i18n="Reset">Reset</button>
+            </div>
             <button id="settings-close" data-i18n="Close">Close</button>
         </div>
     </div>
@@ -159,7 +166,6 @@
                         </div>
                     </div>
                 </div>
-                <div id="tab-headers" class="tab-headers"></div>
             </div>
         </div>
 
@@ -172,11 +178,7 @@
     </main>
 
     <footer>
-        <button id="save-btn" data-i18n="Save">Save</button>
-        <button id="load-btn" data-i18n="Load">Load</button>
-        <button id="settings-btn" data-i18n="Settings">Settings</button>
-        <button id="prestige-btn" data-i18n="Prestige">Prestige</button>
-        <button id="reset-btn" data-i18n="Reset">Reset</button>
+        <div id="tab-headers" class="tab-headers"></div>
     </footer>
     <script src="js/logger.js"></script>
     <script src="js/utils.js"></script>

--- a/js/tab_manager.js
+++ b/js/tab_manager.js
@@ -4,6 +4,13 @@ const TabManager = {
     buttons: {},
     activeSections: {},
     _sectionButtons: {},
+    icons: {
+        routines: '🏠',
+        adventure: '⚔️',
+        inventory: '🎒',
+        automation: '🤖',
+        chip: '💡'
+    },
     load(tabData) {
         this.tabs = Array.isArray(tabData) ? tabData : [];
     },
@@ -44,7 +51,9 @@ const TabManager = {
         if (!btn) return;
         const name = Lang.ui(tab.name) || tab.name;
         const locked = Lang.ui('Locked') || 'Locked';
-        btn.textContent = tab.locked ? `${name} (${locked})` : name;
+        btn.title = tab.locked ? `${name} (${locked})` : name;
+        const icon = this.icons[tab.id] || name[0];
+        btn.textContent = tab.locked ? `${icon}🔒` : icon;
     },
     _updateSectionButton(section, btn) {
         const name = Lang.ui(section.name) || section.name;


### PR DESCRIPTION
## Summary
- move tab navigation into the footer
- lock the footer to the bottom of the screen
- use emoji icons for tab buttons
- relocate save/load/prestige/reset controls inside the settings modal

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_6883e47efa3c8330b9303e83330302ae