### PR TITLE
Fix #149: preserve expanded list state and arrow placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Action buttons display experience progress toward the next level.
 - Action list refreshes when experience is gained and shows a red outline when an action is unaffordable.
 - Tooltips removed from action, home and furniture buttons. Buttons can expand to show details with calculated yields.
+- Expand arrows moved to the right side of buttons and belongings lists remember expanded items.
 
 
 ## [0.41.66] - 2025-07-14

--- a/css/styles.css
+++ b/css/styles.css
@@ -453,7 +453,7 @@ li.unaffordable {
 
 .expand-arrow {
     cursor: pointer;
-    margin-right: 0.25rem;
+    margin-left: 0.25rem;
 }
 
 .expand-details {

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -51,14 +51,14 @@ function createActionElement(action) {
     const pct = Math.floor((action.exp / action.expToNext) * 100);
     fill.style.width = `${pct}%`;
     li.appendChild(fill);
-    const arrow = document.createElement('span');
-    arrow.className = 'expand-arrow';
-    arrow.textContent = '▶';
-    li.appendChild(arrow);
     const label = document.createElement('span');
     label.className = 'action-label';
     label.textContent = actionLabel(action);
     li.appendChild(label);
+    const arrow = document.createElement('span');
+    arrow.className = 'expand-arrow';
+    arrow.textContent = '▶';
+    li.appendChild(arrow);
     const detail = document.createElement('div');
     detail.className = 'expand-details';
     detail.innerHTML = buildActionTooltip(action);

--- a/js/ui/furniture.js
+++ b/js/ui/furniture.js
@@ -1,5 +1,6 @@
 const FurnitureUI = {
     listEl: null,
+    expandedFurniture: new Set(),
     init() {
         this.listEl = document.getElementById('furniture-list');
         if (!this.listEl) return;
@@ -12,17 +13,18 @@ const FurnitureUI = {
     },
     render() {
         if (!this.listEl) return;
+        const prevExpanded = new Set(this.expandedFurniture);
         this.listEl.innerHTML = '';
         FurnitureSystem.furniture.forEach(f => {
             const li = document.createElement('li');
             li.classList.add('expandable');
+            const label = document.createElement('span');
+            label.textContent = f.name;
+            li.appendChild(label);
             const arrow = document.createElement('span');
             arrow.className = 'expand-arrow';
             arrow.textContent = '▶';
             li.appendChild(arrow);
-            const label = document.createElement('span');
-            label.textContent = f.name;
-            li.appendChild(label);
             const detail = document.createElement('div');
             detail.className = 'expand-details';
             detail.innerHTML = `${f.description}<br>Cost: ${Utils.formatCost(f.cost)}`;
@@ -32,10 +34,16 @@ const FurnitureUI = {
             li.setAttribute('draggable', 'true');
             li.addEventListener('dragstart', () => li.classList.add('dragging'));
             li.addEventListener('dragend', () => li.classList.remove('dragging'));
+            if (prevExpanded.has(f.id)) {
+                li.classList.add('expanded');
+                arrow.textContent = '▼';
+                this.expandedFurniture.add(f.id);
+            }
             arrow.addEventListener('click', e => {
                 e.stopPropagation();
                 const expanded = li.classList.toggle('expanded');
                 arrow.textContent = expanded ? '▼' : '▶';
+                if (expanded) this.expandedFurniture.add(f.id); else this.expandedFurniture.delete(f.id);
             });
             this.listEl.appendChild(li);
         });

--- a/js/ui/home.js
+++ b/js/ui/home.js
@@ -3,6 +3,7 @@ const HomeUI = {
     slotContainer: null,
     furnitureContainer: null,
     furnitureSlots: [],
+    expandedHomes: new Set(),
     init() {
         this.listEl = document.getElementById('home-list');
         this.slotContainer = document.getElementById('home-slot');
@@ -19,18 +20,19 @@ const HomeUI = {
         }
     },
     renderList() {
+        const prevExpanded = new Set(this.expandedHomes);
         this.listEl.innerHTML = '';
         HomeSystem.homes.forEach(h => {
             if (h.default) return;
             const li = document.createElement('li');
             li.classList.add('expandable');
+            const label = document.createElement('span');
+            label.textContent = h.name;
+            li.appendChild(label);
             const arrow = document.createElement('span');
             arrow.className = 'expand-arrow';
             arrow.textContent = '▶';
             li.appendChild(arrow);
-            const label = document.createElement('span');
-            label.textContent = h.name;
-            li.appendChild(label);
             const detail = document.createElement('div');
             detail.className = 'expand-details';
             detail.innerHTML = `${h.description}<br>Cost: ${Utils.formatCost(h.cost)}`;
@@ -43,10 +45,16 @@ const HomeUI = {
                 e.dataTransfer.setData('text/plain', h.id);
             });
             li.addEventListener('dragend', () => li.classList.remove('dragging'));
+            if (prevExpanded.has(h.id)) {
+                li.classList.add('expanded');
+                arrow.textContent = '▼';
+                this.expandedHomes.add(h.id);
+            }
             arrow.addEventListener('click', e => {
                 e.stopPropagation();
                 const expanded = li.classList.toggle('expanded');
                 arrow.textContent = expanded ? '▼' : '▶';
+                if (expanded) this.expandedHomes.add(h.id); else this.expandedHomes.delete(h.id);
             });
             li.addEventListener('click', () => HomeSystem.setHome(h.id));
             this.listEl.appendChild(li);

--- a/tests/test_expand_arrow_style.py
+++ b/tests/test_expand_arrow_style.py
@@ -1,0 +1,23 @@
+import os
+
+
+def test_expand_arrow_margin_left():
+    with open(os.path.join('css', 'styles.css')) as f:
+        text = f.read()
+    start = text.find('.expand-arrow')
+    assert start != -1
+    snippet = text[start:start+80]
+    assert 'margin-left' in snippet
+    assert 'margin-right' not in snippet
+
+
+def test_home_ui_expanded_state():
+    with open(os.path.join('js', 'ui', 'home.js')) as f:
+        text = f.read()
+    assert 'expandedHomes' in text
+
+
+def test_furniture_ui_expanded_state():
+    with open(os.path.join('js', 'ui', 'furniture.js')) as f:
+        text = f.read()
+    assert 'expandedFurniture' in text


### PR DESCRIPTION
## Summary
- move expand arrow to the right side of buttons
- remember expanded items on the belongings screen
- update CSS for new arrow position
- add regression tests
- document the change in the changelog

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_688bae216ce48330b8bbac240ad9e028