### PR TITLE
Implement single-cost actions with persistent progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Active slots moved next to the log as a tab and reduced to one slot.
 - Prestige now reassigns the default hut immediately to prevent an empty home slot.
 - Fixed missing default property in Home constructor so default home loads correctly.
+- Actions now cost resources on activation and store progress when interrupted.
 
 
 ## [0.41.66] - 2025-07-14

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 #### 3. Core Gameplay Loop
 
 * Player assigns actions to limited slots
-* Actions consume time, energy, and resources
+* Actions require a resource cost on activation and then progress automatically
 * Tasks improve stats, unlock new actions, or produce magical items
 * Player can automate repeatable tasks
 * New slots and actions unlock over time

--- a/data/actions.json
+++ b/data/actions.json
@@ -20,7 +20,7 @@
       "softcapLevel": 5,
       "falloff": 0.5
     },
-    "resourceConsumption": {
+    "resourceCost": {
       "focus": 0.5
     }
   },
@@ -45,7 +45,7 @@
       "softcapLevel": 5,
       "falloff": 0.5
     },
-    "resourceConsumption": {
+    "resourceCost": {
       "energy": 0.5
     }
   },
@@ -72,7 +72,7 @@
       "softcapLevel": 5,
       "falloff": 0.5
     },
-    "resourceConsumption": {}
+    "resourceCost": {}
   },
   {
     "id": "woodworking",
@@ -96,7 +96,7 @@
       "softcapLevel": 5,
       "falloff": 0.5
     },
-    "resourceConsumption": {
+    "resourceCost": {
       "energy": 0.5,
       "focus": 0.5
     }
@@ -125,6 +125,6 @@
       "softcapLevel": 5,
       "falloff": 0.5
     },
-    "resourceConsumption": {}
+    "resourceCost": {}
   }
 ]

