### PR TITLE
Improve adventure UI and retreat behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.67] - 2025-07-25
 ### Changed
+- Adventure list uses expandable buttons with encounter previews and cancels when resources run out.
 - Adventure tab now requires manual activation and shows encounters in the Active slot.
 - Action buttons show level progress with a darkening background instead of text.
 - Resource costs are deducted at the start of every action cycle.

--- a/css/styles.css
+++ b/css/styles.css
@@ -214,6 +214,11 @@ body.left-collapsed #left {
     padding: 0;
 }
 
+#adventure-list {
+    list-style: none;
+    padding: 0;
+}
+
 #home-list,
 #furniture-list,
 #research-list,
@@ -230,6 +235,16 @@ body.left-collapsed #left {
     margin-bottom: 0.5rem;
     padding: 0.5rem;
     cursor: grab;
+    border-radius: 4px;
+    position: relative;
+    overflow: hidden;
+}
+
+#adventure-list li {
+    background: var(--task-bg);
+    margin-bottom: 0.5rem;
+    padding: 0.5rem;
+    cursor: pointer;
     border-radius: 4px;
     position: relative;
     overflow: hidden;

--- a/index.html
+++ b/index.html
@@ -102,7 +102,7 @@
                     </div>
                     <div class="tab-content hidden" data-tab="adventure">
                         <h2 data-i18n="Adventure">Adventure</h2>
-                        <button id="adventure-start-btn"></button>
+                        <ul id="adventure-list"></ul>
                         <div id="adventure-content" class="hidden">
                             <p id="encounter-location"></p>
                             <progress id="encounter-level-progress" value="0" max="10"></progress>

