### PR TITLE
Implement activation cost and progress resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Changelog
+
+## [Unreleased] - 2025-07-30
+### Added
+- Activation cost for actions deducted only once on start with visible block state when insufficient resources.
+- Slot progress now resumes from previous value when reselecting an action.
 ## [0.41.66] - 2025-07-14
 ### Changed
 - Clicking a task immediately assigns it to an available slot.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 
 * Player assigns actions to limited slots
 * Actions consume time, energy, and resources
+* Activation costs are paid once when starting an action and the slot highlights when resources are missing
+* Action progress resumes from the previous value if the task is interrupted
 * Tasks improve stats, unlock new actions, or produce magical items
 * Player can automate repeatable tasks
 * New slots and actions unlock over time

--- a/data/actions.json
+++ b/data/actions.json
@@ -6,6 +6,7 @@
     "level": 1,
     "exp": 0,
     "expToNext": 10,
+    "activationCost": { "focus": 1 },
     "baseYield": {
       "stats": {
         "intelligence": 0.01
@@ -31,6 +32,7 @@
     "level": 1,
     "exp": 0,
     "expToNext": 10,
+    "activationCost": { "energy": 1 },
     "baseYield": {
       "stats": {
         "strength": 0.02
@@ -56,6 +58,7 @@
     "level": 1,
     "exp": 0,
     "expToNext": 1000,
+    "activationCost": {},
     "baseYield": {
       "stats": {},
       "resources": {
@@ -82,6 +85,7 @@
     "level": 1,
     "exp": 0,
     "expToNext": 10,
+    "activationCost": { "energy": 1, "focus": 1 },
     "baseYield": {
       "stats": {
         "dexterity": 0.01
@@ -109,6 +113,7 @@
     "level": 1,
     "exp": 0,
     "expToNext": 10,
+    "activationCost": {},
     "baseYield": {
       "stats": {},
       "resources": {

--- a/js/action_engine.js
+++ b/js/action_engine.js
@@ -3,10 +3,26 @@
 const ActionEngine = {
     start(slotIndex, actionId) {
         const slot = State.slots[slotIndex];
-        slot.actionId = actionId;
-        slot.progress = 0;
+        const action = actions[actionId];
+        if (!action) return;
         slot.blocked = false;
-        slot.text = actions[actionId] ? actions[actionId].name : '';
+        if (action.activationCost) {
+            const missing = canAfford(action.activationCost, 1, 1);
+            if (missing) {
+                slot.blocked = true;
+                slot.progress = 0;
+                slot.text = `${Lang.resource(missing) || missing} required`;
+                updateSlotUI(slotIndex);
+                return;
+            }
+            for (const r in action.activationCost) {
+                ResourceSystem.consume(State.resources[r], action.activationCost[r]);
+            }
+            if (typeof PubSub !== 'undefined') PubSub.publish('resources:updated');
+        }
+        slot.actionId = actionId;
+        slot.progress = action.exp / action.expToNext;
+        slot.text = action.name;
         updateSlotUI(slotIndex);
     },
     tick(delta) {

--- a/tests/test_action_activation_cost.py
+++ b/tests/test_action_activation_cost.py
@@ -1,0 +1,12 @@
+import json
+import os
+
+
+def test_actions_include_activation_cost():
+    path = os.path.join('data', 'actions.json')
+    with open(path) as f:
+        data = json.load(f)
+    for action in data:
+        assert 'activationCost' in action
+        assert isinstance(action['activationCost'], dict)
+


### PR DESCRIPTION
## Summary
- show activation cost per action and allow resuming progress
- block slots when resources are insufficient on start
- document new behaviour and add changelog entry
- test for activationCost field

## Testing
- `pytest --maxfail=1 -q`

------
https://chatgpt.com/codex/tasks/task_e_688a9bd793cc83308711762ba0e3d9be