### PR TITLE
Add short description to adventure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.67] - 2025-07-25
 ### Changed
+- Adventure details now show a short description when expanded.
 - Adventure list uses expandable buttons with encounter previews and cancels when resources run out.
 - Adventure tab now requires manual activation and shows encounters in the Active slot.
 - Current encounter now appears in the action slot while adventuring.

--- a/data/lang/uk.json
+++ b/data/lang/uk.json
@@ -114,6 +114,11 @@
     "fishingTrip": { "name": "Риболовля", "description": "Закиньте вудку в озеро за швидкою здобиччю." },
     "gatherWater": { "name": "Збір води", "description": "Зберіть свіжу воду з найближчого джерела." }
   },
+  "adventures": {
+    "forest": {
+      "shortDescription": "Дослідіть ліс і зберіть корисні ресурси"
+    }
+  },
   "locations": {
     "Hut in the Forest": "Хатина в лісі",
     "Abandoned Clearing": "Покинута галявина",

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -52,6 +52,7 @@ const AdventureManager = {
         forest: {
             id: 'forest',
             name: 'Forest near the Hut',
+            shortDescription: 'Explore the forest and collect some useful resources',
             encounterIds: [
                 'chopWood',
                 'collectStones',

--- a/js/ui/adventure.js
+++ b/js/ui/adventure.js
@@ -35,11 +35,15 @@ const AdventureUI = {
             li.appendChild(arrow);
             const detail = document.createElement('div');
             detail.className = 'expand-details';
-            const names = (adv.encounterIds || []).map(id => {
-                const enc = EncounterGenerator.encounters.find(e => e.id === id);
-                return enc ? enc.name : id;
-            });
-            detail.textContent = names.join(', ');
+            if (adv.shortDescription) {
+                detail.textContent = adv.shortDescription;
+            } else {
+                const names = (adv.encounterIds || []).map(id => {
+                    const enc = EncounterGenerator.encounters.find(e => e.id === id);
+                    return enc ? enc.name : id;
+                });
+                detail.textContent = names.join(', ');
+            }
             li.appendChild(detail);
             li.dataset.adventureId = adv.id;
             arrow.addEventListener('click', e => {

--- a/tests/test_adventure_description.py
+++ b/tests/test_adventure_description.py
@@ -1,0 +1,14 @@
+import os
+
+def test_adventure_short_description_present():
+    path = os.path.join('js', 'encounter.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'shortDescription' in text
+
+
+def test_adventure_ui_uses_description():
+    path = os.path.join('js', 'ui', 'adventure.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'shortDescription' in text


### PR DESCRIPTION
## Summary
- display adventure shortDescription in the UI when expanded
- add short description to the forest adventure
- include translation for the new description
- add tests for shortDescription support
- document change in CHANGELOG

## Testing
- `pytest -q`
- `pytest --cov=./`

------
https://chatgpt.com/codex/tasks/task_e_688d0d20f88c8330a712fac7623043b8