### PR TITLE
Fix action slot assignment logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Furniture destruction now triggers a `furniture:destroyed` event to lock its actions.
 - Prestige removes furniture-unlocked actions using the new event.
 - Added AdventureManager with per-adventure encounter pools and levels.
+- Clicking an action now assigns it directly to an available slot.
 
 
 ## [0.41.66] - 2025-07-14

--- a/js/main.js
+++ b/js/main.js
@@ -3,7 +3,6 @@ const LOGIC_TICK_MS = 100;
 const TICKS_PER_SECOND = 1000 / LOGIC_TICK_MS;
 
 let actions = {};
-let selectedActionId = null;
 
 function updateUI() {
     StatsUI.update();

--- a/js/pubsub.js
+++ b/js/pubsub.js
@@ -66,7 +66,6 @@ function initPubSub() {
         if (actions[id]) {
             actions[id].hidden = true;
             actions[id].locked = true;
-            if (selectedActionId === id) selectedActionId = null;
             updateTaskList();
             State.slots.forEach((slot, i) => {
                 if (slot.actionId === id) {

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -42,6 +42,15 @@ function actionLabel(action) {
     return `${action.name} Lv.${action.level}`;
 }
 
+function assignActionToSlot(actionId) {
+    let index = State.slots.findIndex(s => !s.actionId);
+    if (index === -1) {
+        index = State.slots.findIndex(s => s.actionId === State.defaultActionId);
+    }
+    if (index === -1) index = 0;
+    ActionEngine.start(index, actionId);
+}
+
 function createActionElement(action) {
     if (action.hidden) return null;
     const li = document.createElement('li');
@@ -83,16 +92,7 @@ function createActionElement(action) {
             const expanded = li.classList.toggle('expanded');
             arrow.textContent = expanded ? '▼' : '▶';
         });
-        li.addEventListener('click', () => {
-            if (selectedActionId === action.id) {
-                selectedActionId = null;
-                li.classList.remove('selected');
-            } else {
-                selectedActionId = action.id;
-                document.querySelectorAll('#task-list li').forEach(el => el.classList.remove('selected'));
-                li.classList.add('selected');
-            }
-        });
+        li.addEventListener('click', () => assignActionToSlot(action.id));
     }
     return li;
 }
@@ -154,11 +154,6 @@ function setupDragAndDrop() {
             const index = parseInt(slotEl.dataset.slot, 10);
             ActionEngine.start(index, id);
         });
-        slotEl.addEventListener('click', () => {
-            if (!selectedActionId) return;
-            const index = parseInt(slotEl.dataset.slot, 10);
-            ActionEngine.start(index, selectedActionId);
-        });
     });
 }
 
@@ -169,7 +164,6 @@ function updateTaskList() {
         const li = list.querySelector(`li[data-task-id="${action.id}"]`);
         if (action.hidden) {
             if (li) li.remove();
-            if (selectedActionId === action.id) selectedActionId = null;
             return;
         }
         if (!li) {
@@ -302,6 +296,7 @@ if (typeof module !== 'undefined') {
         setupDragAndDrop,
         updateTaskList,
         updateSlotUI,
-        updateAdventureSlotUI
+        updateAdventureSlotUI,
+        assignActionToSlot
     };
 }


### PR DESCRIPTION
## Summary
- remove selection state from actions
- auto-assign clicked actions to the first open or default slot
- drop outdated docs entry about tapping actions
- document the new behavior in the changelog

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_688d0c9e77f88330b1ad9c8c62a76bc7