### PR TITLE
Fix #134: apply action costs upfront and show exp progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Prestige now reassigns the default hut immediately to prevent an empty home slot.
 - Fixed missing default property in Home constructor so default home loads correctly.
 - Actions now cost resources on activation and store progress when interrupted.
+- Resource yields now grant rewards on completion rather than per second.
+- Action buttons display experience progress toward the next level.
 
 
 ## [0.41.66] - 2025-07-14

--- a/js/action_engine.js
+++ b/js/action_engine.js
@@ -48,11 +48,29 @@ const ActionEngine = {
             }
             const action = actions[slot.actionId];
             if (!action) return;
+            if (action.resourceConsumption) {
+                const missing = canAfford(action.resourceConsumption, delta);
+                if (missing) {
+                    slot.actionId = State.defaultActionId;
+                    slot.blocked = true;
+                    slot.progress = actions[State.defaultActionId].progress || 0;
+                    slot.text = actions[State.defaultActionId] ? actions[State.defaultActionId].name : '';
+                    updateSlotUI(i);
+                    return;
+                }
+                for (const r in action.resourceConsumption) {
+                    const amt = action.resourceConsumption[r] * State.time * delta;
+                    ResourceSystem.consume(State.resources[r], amt);
+                }
+                if (typeof PubSub !== 'undefined') {
+                    PubSub.publish('resources:updated');
+                }
+            }
             slot.progress = (slot.progress || 0) + delta * State.time;
             while (slot.progress >= 1) {
                 const mult = scalingMultiplier(action);
                 if (action.baseYield) {
-                    applyYield(action.baseYield, mult, 1);
+                    applyYield(action.baseYield, mult, 1, false);
                 }
                 if (action.baseYield && action.baseYield.exp) {
                     gainExp(action, action.baseYield.exp * mult);

--- a/js/action_utils.js
+++ b/js/action_utils.js
@@ -51,15 +51,16 @@ function canAfford(cost, delta, mult = 1) {
     return null;
 }
 
-function applyYield(base, mult, delta) {
+function applyYield(base, mult, delta, scaleTime = false) {
+    const timeMult = scaleTime ? State.time : 1;
     if (base.stats) {
         for (const s in base.stats) {
-            StatSystem.add(State.stats[s], base.stats[s] * mult * State.time * delta);
+            StatSystem.add(State.stats[s], base.stats[s] * mult * timeMult * delta);
         }
     }
     if (base.resources) {
         for (const r in base.resources) {
-            ResourceSystem.add(State.resources[r], base.resources[r] * mult * State.time * delta);
+            ResourceSystem.add(State.resources[r], base.resources[r] * mult * timeMult * delta);
         }
     }
 }

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -28,10 +28,15 @@ function buildActionTooltip(action) {
     return parts.join('<br>');
 }
 
+function actionLabel(action) {
+    const pct = Math.floor((action.exp / action.expToNext) * 100);
+    return `${action.name} Lv.${action.level} (${pct}%)`;
+}
+
 function createActionElement(action) {
     if (action.hidden) return null;
     const li = document.createElement('li');
-    li.textContent = `${action.name} Lv.${action.level}`;
+    li.textContent = actionLabel(action);
     li.dataset.taskId = action.id;
     li.dataset.tooltip = buildActionTooltip(action);
     const tierClass = `tier-${getActionTier(action.level)}`;
@@ -139,7 +144,7 @@ function updateTaskList() {
             if (el) list.appendChild(el);
             return;
         }
-        li.textContent = `${action.name} Lv.${action.level}`;
+        li.textContent = actionLabel(action);
         li.dataset.tooltip = buildActionTooltip(action);
         li.classList.remove('tier-normal', 'tier-bronze', 'tier-silver', 'tier-gold');
         li.classList.add(`tier-${getActionTier(action.level)}`);

--- a/tests/test_action_cost.py
+++ b/tests/test_action_cost.py
@@ -15,3 +15,4 @@ def test_action_engine_references_resource_cost():
     with open(os.path.join('js', 'action_engine.js')) as f:
         text = f.read()
     assert 'resourceCost' in text
+    assert 'resourceConsumption' in text

--- a/tests/test_prestige.py
+++ b/tests/test_prestige.py
@@ -59,6 +59,13 @@ def test_prestige_keeps_action_slots():
     assert 's.actionId = null' not in text
 
 
+def test_prestige_resets_action_progress():
+    path = os.path.join('js', 'save_system.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'progress: 0' in text
+
+
 def test_research_persists_through_prestige():
     path = os.path.join('js', 'save_system.js')
     with open(path) as f:


### PR DESCRIPTION
## Summary
- update action yield application so completion rewards aren't scaled by game speed
- consume activation cost immediately and handle per-second resource consumption
- show experience progress in the action list
- document the change in the changelog
- add tests for new logic and prestige progress reset

## Testing
- `pytest -q`
- `pytest --cov=js -q` *(fails: No data collected)*

------
https://chatgpt.com/codex/tasks/task_e_688b68a3130c833083c1524da09bd4de