### PR TITLE
Add manual adventure activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.67] - 2025-07-25
 ### Changed
+- Adventure tab now requires manual activation and shows encounters in the Active slot.
 - Action buttons show level progress with a darkening background instead of text.
 - Resource costs are deducted at the start of every action cycle.
 - Furniture purchases no longer replace existing pieces; repairing uses scaled cost.

--- a/index.html
+++ b/index.html
@@ -102,13 +102,16 @@
                     </div>
                     <div class="tab-content hidden" data-tab="adventure">
                         <h2 data-i18n="Adventure">Adventure</h2>
-                        <p id="encounter-location"></p>
-                        <progress id="encounter-level-progress" value="0" max="10"></progress>
-                        <div id="adventure-controls">
-                            <button id="return-btn" data-i18n="Return">Return</button>
-                            <label><input type="checkbox" id="autoprogress-toggle" checked> <span data-i18n="Autoprogress">Autoprogress</span></label>
+                        <button id="adventure-start-btn"></button>
+                        <div id="adventure-content" class="hidden">
+                            <p id="encounter-location"></p>
+                            <progress id="encounter-level-progress" value="0" max="10"></progress>
+                            <div id="adventure-controls">
+                                <button id="return-btn" data-i18n="Return">Return</button>
+                                <label><input type="checkbox" id="autoprogress-toggle" checked> <span data-i18n="Autoprogress">Autoprogress</span></label>
+                            </div>
+                            <div id="adventure-slots" class="slots"></div>
                         </div>
-                        <div id="adventure-slots" class="slots"></div>
                     </div>
                     <div class="tab-content hidden" data-tab="inventory">
                         <div class="tab-section" data-section="home" data-type="slots">
@@ -215,6 +218,7 @@
     <script src="js/engine.js"></script>
     <script src="js/action_engine.js"></script>
     <script src="js/adventure_engine.js"></script>
+    <script src="js/ui/adventure.js"></script>
     <script src="js/slotSetup.js"></script>
     <script src="js/ui/encounter.js"></script>
     <script src="js/ui/modal.js"></script>

