### PR TITLE
Fix default home initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - UI updates now subscribe to events instead of polling every 200ms.
 - Home and update lists refresh when inventory changes.
 - Chip section heading renamed to "Updates" while tab name remains.
+- Fixed default home not appearing for new saves because the `default` field was ignored.
 - Empty action slots now default to the Rest action.
 - Removed creativity stat and updated items and encounters to match current
   resources. Money no longer grants a softcap bonus.

--- a/js/home.js
+++ b/js/home.js
@@ -5,6 +5,7 @@ class Home {
         this.description = data.description || '';
         this.image = data.image || null;
         this.rarity = data.rarity || 'common';
+        this.default = data.default || false;
         this.furnitureSlots = data.furnitureSlots || 0;
         this.cost = data.cost || {};
     }

--- a/tests/test_home_system_module.py
+++ b/tests/test_home_system_module.py
@@ -18,3 +18,9 @@ def test_home_system_tracks_purchase():
         text = f.read()
     assert "pushState('homesOwned'" in text
 
+
+def test_home_class_preserves_default():
+    with open(os.path.join('js', 'home.js')) as f:
+        text = f.read()
+    assert 'this.default = data.default' in text
+


### PR DESCRIPTION
## Summary
- store `default` flag when creating `Home` objects
- test that `Home` constructor preserves this field
- note fix in the changelog

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a4db7432083309492e56534820e7d