### PR TITLE
Fix default Rest action progress resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Tabs use icons in a fixed footer and old footer actions moved into the settings modal.
 - Default home now falls back to "Hut in the Woods" if the saved home is missing.
 - Home slot now updates correctly after reloads and prestiges.
+- Action slots falling back to the Rest action now begin progress automatically.
 
 - Active slots moved next to the log as a tab and reduced to one slot.
 - Prestige now reassigns the default hut immediately to prevent an empty home slot.

--- a/js/action_engine.js
+++ b/js/action_engine.js
@@ -17,7 +17,7 @@ const ActionEngine = {
         }
         if (!canStart) {
             slot.actionId = State.defaultActionId;
-            slot.blocked = true;
+            slot.blocked = false;
             slot.progress = actions[State.defaultActionId].progress || 0;
             slot.text = actions[State.defaultActionId] ? actions[State.defaultActionId].name : '';
             updateSlotUI(slotIndex);
@@ -52,7 +52,7 @@ const ActionEngine = {
                 const missing = canAfford(action.resourceConsumption, delta);
                 if (missing) {
                     slot.actionId = State.defaultActionId;
-                    slot.blocked = true;
+                    slot.blocked = false;
                     slot.progress = actions[State.defaultActionId].progress || 0;
                     slot.text = actions[State.defaultActionId] ? actions[State.defaultActionId].name : '';
                     updateSlotUI(i);
@@ -88,7 +88,7 @@ const ActionEngine = {
                     }
                     if (!canRun) {
                         slot.actionId = State.defaultActionId;
-                        slot.blocked = true;
+                        slot.blocked = false;
                         slot.progress = actions[State.defaultActionId].progress || 0;
                         slot.text = actions[State.defaultActionId] ? actions[State.defaultActionId].name : '';
                         updateSlotUI(i);

--- a/tests/test_action_engine_default_action.py
+++ b/tests/test_action_engine_default_action.py
@@ -1,0 +1,11 @@
+import os
+import re
+
+def test_default_action_unblocked_on_reset():
+    with open(os.path.join('js', 'action_engine.js')) as f:
+        text = f.read()
+    pattern = r"slot\.actionId = State\.defaultActionId;\s*slot\.blocked = false;"
+    matches = re.findall(pattern, text)
+    # three situations should un-block when resetting to default
+    assert len(matches) >= 3
+


### PR DESCRIPTION
## Summary
- unblock action slots when falling back to Rest so progress continues
- test that default action unblocks slots
- note the fix in the changelog

## Testing
- `pip install -r requirements.txt`
- `pip install pytest pytest-cov`
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_688ba56baecc83308871a42279d9ec36