### PR TITLE
Add expandable info for action, home and furniture buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Resource yields now grant rewards on completion rather than per second.
 - Action buttons display experience progress toward the next level.
 - Action list refreshes when experience is gained and shows a red outline when an action is unaffordable.
+- Tooltips removed from action, home and furniture buttons. Buttons can expand to show details with calculated yields.
 
 
 ## [0.41.66] - 2025-07-14

--- a/css/styles.css
+++ b/css/styles.css
@@ -451,6 +451,21 @@ li.unaffordable {
     outline: 2px solid #cc6666;
 }
 
+.expand-arrow {
+    cursor: pointer;
+    margin-right: 0.25rem;
+}
+
+.expand-details {
+    display: none;
+    font-size: 0.85rem;
+    margin-top: 0.25rem;
+}
+
+.expandable.expanded .expand-details {
+    display: block;
+}
+
 .tab-headers {
     display: flex;
     gap: 0.5rem;

--- a/js/action_utils.js
+++ b/js/action_utils.js
@@ -65,6 +65,31 @@ function applyYield(base, mult, delta, scaleTime = false) {
     }
 }
 
+function computeActionYield(action) {
+    if (!action.baseYield) return {};
+    const mult = scalingMultiplier(action);
+    const result = { stats: {}, resources: {} };
+    if (action.baseYield.stats) {
+        for (const [s, v] of Object.entries(action.baseYield.stats)) {
+            let val = v * mult;
+            if (typeof BonusEngine !== 'undefined' && BonusEngine.applyStat) {
+                val = BonusEngine.applyStat(val, s);
+            }
+            result.stats[s] = val;
+        }
+    }
+    if (action.baseYield.resources) {
+        for (const [r, v] of Object.entries(action.baseYield.resources)) {
+            let val = v * mult;
+            if (typeof BonusEngine !== 'undefined' && BonusEngine.applyResource) {
+                val = BonusEngine.applyResource(val, r);
+            }
+            result.resources[r] = val;
+        }
+    }
+    return result;
+}
+
 function gainExp(action, amount) {
     action.exp += amount;
     const beforeLevel = action.level;
@@ -98,6 +123,7 @@ if (typeof module !== 'undefined') {
         scalingMultiplier,
         canAfford,
         applyYield,
-        gainExp
+        gainExp,
+        computeActionYield
     };
 }

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -8,17 +8,18 @@ function buildActionTooltip(action) {
     }
     const effects = [];
     if (action.baseYield) {
-        if (action.baseYield.stats) {
-            for (const [stat, val] of Object.entries(action.baseYield.stats)) {
+        const yields = computeActionYield(action);
+        if (yields.stats) {
+            for (const [stat, val] of Object.entries(yields.stats)) {
                 const name = Lang.stat(stat) || capitalize(stat);
-                effects.push(`+${val} ${name}`);
+                effects.push(`+${val.toFixed(2)} ${name}`);
             }
         }
-        if (action.baseYield.resources) {
-            for (const [res, val] of Object.entries(action.baseYield.resources)) {
+        if (yields.resources) {
+            for (const [res, val] of Object.entries(yields.resources)) {
                 const name = Lang.resource(res) || capitalize(res);
                 const sign = val >= 0 ? '+' : '';
-                effects.push(`${sign}${val} ${name}`);
+                effects.push(`${sign}${val.toFixed(2)} ${name}`);
             }
         }
     }
@@ -44,17 +45,25 @@ function actionLabel(action) {
 function createActionElement(action) {
     if (action.hidden) return null;
     const li = document.createElement('li');
+    li.classList.add('expandable');
     const fill = document.createElement('div');
     fill.className = 'level-fill';
     const pct = Math.floor((action.exp / action.expToNext) * 100);
     fill.style.width = `${pct}%`;
     li.appendChild(fill);
+    const arrow = document.createElement('span');
+    arrow.className = 'expand-arrow';
+    arrow.textContent = '▶';
+    li.appendChild(arrow);
     const label = document.createElement('span');
     label.className = 'action-label';
     label.textContent = actionLabel(action);
     li.appendChild(label);
+    const detail = document.createElement('div');
+    detail.className = 'expand-details';
+    detail.innerHTML = buildActionTooltip(action);
+    li.appendChild(detail);
     li.dataset.taskId = action.id;
-    li.dataset.tooltip = buildActionTooltip(action);
     const tierClass = `tier-${getActionTier(action.level)}`;
     li.classList.add(tierClass);
     if (!actionAffordable(action)) {
@@ -69,6 +78,11 @@ function createActionElement(action) {
             e.dataTransfer.setData('text/plain', action.id);
         });
         li.addEventListener('dragend', () => li.classList.remove('dragging'));
+        arrow.addEventListener('click', e => {
+            e.stopPropagation();
+            const expanded = li.classList.toggle('expanded');
+            arrow.textContent = expanded ? '▼' : '▶';
+        });
         li.addEventListener('click', () => {
             if (selectedActionId === action.id) {
                 selectedActionId = null;
@@ -170,7 +184,8 @@ function updateTaskList() {
             const pct = Math.floor((action.exp / action.expToNext) * 100);
             fill.style.width = `${pct}%`;
         }
-        li.dataset.tooltip = buildActionTooltip(action);
+        const detail = li.querySelector('.expand-details');
+        if (detail) detail.innerHTML = buildActionTooltip(action);
         li.classList.remove('tier-normal', 'tier-bronze', 'tier-silver', 'tier-gold');
         li.classList.add(`tier-${getActionTier(action.level)}`);
         li.classList.toggle('unaffordable', !actionAffordable(action));

--- a/js/ui/furniture.js
+++ b/js/ui/furniture.js
@@ -15,13 +15,28 @@ const FurnitureUI = {
         this.listEl.innerHTML = '';
         FurnitureSystem.furniture.forEach(f => {
             const li = document.createElement('li');
-            li.textContent = f.name;
-            li.dataset.tooltip = `${f.description}\nCost: ${Utils.formatCost(f.cost)}`;
+            li.classList.add('expandable');
+            const arrow = document.createElement('span');
+            arrow.className = 'expand-arrow';
+            arrow.textContent = '▶';
+            li.appendChild(arrow);
+            const label = document.createElement('span');
+            label.textContent = f.name;
+            li.appendChild(label);
+            const detail = document.createElement('div');
+            detail.className = 'expand-details';
+            detail.innerHTML = `${f.description}<br>Cost: ${Utils.formatCost(f.cost)}`;
+            li.appendChild(detail);
             if (Inventory.canAfford(f.cost)) li.classList.add('affordable');
             li.addEventListener('click', () => FurnitureSystem.purchase(f.id));
             li.setAttribute('draggable', 'true');
             li.addEventListener('dragstart', () => li.classList.add('dragging'));
             li.addEventListener('dragend', () => li.classList.remove('dragging'));
+            arrow.addEventListener('click', e => {
+                e.stopPropagation();
+                const expanded = li.classList.toggle('expanded');
+                arrow.textContent = expanded ? '▼' : '▶';
+            });
             this.listEl.appendChild(li);
         });
     }

--- a/js/ui/home.js
+++ b/js/ui/home.js
@@ -23,9 +23,19 @@ const HomeUI = {
         HomeSystem.homes.forEach(h => {
             if (h.default) return;
             const li = document.createElement('li');
-            li.textContent = h.name;
+            li.classList.add('expandable');
+            const arrow = document.createElement('span');
+            arrow.className = 'expand-arrow';
+            arrow.textContent = '▶';
+            li.appendChild(arrow);
+            const label = document.createElement('span');
+            label.textContent = h.name;
+            li.appendChild(label);
+            const detail = document.createElement('div');
+            detail.className = 'expand-details';
+            detail.innerHTML = `${h.description}<br>Cost: ${Utils.formatCost(h.cost)}`;
+            li.appendChild(detail);
             li.dataset.homeId = h.id;
-            li.dataset.tooltip = `${h.description}\nCost: ${Utils.formatCost(h.cost)}`;
             if (Inventory.canAfford(h.cost)) li.classList.add('affordable');
             li.setAttribute('draggable', 'true');
             li.addEventListener('dragstart', e => {
@@ -33,6 +43,11 @@ const HomeUI = {
                 e.dataTransfer.setData('text/plain', h.id);
             });
             li.addEventListener('dragend', () => li.classList.remove('dragging'));
+            arrow.addEventListener('click', e => {
+                e.stopPropagation();
+                const expanded = li.classList.toggle('expanded');
+                arrow.textContent = expanded ? '▼' : '▶';
+            });
             li.addEventListener('click', () => HomeSystem.setHome(h.id));
             this.listEl.appendChild(li);
         });


### PR DESCRIPTION
## Summary
- remove button tooltips in favor of expandable panels
- compute action yields using current multipliers
- show calculated yields in expanded panels
- style expand arrows and hidden details

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-cov`
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_688ba8c7987c8330be42306b65aa4bd6