### PR TITLE
Display active encounter in main action slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 - Adventure list uses expandable buttons with encounter previews and cancels when resources run out.
 - Adventure tab now requires manual activation and shows encounters in the Active slot.
+- Current encounter now appears in the action slot while adventuring.
 - Action buttons show level progress with a darkening background instead of text.
 - Resource costs are deducted at the start of every action cycle.
 - Furniture purchases no longer replace existing pieces; repairing uses scaled cost.

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -288,6 +288,8 @@ function updateAdventureSlotUI(i) {
         slotEl.style.backgroundImage = 'none';
         slotEl.dataset.tooltip = '';
     }
+    const actionEl = document.querySelector(`#slots .slot[data-slot="${i}"]`);
+    if (actionEl) updateSlotUI(i);
 }
 
 if (typeof module !== 'undefined') {

--- a/tests/test_adventure_buttons.py
+++ b/tests/test_adventure_buttons.py
@@ -19,3 +19,11 @@ def test_retreat_stops_adventure():
         text = f.read()
     assert 'AdventureEngine.cancel();' in text
     assert 'State.defaultActionId' in text
+
+
+def test_adventure_slot_updates_action_slot():
+    path = os.path.join('js', 'slotSetup.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'const actionEl' in text
+    assert 'updateSlotUI(i)' in text


### PR DESCRIPTION
## Summary
- ensure adventure slot UI refresh also updates main action slot
- test that slotSetup links adventure slot to action slot
- document feature in changelog

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_688d0ac6809c833087258cbc11a9ff48