### PR TITLE
Implement furniture destroyed event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Action buttons display experience progress toward the next level.
 - Action list refreshes when experience is gained and shows a red outline when an action is unaffordable.
 - Tooltips removed from action, home and furniture buttons. Buttons can expand to show details with calculated yields.
+- Furniture destruction now triggers a `furniture:destroyed` event to lock its actions.
+- Prestige removes furniture-unlocked actions using the new event.
 
 
 ## [0.41.66] - 2025-07-14

--- a/js/furniture.js
+++ b/js/furniture.js
@@ -66,6 +66,7 @@ const FurnitureSystem = {
     use(actionId, seconds = 1) {
         let changed = false;
         const removedUnlocks = [];
+        const destroyed = [];
         const updated = State.furniture.filter(f => {
             const def = this.furniture.find(x => x.id === f.id);
             if (!def) return false;
@@ -76,13 +77,14 @@ const FurnitureSystem = {
             if (f.durability > 0) return true;
             changed = true;
             removedUnlocks.push(...def.unlocks);
+            destroyed.push({ id: f.id, unlocks: def.unlocks });
             return false;
         });
         setState('furniture', updated);
         if (typeof PubSub !== 'undefined') {
             PubSub.publish('furniture:durabilityChanged');
             if (changed) {
-                removedUnlocks.forEach(a => PubSub.publish('lock:action', a));
+                destroyed.forEach(d => PubSub.publish('furniture:destroyed', d));
                 PubSub.publish('furniture:updated');
             }
         }

--- a/js/pubsub.js
+++ b/js/pubsub.js
@@ -80,6 +80,11 @@ function initPubSub() {
             });
         }
     });
+    PubSub.subscribe('furniture:destroyed', data => {
+        if (data && Array.isArray(data.unlocks)) {
+            data.unlocks.forEach(id => PubSub.publish('lock:action', id));
+        }
+    });
     PubSub.subscribe('unlock:encounter', id => {
         const enc = EncounterGenerator.encounters.find(e => e.id === id);
         if (enc) enc.locked = false;

--- a/js/save_system.js
+++ b/js/save_system.js
@@ -143,6 +143,13 @@ const SaveSystem = {
         setState('inventory', {});
         setState('homeId', null);
         setState('furniture', []);
+        if (typeof PubSub !== 'undefined' && Array.isArray(FurnitureSystem.furniture)) {
+            FurnitureSystem.furniture.forEach(f => {
+                if (Array.isArray(f.unlocks)) {
+                    PubSub.publish('furniture:destroyed', { id: f.id, unlocks: f.unlocks });
+                }
+            });
+        }
         setState('adventureSlots', State.adventureSlots.map(() => ({
             text: '', progress: 0, duration: 1, encounter: null, active: false
         })));

--- a/tests/test_furniture_destroyed_event.py
+++ b/tests/test_furniture_destroyed_event.py
@@ -1,0 +1,19 @@
+import os
+
+
+def test_furniture_destroyed_event_in_furniture_system():
+    with open(os.path.join('js', 'furniture.js')) as f:
+        text = f.read()
+    assert 'furniture:destroyed' in text
+
+
+def test_pubsub_handles_furniture_destroyed():
+    with open(os.path.join('js', 'pubsub.js')) as f:
+        text = f.read()
+    assert 'furniture:destroyed' in text
+
+
+def test_prestige_triggers_furniture_cleanup():
+    with open(os.path.join('js', 'save_system.js')) as f:
+        text = f.read()
+    assert 'furniture:destroyed' in text


### PR DESCRIPTION
## Summary
- trigger `furniture:destroyed` when durability hits zero
- subscribe to that event in `pubsub.js` to lock related actions
- clean up furniture actions during prestige using this event
- document the change in `CHANGELOG.md`
- add tests for the new event

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bad7d199c83309e9c033eea959cbf