### PR TITLE
Improve action UI refresh and affordability indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Actions now cost resources on activation and store progress when interrupted.
 - Resource yields now grant rewards on completion rather than per second.
 - Action buttons display experience progress toward the next level.
+- Action list refreshes when experience is gained and shows a red outline when an action is unaffordable.
 
 
 ## [0.41.66] - 2025-07-14

--- a/css/styles.css
+++ b/css/styles.css
@@ -447,6 +447,10 @@ li.affordable {
     outline: 2px solid #66cc66;
 }
 
+li.unaffordable {
+    outline: 2px solid #cc6666;
+}
+
 .tab-headers {
     display: flex;
     gap: 0.5rem;

--- a/js/action_utils.js
+++ b/js/action_utils.js
@@ -87,6 +87,7 @@ function gainExp(action, amount) {
         if (State.masteryPoints !== beforeMastery) {
             PubSub.publish('mastery:changed', State.masteryPoints);
         }
+        PubSub.publish('action:exp', { id: action.id, exp: action.exp });
     }
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -194,11 +194,15 @@ async function init() {
     applyDarkMode();
     updateUI();
     if (typeof PubSub !== 'undefined') {
-        PubSub.subscribe('resources:updated', updateUI);
+        PubSub.subscribe('resources:updated', data => {
+            updateUI();
+            updateTaskList();
+        });
         PubSub.subscribe('stats:updated', updateUI);
         PubSub.subscribe('mastery:changed', updateUI);
         PubSub.subscribe('age:advanced', updateUI);
         PubSub.subscribe('action:levelUp', updateTaskList);
+        PubSub.subscribe('action:exp', updateTaskList);
         PubSub.subscribe('lang:changed', updateTaskList);
     }
     setInterval(() => {

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -28,6 +28,15 @@ function buildActionTooltip(action) {
     return parts.join('<br>');
 }
 
+function actionAffordable(action) {
+    if (!action.resourceCost) return true;
+    for (const r in action.resourceCost) {
+        const res = State.resources[r];
+        if (!res || res.value < action.resourceCost[r]) return false;
+    }
+    return true;
+}
+
 function actionLabel(action) {
     return `${action.name} Lv.${action.level}`;
 }
@@ -48,6 +57,9 @@ function createActionElement(action) {
     li.dataset.tooltip = buildActionTooltip(action);
     const tierClass = `tier-${getActionTier(action.level)}`;
     li.classList.add(tierClass);
+    if (!actionAffordable(action)) {
+        li.classList.add('unaffordable');
+    }
     if (action.locked) {
         li.classList.add('locked');
     } else {
@@ -161,6 +173,7 @@ function updateTaskList() {
         li.dataset.tooltip = buildActionTooltip(action);
         li.classList.remove('tier-normal', 'tier-bronze', 'tier-silver', 'tier-gold');
         li.classList.add(`tier-${getActionTier(action.level)}`);
+        li.classList.toggle('unaffordable', !actionAffordable(action));
     });
 }
 


### PR DESCRIPTION
## Summary
- refresh action list when experience is gained
- highlight unaffordable actions in red
- subscribe to new events in the UI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b83bac4c48330bf1fb12ebe3c2180