--- a/js/adventure_engine.js
+++ b/js/adventure_engine.js
@@ -2,13 +2,16 @@
 
 const AdventureEngine = {
     activeIndex: null,
-    waitResource: null,
-    recovering: false,
     active: false,
     start() {
         if (this.active) return;
         this.active = true;
+        const actionSlot = State.slots[0];
+        actionSlot.actionId = null;
+        actionSlot.progress = 0;
+        actionSlot.text = '';
         setState(['slots', 0, 'blocked'], true);
+        updateSlotUI(0);
         this.startSlot(0);
         if (typeof PubSub !== 'undefined') {
             PubSub.publish('adventure:started');
@@ -25,9 +28,13 @@ const AdventureEngine = {
             updateAdventureSlotUI(this.activeIndex);
         }
         this.activeIndex = null;
-        this.waitResource = null;
-        this.recovering = false;
+        const actionSlot = State.slots[0];
+        actionSlot.actionId = State.defaultActionId;
+        actionSlot.blocked = false;
+        actionSlot.progress = actions[State.defaultActionId].progress || 0;
+        actionSlot.text = actions[State.defaultActionId] ? actions[State.defaultActionId].name : '';
         setState(['slots', 0, 'blocked'], false);
+        updateSlotUI(0);
         EncounterGenerator.populateSlots();
         if (typeof PubSub !== 'undefined') {
             PubSub.publish('adventure:stopped');
@@ -35,27 +42,16 @@ const AdventureEngine = {
     },
     startSlot(i = 0) {
         if (!this.active) return;
-        if (this.recovering) {
-            const rec = EncounterGenerator.getRecoverEncounter();
-            if (rec) {
-                const slot = State.adventureSlots[i];
-                slot.encounter = rec;
-                slot.duration = rec.getDuration();
-                slot.progress = 0;
-                slot.active = true;
-                this.activeIndex = i;
-                this.recovering = false;
-                updateAdventureSlotUI(i);
-                return;
-            }
-        }
-        if (this.waitResource) {
-            const res = State.resources[this.waitResource];
-            if (res && res.value < ResourceSystem.max(res)) {
-                this.activeIndex = null;
-                return;
-            }
-            this.waitResource = null;
+        const rec = EncounterGenerator.getRecoverEncounter();
+        if (rec && State.resources.health.value < ResourceSystem.max(State.resources.health)) {
+            const slot = State.adventureSlots[i];
+            slot.encounter = rec;
+            slot.duration = rec.getDuration();
+            slot.progress = 0;
+            slot.active = true;
+            this.activeIndex = i;
+            updateAdventureSlotUI(i);
+            return;
         }
         const encounter = EncounterGenerator.randomEncounter();
         const slot = State.adventureSlots[i];
@@ -118,10 +114,9 @@ function retreat(resourceName, manual = false) {
     const msg = Lang.log('retreat', { encounter: enc, resource: resLabel }) ||
         `You had to retreat after ${enc} because you ran out of ${resLabel}.`;
     Log.add(msg);
-    AdventureEngine.waitResource = resourceName;
-    if (!manual) AdventureEngine.recovering = true;
     EncounterGenerator.decrementLevel();
     EncounterGenerator.resetProgress();
+    AdventureEngine.cancel();
 }
 
 function checkHealth() {

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -67,6 +67,19 @@ const AdventureManager = {
     getCurrent() {
         return this.adventures[State.currentAdventure] || this.adventures.forest;
     },
+    setCurrent(id) {
+        if (this.adventures[id]) {
+            setState('currentAdventure', id);
+        }
+    },
+    getEncounterNames(id) {
+        const adv = this.adventures[id] || this.adventures[State.currentAdventure];
+        const ids = adv ? adv.encounterIds || [] : [];
+        return ids.map(eid => {
+            const enc = EncounterGenerator.encounters.find(e => e.id === eid);
+            return enc ? enc.name : eid;
+        });
+    },
     getLevel(id) {
         const advId = id || State.currentAdventure;
         return (State.adventureLevels && State.adventureLevels[advId]) || 1;

--- a/js/ui/adventure.js
+++ b/js/ui/adventure.js
@@ -1,12 +1,10 @@
 const AdventureUI = {
+    expanded: new Set(),
     init() {
-        this.startBtn = document.getElementById('adventure-start-btn');
+        this.listEl = document.getElementById('adventure-list');
         this.content = document.getElementById('adventure-content');
-        if (!this.startBtn || !this.content) return;
-        this.startBtn.addEventListener('click', () => {
-            AdventureEngine.start();
-            this.update();
-        });
+        if (!this.listEl || !this.content) return;
+        this.renderList();
         const returnBtn = document.getElementById('return-btn');
         if (returnBtn) {
             returnBtn.addEventListener('click', () => {
@@ -20,11 +18,52 @@ const AdventureUI = {
         }
         this.update();
     },
+    renderList() {
+        const prev = new Set(this.expanded);
+        this.expanded.clear();
+        this.listEl.innerHTML = '';
+        Object.values(AdventureManager.adventures).forEach(adv => {
+            const li = document.createElement('li');
+            li.classList.add('expandable');
+            const label = document.createElement('span');
+            label.className = 'action-label';
+            label.textContent = adv.name;
+            li.appendChild(label);
+            const arrow = document.createElement('span');
+            arrow.className = 'expand-arrow';
+            arrow.textContent = '▶';
+            li.appendChild(arrow);
+            const detail = document.createElement('div');
+            detail.className = 'expand-details';
+            const names = (adv.encounterIds || []).map(id => {
+                const enc = EncounterGenerator.encounters.find(e => e.id === id);
+                return enc ? enc.name : id;
+            });
+            detail.textContent = names.join(', ');
+            li.appendChild(detail);
+            li.dataset.adventureId = adv.id;
+            arrow.addEventListener('click', e => {
+                e.stopPropagation();
+                const expanded = li.classList.toggle('expanded');
+                arrow.textContent = expanded ? '▼' : '▶';
+                if (expanded) this.expanded.add(adv.id); else this.expanded.delete(adv.id);
+            });
+            li.addEventListener('click', () => {
+                setState('currentAdventure', adv.id);
+                AdventureEngine.start();
+                this.update();
+            });
+            if (prev.has(adv.id)) {
+                li.classList.add('expanded');
+                arrow.textContent = '▼';
+                this.expanded.add(adv.id);
+            }
+            this.listEl.appendChild(li);
+        });
+    },
     update() {
-        const adv = AdventureManager.getCurrent();
-        if (this.startBtn) this.startBtn.textContent = adv.name;
         const active = AdventureEngine.active;
-        this.startBtn.classList.toggle('hidden', active);
+        this.listEl.classList.toggle('hidden', active);
         this.content.classList.toggle('hidden', !active);
     }
 };

--- a/tests/test_adventure_buttons.py
+++ b/tests/test_adventure_buttons.py
@@ -1,0 +1,21 @@
+import os
+
+
+def test_adventure_list_exists():
+    with open('index.html') as f:
+        html = f.read()
+    assert 'adventure-list' in html
+
+
+def test_adventure_ui_expandable():
+    path = os.path.join('js', 'ui', 'adventure.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'expand-arrow' in text and 'expandable' in text
+
+
+def test_retreat_stops_adventure():
+    with open(os.path.join('js', 'adventure_engine.js')) as f:
+        text = f.read()
+    assert 'AdventureEngine.cancel();' in text
+    assert 'State.defaultActionId' in text


### PR DESCRIPTION
## Summary
- show adventures as expandable buttons with encounter names
- style adventure list like action buttons
- replace action slot when adventure starts and restore default when stopping
- stop adventure on retreat
- test new adventure list and cancel logic

## Testing
- `pip install -r requirements.txt`
- `pytest --maxfail=1 -q`
- `pytest --cov=js -q`

------
https://chatgpt.com/codex/tasks/task_e_688d071349cc8330bd6cda800702ee6e