### PR TITLE
Add multi-adventure encounter system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Expand arrows moved to the right side of buttons and belongings lists remember expanded items.
 - Furniture destruction now triggers a `furniture:destroyed` event to lock its actions.
 - Prestige removes furniture-unlocked actions using the new event.
+- Added AdventureManager with per-adventure encounter pools and levels.
 
 
 ## [0.41.66] - 2025-07-14

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -47,6 +47,49 @@ class Encounter {
     }
 }
 
+const AdventureManager = {
+    adventures: {
+        forest: {
+            id: 'forest',
+            name: 'Forest near the Hut',
+            encounterIds: [
+                'chopWood',
+                'collectStones',
+                'foragingHerbs',
+                'rabbitHunt',
+                'wolfAmbush',
+                'gatherWater',
+                'berryPicking',
+                'digClay'
+            ]
+        }
+    },
+    getCurrent() {
+        return this.adventures[State.currentAdventure] || this.adventures.forest;
+    },
+    getLevel(id) {
+        const advId = id || State.currentAdventure;
+        return (State.adventureLevels && State.adventureLevels[advId]) || 1;
+    },
+    incrementLevel(id) {
+        const advId = id || State.currentAdventure;
+        const lvl = this.getLevel(advId) + 1;
+        setState(['adventureLevels', advId], lvl);
+        return lvl;
+    },
+    decrementLevel(id) {
+        const advId = id || State.currentAdventure;
+        let lvl = this.getLevel(advId);
+        if (lvl > 1) lvl -= 1;
+        setState(['adventureLevels', advId], lvl);
+        return lvl;
+    }
+};
+
+if (typeof module !== 'undefined') {
+    module.exports = { AdventureManager, EncounterGenerator, Encounter };
+}
+
 const EncounterGenerator = {
     encounters: [],
     container: null,
@@ -103,16 +146,14 @@ const EncounterGenerator = {
     },
 
     incrementLevel() {
-        this.level += 1;
+        this.level = AdventureManager.incrementLevel();
         setState('encounterLevel', this.level);
         this.updateName();
         this.updateProgressBar();
     },
 
     decrementLevel() {
-        if (this.level > 1) {
-            this.level -= 1;
-        }
+        this.level = AdventureManager.decrementLevel();
         setState('encounterLevel', this.level);
         this.updateName();
         this.updateProgressBar();
@@ -129,7 +170,7 @@ const EncounterGenerator = {
 
     init() {
         this.container = null;
-        this.level = State.encounterLevel || 1;
+        this.level = AdventureManager.getLevel();
         this.updateName();
         this.updateProgressBar();
         this.populateSlots();
@@ -152,7 +193,9 @@ const EncounterGenerator = {
         });
         if (story) return story;
 
+        const ids = AdventureManager.getCurrent().encounterIds || [];
         const pool = this.encounters.filter(e => {
+            if (ids.length && !ids.includes(e.id)) return false;
             if (e.locked) return false;
             if ((e.minLevel || 0) > this.level) return false;
             // Recover is only triggered after retreats and should not be random

--- a/js/save_system.js
+++ b/js/save_system.js
@@ -49,6 +49,14 @@ const SaveSystem = {
                 if (State.encounterStreak === undefined) {
                     setState('encounterStreak', 0);
                 }
+                if (!State.currentAdventure) {
+                    setState('currentAdventure', 'forest');
+                }
+                if (!State.adventureLevels || typeof State.adventureLevels !== 'object') {
+                    setState('adventureLevels', { forest: 1 });
+                } else if (State.adventureLevels.forest === undefined) {
+                    setState(['adventureLevels', 'forest'], 1);
+                }
                 if (State.adventureSlotCount === undefined || State.adventureSlotCount > 1) {
                     setState('adventureSlotCount', 1);
                 }
@@ -153,6 +161,8 @@ const SaveSystem = {
         setState('adventureSlots', State.adventureSlots.map(() => ({
             text: '', progress: 0, duration: 1, encounter: null, active: false
         })));
+        setState('currentAdventure', 'forest');
+        setState('adventureLevels', { forest: 1 });
         setState('encounterLevel', 1);
         setState('encounterStreak', 0);
         Object.entries(preserved).forEach(([id, data]) => {

--- a/js/state.js
+++ b/js/state.js
@@ -164,6 +164,8 @@ const State = {
     masteryPoints: 0,
     encounterLevel: 1,
     encounterStreak: 0,
+    currentAdventure: 'forest',
+    adventureLevels: { forest: 1 },
     autoProgress: true,
     darkMode: true,
     language: 'en',

--- a/tests/test_prestige.py
+++ b/tests/test_prestige.py
@@ -36,20 +36,22 @@ def test_prestige_ui_defined():
     assert 'prestige-block' in text
 
 
-def test_encounter_level_default_one():
+def test_adventure_defaults_present():
     with open(os.path.join('js', 'state.js')) as f:
         text = f.read()
-    assert 'encounterLevel: 1' in text
+    assert "currentAdventure: 'forest'" in text
+    assert "adventureLevels: { forest: 1 }" in text
     with open(os.path.join('js', 'save_system.js')) as f:
         mtext = f.read()
-    assert "setState('encounterLevel', 1)" in mtext
+    assert "setState('currentAdventure', 'forest')" in mtext
+    assert "setState('adventureLevels', { forest: 1 })" in mtext
 
 
-def test_prestige_resets_encounter_level():
+def test_prestige_resets_adventure_levels():
     path = os.path.join('js', 'save_system.js')
     with open(path) as f:
         text = f.read()
-    assert text.count("setState('encounterLevel', 1)") >= 2
+    assert text.count("setState('adventureLevels', { forest: 1 })") >= 1
 
 
 def test_prestige_keeps_action_slots():


### PR DESCRIPTION
## Summary
- track the current adventure and per-adventure levels in `State`
- default state values added when loading old saves
- introduce `AdventureManager` with encounter pools and level helpers
- generate encounters only from the active adventure pool
- reset adventure levels on prestige
- update tests for new properties

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ce1538fc88330af15229d7b0a443b