--- a/js/action_engine.js
+++ b/js/action_engine.js
@@ -3,24 +3,63 @@
 const ActionEngine = {
     start(slotIndex, actionId) {
         const slot = State.slots[slotIndex];
+        const action = actions[actionId];
+        if (!action) return;
+        let canStart = true;
+        if (action.resourceCost) {
+            for (const r in action.resourceCost) {
+                const res = State.resources[r];
+                if (!res || res.value < action.resourceCost[r]) {
+                    canStart = false;
+                    break;
+                }
+            }
+        }
+        if (!canStart) {
+            slot.actionId = State.defaultActionId;
+            slot.blocked = true;
+            slot.progress = actions[State.defaultActionId].progress || 0;
+            slot.text = actions[State.defaultActionId] ? actions[State.defaultActionId].name : '';
+            updateSlotUI(slotIndex);
+            return;
+        }
+        if (action.resourceCost) {
+            for (const r in action.resourceCost) {
+                ResourceSystem.consume(State.resources[r], action.resourceCost[r]);
+            }
+            if (typeof PubSub !== 'undefined') {
+                PubSub.publish('resources:updated');
+            }
+        }
         slot.actionId = actionId;
-        slot.progress = 0;
+        slot.progress = action.progress || 0;
         slot.blocked = false;
-        slot.text = actions[actionId] ? actions[actionId].name : '';
+        slot.text = action.name;
         updateSlotUI(slotIndex);
     },
     tick(delta) {
         DeltaEngine.calculate();
         DeltaEngine.apply(delta, State.time);
         State.slots.forEach((slot, i) => {
-            if (!slot.actionId) return;
+            if (!slot.actionId || slot.blocked) return;
             if (typeof FurnitureSystem !== 'undefined' && FurnitureSystem.use) {
                 FurnitureSystem.use(slot.actionId, delta * State.time);
                 if (!slot.actionId) return; // action may be locked and removed
             }
             const action = actions[slot.actionId];
             if (!action) return;
-            slot.progress = action.exp / action.expToNext;
+            slot.progress = (slot.progress || 0) + delta * State.time;
+            while (slot.progress >= 1) {
+                const mult = scalingMultiplier(action);
+                if (action.baseYield) {
+                    applyYield(action.baseYield, mult, 1);
+                }
+                if (action.baseYield && action.baseYield.exp) {
+                    gainExp(action, action.baseYield.exp * mult);
+                }
+                slot.progress -= 1;
+            }
+            action.progress = slot.progress;
             updateSlotUI(i);
         });
         SoftCapSystem.apply();

--- a/js/engine.js
+++ b/js/engine.js
@@ -21,38 +21,7 @@ const DeltaEngine = {
             delete expDeltas[id];
         }
 
-        // contributions from active actions
-        State.slots.forEach(slot => {
-            if (!slot.actionId || slot.blocked) return;
-            const action = actions[slot.actionId];
-            const mult = scalingMultiplier(action);
-
-            if (action.baseYield.stats) {
-                for (const s in action.baseYield.stats) {
-                    statDeltas[s] = (statDeltas[s] || 0) +
-                        action.baseYield.stats[s] * mult;
-                }
-            }
-
-            if (action.baseYield.resources) {
-                for (const r in action.baseYield.resources) {
-                    const rate = action.baseYield.resources[r] * mult;
-                    resourceDeltas[r] = (resourceDeltas[r] || 0) + rate;
-                }
-            }
-
-            if (action.resourceConsumption) {
-                for (const r in action.resourceConsumption) {
-                    const rate = action.resourceConsumption[r] * mult;
-                    resourceDeltas[r] = (resourceDeltas[r] || 0) - rate;
-                }
-            }
-
-            if (action.baseYield.exp) {
-                expDeltas[action.id] = (expDeltas[action.id] || 0) +
-                    action.baseYield.exp * mult;
-            }
-        });
+        // action contributions handled by ActionEngine
 
         // contributions from active encounters
         encounterProgressDeltas.length = State.adventureSlots.length;
@@ -92,9 +61,7 @@ const DeltaEngine = {
             if (State.resources[k].value !== before) resourcesChanged = true;
         });
         AgeSystem.addDays(ageDelta * deltaSeconds * mult);
-        for (const id in expDeltas) {
-            gainExp(actions[id], expDeltas[id] * deltaSeconds * mult);
-        }
+        // action experience applied by ActionEngine
         State.adventureSlots.forEach((slot, i) => {
             if (!slot.active || !slot.encounter) return;
             slot.progress += encounterProgressDeltas[i] * deltaSeconds * mult;

--- a/js/main.js
+++ b/js/main.js
@@ -37,12 +37,20 @@ async function init() {
         json.forEach(a => {
             a.hidden = a.hidden || false;
             a.locked = a.locked || false;
+            if (a.resourceConsumption) {
+                a.resourceCost = a.resourceConsumption;
+                delete a.resourceConsumption;
+            }
+            a.progress = 0;
             actions[a.id] = a;
         });
         if (loadedActions) {
             for (const id in loadedActions) {
                 if (actions[id]) {
                     Object.assign(actions[id], loadedActions[id]);
+                    if (loadedActions[id].progress !== undefined) {
+                        actions[id].progress = loadedActions[id].progress;
+                    }
                 }
             }
         }

--- a/js/save_system.js
+++ b/js/save_system.js
@@ -9,7 +9,8 @@ const SaveSystem = {
                 expToNext: a.expToNext,
                 currentTier: a.currentTier,
                 locked: a.locked,
-                hidden: a.hidden
+                hidden: a.hidden,
+                progress: a.progress || 0
             };
         });
         const data = { version: VERSION, state: State, actions: actionData };
@@ -116,7 +117,8 @@ const SaveSystem = {
                 level: a.level,
                 exp: 0,
                 expToNext: a.expToNext,
-                currentTier: a.currentTier
+                currentTier: a.currentTier,
+                progress: 0
             };
         });
 

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -2,8 +2,8 @@
 
 function buildActionTooltip(action) {
     const parts = [`<strong>${action.name}</strong> - ${capitalize(getActionTier(action.level))}`];
-    if (action.resourceConsumption && Object.keys(action.resourceConsumption).length) {
-        const cost = Utils.formatCost(action.resourceConsumption);
+    if (action.resourceCost && Object.keys(action.resourceCost).length) {
+        const cost = Utils.formatCost(action.resourceCost);
         parts.push(`<strong>${Lang.ui('Cost') || 'Cost'}:</strong> ${cost}`);
     }
     const effects = [];
@@ -158,7 +158,7 @@ function updateSlotUI(i) {
     }
     const action = actions[slot.actionId];
     progressEl.max = 1;
-    progressEl.value = slot.progress;
+    progressEl.value = action.progress || 0;
     labelEl.textContent = slot.text || `${action.name} Lv.${action.level}`;
     if (action.image) {
         slotEl.style.backgroundImage = `url(${action.image})`;

--- a/tests/test_action_cost.py
+++ b/tests/test_action_cost.py
@@ -1,0 +1,17 @@
+import json
+import os
+
+
+def test_actions_use_resource_cost():
+    path = os.path.join('data', 'actions.json')
+    with open(path) as f:
+        actions = json.load(f)
+    for action in actions:
+        assert 'resourceCost' in action
+        assert 'resourceConsumption' not in action
+
+
+def test_action_engine_references_resource_cost():
+    with open(os.path.join('js', 'action_engine.js')) as f:
+        text = f.read()
+    assert 'resourceCost' in text


### PR DESCRIPTION
## Summary
- change action data to use `resourceCost`
- persist action progress across interruptions
- pay action cost once on activation and default to Rest when unaffordable
- drop per-second consumption from engine logic
- document new behavior in README and changelog
- add tests for resourceCost usage

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b62ca265883309a3feaa573e19c6d