### PR TITLE
Implement instant action slot filling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## [0.41.66] - 2025-07-14
 ### Changed
+- Clicking a task immediately assigns it to an available slot.
+- Default number of action slots is now 1 instead of 6.
 - Research progress now persists through prestiges.
 - Research progress is restored after page reloads.
 - Unlocked actions now persist through reloads and prestiges.

--- a/README.md
+++ b/README.md
@@ -80,8 +80,9 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 
 #### 8. Slot System
 
-* Player begins with **six** action slots
+* Player begins with **one** action slot
 * Additional slots may be added dynamically
+* Clicking a task automatically fills the next available slot
 * Actions are blocked if resources are insufficient
 
 #### 9. Visual Style

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -46,14 +46,9 @@ function createActionElement(action) {
         });
         li.addEventListener('dragend', () => li.classList.remove('dragging'));
         li.addEventListener('click', () => {
-            if (selectedActionId === action.id) {
-                selectedActionId = null;
-                li.classList.remove('selected');
-            } else {
-                selectedActionId = action.id;
-                document.querySelectorAll('#task-list li').forEach(el => el.classList.remove('selected'));
-                li.classList.add('selected');
-            }
+            let index = State.slots.findIndex(s => s.actionId === State.defaultActionId);
+            if (index === -1) index = 0;
+            ActionEngine.start(index, action.id);
         });
     }
     return li;

--- a/js/state.js
+++ b/js/state.js
@@ -150,7 +150,7 @@ const State = {
     prestige: {},
     prestiging: false,
     // number of available action slots
-    slotCount: 6,
+    slotCount: 1,
     slots: [],
     adventureSlotCount: 1,
     adventureSlots: [],


### PR DESCRIPTION
## Summary
- update slot count default to 1
- assign clicked actions directly to an available slot
- document new slot behaviour

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-cov`
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_68893b0df7708330be7d2cae3969df0a