### PR TITLE
Fix default home slot after prestige

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Tabs use icons in a fixed footer and old footer actions moved into the settings modal.
 - Default home now falls back to "Hut in the Woods" if the saved home is missing.
 - Home slot now updates correctly after reloads and prestiges.
+- Prestige now reassigns the default hut immediately to prevent an empty home slot.
 
 ## [0.41.66] - 2025-07-14
 ### Changed

--- a/js/home.js
+++ b/js/home.js
@@ -12,6 +12,25 @@ class Home {
 
 const HomeSystem = {
     homes: [],
+    assignDefault() {
+        const defaultHome = this.homes.find(h => h.default);
+        const currentHome = this.homes.find(h => h.id === State.homeId);
+        if (!currentHome && defaultHome) {
+            setState('homeId', defaultHome.id);
+            if (!Array.isArray(State.homesOwned)) {
+                setState('homesOwned', []);
+            }
+            if (!State.homesOwned.includes(defaultHome.id)) {
+                pushState('homesOwned', defaultHome.id);
+            }
+            if (typeof SaveSystem !== 'undefined') {
+                SaveSystem.save();
+            }
+            if (typeof PubSub !== 'undefined') {
+                PubSub.publish('home:changed', State.homeId);
+            }
+        }
+    },
     async load() {
         try {
             const res = await fetch('data/homes.json');
@@ -21,24 +40,7 @@ const HomeSystem = {
             console.error('Failed to load homes', e);
             this.homes = [];
         }
-        const defaultHome = this.homes.find(h => h.default);
-        const currentHome = this.homes.find(h => h.id === State.homeId);
-        // Ensure a valid home is always selected. If none is set or the
-        // current id doesn't exist in the loaded list, fall back to the
-        // default option.
-        if (!currentHome && defaultHome) {
-            setState('homeId', defaultHome.id);
-            if (!Array.isArray(State.homesOwned)) {
-                setState('homesOwned', []);
-            }
-            if (!State.homesOwned.includes(defaultHome.id)) {
-                pushState('homesOwned', defaultHome.id);
-            }
-            SaveSystem.save();
-        }
-        if (typeof PubSub !== 'undefined') {
-            PubSub.publish('home:changed', State.homeId);
-        }
+        this.assignDefault();
     },
     setHome(id) {
         const home = this.homes.find(h => h.id === id);

--- a/js/save_system.js
+++ b/js/save_system.js
@@ -150,6 +150,9 @@ const SaveSystem = {
             if (actions[id]) Object.assign(actions[id], data);
         });
         setState('prestiging', false);
+        if (typeof HomeSystem !== 'undefined' && HomeSystem.assignDefault) {
+            HomeSystem.assignDefault();
+        }
         SaveSystem.save();
         window.location.reload();
     }


### PR DESCRIPTION
## Summary
- refactor home system default assignment into `assignDefault`
- call `HomeSystem.assignDefault()` during prestige reset
- document new behavior in changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688936cc6bb483309581ba385876d3f8