--- a/js/action_engine.js
+++ b/js/action_engine.js
@@ -2,6 +2,9 @@
 
 const ActionEngine = {
     start(slotIndex, actionId) {
+        if (typeof AdventureEngine !== 'undefined' && AdventureEngine.active) {
+            AdventureEngine.cancel();
+        }
         const slot = State.slots[slotIndex];
         const action = actions[actionId];
         if (!action) return;

--- a/js/adventure_engine.js
+++ b/js/adventure_engine.js
@@ -4,7 +4,37 @@ const AdventureEngine = {
     activeIndex: null,
     waitResource: null,
     recovering: false,
+    active: false,
+    start() {
+        if (this.active) return;
+        this.active = true;
+        setState(['slots', 0, 'blocked'], true);
+        this.startSlot(0);
+        if (typeof PubSub !== 'undefined') {
+            PubSub.publish('adventure:started');
+        }
+    },
+    cancel() {
+        if (!this.active) return;
+        this.active = false;
+        if (this.activeIndex !== null) {
+            const slot = State.adventureSlots[this.activeIndex];
+            slot.active = false;
+            slot.encounter = null;
+            slot.progress = 0;
+            updateAdventureSlotUI(this.activeIndex);
+        }
+        this.activeIndex = null;
+        this.waitResource = null;
+        this.recovering = false;
+        setState(['slots', 0, 'blocked'], false);
+        EncounterGenerator.populateSlots();
+        if (typeof PubSub !== 'undefined') {
+            PubSub.publish('adventure:stopped');
+        }
+    },
     startSlot(i = 0) {
+        if (!this.active) return;
         if (this.recovering) {
             const rec = EncounterGenerator.getRecoverEncounter();
             if (rec) {
@@ -37,8 +67,9 @@ const AdventureEngine = {
         updateAdventureSlotUI(i);
     },
     tick(delta) {
+        if (!this.active) return;
         if (this.activeIndex === null) {
-            if (State.healerGoneSeen) this.startSlot(0);
+            this.startSlot(0);
             return;
         }
         const slot = State.adventureSlots[this.activeIndex];
@@ -71,7 +102,7 @@ const AdventureEngine = {
                     EncounterGenerator.updateProgressBar();
                 }
             }
-            this.startSlot(this.activeIndex);
+            if (this.active) this.startSlot(this.activeIndex);
         } else {
             updateAdventureSlotUI(this.activeIndex);
         }

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -163,7 +163,7 @@ const EncounterGenerator = {
         this.populateSlots();
         setState('encounterStreak', 0);
         this.updateProgressBar();
-        if (typeof AdventureEngine !== 'undefined') {
+        if (typeof AdventureEngine !== 'undefined' && AdventureEngine.active) {
             AdventureEngine.startSlot(0);
         }
     },

--- a/js/main.js
+++ b/js/main.js
@@ -93,6 +93,7 @@ async function init() {
     setupInventorySlots();
     EncounterGenerator.init();
     EncounterUI.init();
+    AdventureUI.init();
     StoryUI.init();
     ModalUI.init();
     setupDragAndDrop();
@@ -183,9 +184,6 @@ async function init() {
             SaveSystem.save();
         });
     }
-    document.getElementById('return-btn').addEventListener('click', () => {
-        retreat('resolve', true);
-    });
     document.getElementById('reset-btn').addEventListener('click', () => SaveSystem.reset());
     const prestigeBtn = document.getElementById('prestige-btn');
     if (prestigeBtn) {

--- a/js/save_system.js
+++ b/js/save_system.js
@@ -77,6 +77,9 @@ const SaveSystem = {
                 if (State.banditsAmbushSeen === undefined) {
                     setState('banditsAmbushSeen', false);
                 }
+                if (State.adventureActive === undefined) {
+                    setState('adventureActive', false);
+                }
                 if (State.autoProgress === undefined) {
                     setState('autoProgress', true);
                 }
@@ -163,6 +166,7 @@ const SaveSystem = {
         })));
         setState('currentAdventure', 'forest');
         setState('adventureLevels', { forest: 1 });
+        setState('adventureActive', false);
         setState('encounterLevel', 1);
         setState('encounterStreak', 0);
         Object.entries(preserved).forEach(([id, data]) => {

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -198,6 +198,30 @@ function updateSlotUI(i) {
     if (!slotEl) return;
     const progressEl = slotEl.querySelector('progress');
     const labelEl = slotEl.querySelector('.label');
+    if (typeof AdventureEngine !== 'undefined' && AdventureEngine.active &&
+        AdventureEngine.activeIndex === i) {
+        const aSlot = State.adventureSlots[i];
+        const enc = aSlot.encounter;
+        RARITY_CLASSES.forEach(r => slotEl.classList.remove(`rarity-${r}`));
+        progressEl.max = 1;
+        progressEl.value = aSlot.progress || 0;
+        if (enc) {
+            labelEl.textContent = enc.name;
+            if (enc.image) {
+                slotEl.style.backgroundImage = `url(${enc.image})`;
+                slotEl.style.backgroundSize = 'cover';
+            } else {
+                slotEl.style.backgroundImage = 'none';
+            }
+            slotEl.classList.add(`rarity-${enc.rarity}`);
+            slotEl.dataset.tooltip = enc.description || '';
+        } else {
+            labelEl.textContent = '';
+            slotEl.style.backgroundImage = 'none';
+            slotEl.dataset.tooltip = '';
+        }
+        return;
+    }
     slotEl.classList.toggle('blocked', slot.blocked);
     if (!slot.actionId) {
         slot.actionId = State.defaultActionId;

--- a/js/state.js
+++ b/js/state.js
@@ -166,6 +166,7 @@ const State = {
     encounterStreak: 0,
     currentAdventure: 'forest',
     adventureLevels: { forest: 1 },
+    adventureActive: false,
     autoProgress: true,
     darkMode: true,
     language: 'en',

--- a/js/ui/adventure.js
+++ b/js/ui/adventure.js
@@ -1,0 +1,34 @@
+const AdventureUI = {
+    init() {
+        this.startBtn = document.getElementById('adventure-start-btn');
+        this.content = document.getElementById('adventure-content');
+        if (!this.startBtn || !this.content) return;
+        this.startBtn.addEventListener('click', () => {
+            AdventureEngine.start();
+            this.update();
+        });
+        const returnBtn = document.getElementById('return-btn');
+        if (returnBtn) {
+            returnBtn.addEventListener('click', () => {
+                AdventureEngine.cancel();
+                this.update();
+            });
+        }
+        if (typeof PubSub !== 'undefined') {
+            PubSub.subscribe('adventure:started', () => this.update());
+            PubSub.subscribe('adventure:stopped', () => this.update());
+        }
+        this.update();
+    },
+    update() {
+        const adv = AdventureManager.getCurrent();
+        if (this.startBtn) this.startBtn.textContent = adv.name;
+        const active = AdventureEngine.active;
+        this.startBtn.classList.toggle('hidden', active);
+        this.content.classList.toggle('hidden', !active);
+    }
+};
+
+if (typeof module !== 'undefined') {
+    module.exports = { AdventureUI };
+}


### PR DESCRIPTION
## Summary
- allow starting and stopping adventures manually
- display active encounter in the Active slot
- cancel adventures when another action starts
- add `adventure-start-btn` UI and supporting script
- record change in changelog

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688cf02272488330a62e1a35dd3ee49b