### PR TITLE
Fix default home assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - Active slots moved next to the log as a tab and reduced to one slot.
 - Prestige now reassigns the default hut immediately to prevent an empty home slot.
+- Fixed missing default property in Home constructor so default home loads correctly.
 
 
 ## [0.41.66] - 2025-07-14

--- a/js/home.js
+++ b/js/home.js
@@ -7,6 +7,7 @@ class Home {
         this.rarity = data.rarity || 'common';
         this.furnitureSlots = data.furnitureSlots || 0;
         this.cost = data.cost || {};
+        this.default = data.default || false;
     }
 }
 

--- a/tests/test_home_system_module.py
+++ b/tests/test_home_system_module.py
@@ -32,3 +32,10 @@ def test_home_system_notifies_on_load():
         text = f.read()
     assert "PubSub.publish('home:changed', State.homeId" in text
 
+
+def test_home_constructor_preserves_default_property():
+    path = os.path.join('js', 'home.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'this.default = data.default' in text
+


### PR DESCRIPTION
## Summary
- ensure `Home` constructor preserves `default` field
- test for default field in `Home`
- document fix in changelog

## Testing
- `pytest --cov -q`

------
https://chatgpt.com/codex/tasks/task_e_688a6e96339c83308c7303df3392a4d9