### PR TITLE
Fix #49: ensure home slot updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Tab layout moved to bottom on mobile with collapsible sections via new TabContainer.
 - Tabs use icons in a fixed footer and old footer actions moved into the settings modal.
 - Default home now falls back to "Hut in the Woods" if the saved home is missing.
+- Home slot now updates correctly after reloads and prestiges.
 
 ## [0.41.66] - 2025-07-14
 ### Changed

--- a/js/home.js
+++ b/js/home.js
@@ -36,6 +36,9 @@ const HomeSystem = {
             }
             SaveSystem.save();
         }
+        if (typeof PubSub !== 'undefined') {
+            PubSub.publish('home:changed', State.homeId);
+        }
     },
     setHome(id) {
         const home = this.homes.find(h => h.id === id);

--- a/tests/test_home_system_module.py
+++ b/tests/test_home_system_module.py
@@ -25,3 +25,10 @@ def test_default_home_fallback():
     assert 'currentHome' in text
     assert 'if (!currentHome && defaultHome)' in text
 
+
+def test_home_system_notifies_on_load():
+    path = os.path.join('js', 'home.js')
+    with open(path) as f:
+        text = f.read()
+    assert "PubSub.publish('home:changed', State.homeId" in text
+


### PR DESCRIPTION
## Summary
- trigger a `home:changed` event when HomeSystem loads homes so the UI refreshes
- test that the event is published
- note fix in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887d8fc0b0c8330a5111a33f5243070