### PR TITLE
Move active slot to log panel tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Tabs use icons in a fixed footer and old footer actions moved into the settings modal.
 - Default home now falls back to "Hut in the Woods" if the saved home is missing.
 - Home slot now updates correctly after reloads and prestiges.
+- Active slots moved next to the log as a tab and reduced to one slot.
 
 ## [0.41.66] - 2025-07-14
 ### Changed

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 
 #### 8. Slot System
 
-* Player begins with **six** action slots
+* Player begins with **one** action slot
 * Additional slots may be added dynamically
 * Actions are blocked if resources are insufficient
 

--- a/css/styles.css
+++ b/css/styles.css
@@ -501,6 +501,20 @@ li.affordable {
     flex-direction: column;
 }
 
+.right-tabs {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.right-tabs button.active {
+    background: #333;
+    color: #fff;
+}
+
+.right-view.hidden {
+    display: none;
+}
+
 .log-container {
     height: 300px;
     overflow-y: auto;

--- a/data/ui.json
+++ b/data/ui.json
@@ -12,13 +12,6 @@
                     "type": "buttons",
                     "hidden": false,
                     "locked": false
-                },
-                {
-                    "id": "action-slots",
-                    "name": "Action Slots",
-                    "type": "slots",
-                    "hidden": false,
-                    "locked": false
                 }
             ]
         },

--- a/index.html
+++ b/index.html
@@ -99,12 +99,6 @@
                                 <ul id="task-list"></ul>
                             </div>
                         </div>
-                        <div class="tab-section" data-section="action-slots" data-type="slots">
-                            <h2 data-i18n="Action Slots">Action Slots</h2>
-                            <div class="section-body">
-                                <div id="slots" class="slots"></div>
-                            </div>
-                        </div>
                     </div>
                     <div class="tab-content hidden" data-tab="adventure">
                         <h2 data-i18n="Adventure">Adventure</h2>
@@ -170,9 +164,17 @@
         </div>
 
         <div id="right" class="panel log-panel">
-            <h2 data-i18n="Log">Log</h2>
-            <div id="log-container" class="log-container">
-                <div id="log" class="log-view"></div>
+            <div class="right-tabs">
+                <button data-panel="log" class="active" data-i18n="Log">Log</button>
+                <button data-panel="active" data-i18n="Active">Active</button>
+            </div>
+            <div id="log-panel" class="right-view">
+                <div id="log-container" class="log-container">
+                    <div id="log" class="log-view"></div>
+                </div>
+            </div>
+            <div id="active-panel" class="right-view hidden">
+                <div id="slots" class="slots"></div>
             </div>
         </div>
     </main>

--- a/js/main.js
+++ b/js/main.js
@@ -137,6 +137,10 @@ async function init() {
             SaveSystem.save();
         });
     }
+    document.querySelectorAll('#right .right-tabs button').forEach(btn => {
+        btn.addEventListener('click', () => showRightPanel(btn.dataset.panel));
+    });
+    showRightPanel('log');
     const langSelect = document.getElementById('language-select');
     if (langSelect) {
         langSelect.value = State.language;

--- a/js/state.js
+++ b/js/state.js
@@ -150,7 +150,7 @@ const State = {
     prestige: {},
     prestiging: false,
     // number of available action slots
-    slotCount: 6,
+    slotCount: 1,
     slots: [],
     adventureSlotCount: 1,
     adventureSlots: [],

--- a/js/story_core.js
+++ b/js/story_core.js
@@ -35,3 +35,15 @@ function openInventoryFilter() {
 function closeInventoryFilter() {
     PubSub.publish('modal:close', 'inventory-filter-modal');
 }
+
+function showRightPanel(panel) {
+    const logPanel = document.getElementById('log-panel');
+    const activePanel = document.getElementById('active-panel');
+    const buttons = document.querySelectorAll('#right .right-tabs button');
+    if (!logPanel || !activePanel) return;
+    logPanel.classList.toggle('hidden', panel !== 'log');
+    activePanel.classList.toggle('hidden', panel !== 'active');
+    buttons.forEach(btn => {
+        btn.classList.toggle('active', btn.dataset.panel === panel);
+    });
+}


### PR DESCRIPTION
## Summary
- move active slots next to the log
- reduce action slot count to one
- update styles and event hooks for new right panel tabs
- document slot count change

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68893727c1248330a413b1376cbb7556