### PR TITLE
Add action progress fill and repeated cost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 ## [0.41.67] - 2025-07-25
 ### Changed
+- Action buttons show level progress with a darkening background instead of text.
+- Resource costs are deducted at the start of every action cycle.
 - Furniture purchases no longer replace existing pieces; repairing uses scaled cost.
 - Tab layout moved to bottom on mobile with collapsible sections via new TabContainer.
 - Tabs use icons in a fixed footer and old footer actions moved into the settings modal.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 * Actions require a resource cost on activation and then progress automatically
 * Tasks improve stats, unlock new actions, or produce magical items
 * Player can automate repeatable tasks
+* Action buttons darken as they fill with experience toward the next level
 * New slots and actions unlock over time
 * Resources can be replenished or crafted
 * Research progress persists across page reloads and prestiges

--- a/css/styles.css
+++ b/css/styles.css
@@ -231,6 +231,24 @@ body.left-collapsed #left {
     padding: 0.5rem;
     cursor: grab;
     border-radius: 4px;
+    position: relative;
+    overflow: hidden;
+}
+
+#task-list li .level-fill {
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: 0%;
+    background: rgba(0, 0, 0, 0.3);
+    pointer-events: none;
+    z-index: 0;
+}
+
+#task-list li .action-label {
+    position: relative;
+    z-index: 1;
 }
 
 #home-list li,

--- a/js/action_engine.js
+++ b/js/action_engine.js
@@ -76,6 +76,31 @@ const ActionEngine = {
                     gainExp(action, action.baseYield.exp * mult);
                 }
                 slot.progress -= 1;
+                // deduct start cost for next cycle
+                if (action.resourceCost) {
+                    let canRun = true;
+                    for (const r in action.resourceCost) {
+                        const res = State.resources[r];
+                        if (!res || res.value < action.resourceCost[r]) {
+                            canRun = false;
+                            break;
+                        }
+                    }
+                    if (!canRun) {
+                        slot.actionId = State.defaultActionId;
+                        slot.blocked = true;
+                        slot.progress = actions[State.defaultActionId].progress || 0;
+                        slot.text = actions[State.defaultActionId] ? actions[State.defaultActionId].name : '';
+                        updateSlotUI(i);
+                        return;
+                    }
+                    for (const r in action.resourceCost) {
+                        ResourceSystem.consume(State.resources[r], action.resourceCost[r]);
+                    }
+                    if (typeof PubSub !== 'undefined') {
+                        PubSub.publish('resources:updated');
+                    }
+                }
             }
             action.progress = slot.progress;
             updateSlotUI(i);

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -29,14 +29,21 @@ function buildActionTooltip(action) {
 }
 
 function actionLabel(action) {
-    const pct = Math.floor((action.exp / action.expToNext) * 100);
-    return `${action.name} Lv.${action.level} (${pct}%)`;
+    return `${action.name} Lv.${action.level}`;
 }
 
 function createActionElement(action) {
     if (action.hidden) return null;
     const li = document.createElement('li');
-    li.textContent = actionLabel(action);
+    const fill = document.createElement('div');
+    fill.className = 'level-fill';
+    const pct = Math.floor((action.exp / action.expToNext) * 100);
+    fill.style.width = `${pct}%`;
+    li.appendChild(fill);
+    const label = document.createElement('span');
+    label.className = 'action-label';
+    label.textContent = actionLabel(action);
+    li.appendChild(label);
     li.dataset.taskId = action.id;
     li.dataset.tooltip = buildActionTooltip(action);
     const tierClass = `tier-${getActionTier(action.level)}`;
@@ -144,7 +151,13 @@ function updateTaskList() {
             if (el) list.appendChild(el);
             return;
         }
-        li.textContent = actionLabel(action);
+        const label = li.querySelector('.action-label');
+        const fill = li.querySelector('.level-fill');
+        if (label) label.textContent = actionLabel(action);
+        if (fill) {
+            const pct = Math.floor((action.exp / action.expToNext) * 100);
+            fill.style.width = `${pct}%`;
+        }
         li.dataset.tooltip = buildActionTooltip(action);
         li.classList.remove('tier-normal', 'tier-bronze', 'tier-silver', 'tier-gold');
         li.classList.add(`tier-${getActionTier(action.level)}`);

--- a/tests/test_action_cost.py
+++ b/tests/test_action_cost.py
@@ -16,3 +16,9 @@ def test_action_engine_references_resource_cost():
         text = f.read()
     assert 'resourceCost' in text
     assert 'resourceConsumption' in text
+
+
+def test_action_engine_deducts_cost_each_cycle():
+    with open(os.path.join('js', 'action_engine.js')) as f:
+        text = f.read()
+    assert 'deduct start cost for next cycle' in text


### PR DESCRIPTION
## Summary
- show action level progress with a darkening overlay
- deduct resource cost each time an action cycle begins
- document the new behavior
- test for repeat cost logic

## Testing
- `pip install -r requirements.txt`
- `pip install pytest pytest-cov`
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_688b758d0fa88330827d06bdec015fef