### PR TITLE
Add action queuing for blocked tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Prestige removes furniture-unlocked actions using the new event.
 - Added AdventureManager with per-adventure encounter pools and levels.
 - Clicking an action now assigns it directly to an available slot.
+- Blocked actions are queued and resume automatically once resources recover.
 
 
 ## [0.41.66] - 2025-07-14

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ In this prototype you awaken in the body of a 16‑year‑old after bandits ambu
 * Action buttons darken as they fill with experience toward the next level
 * New slots and actions unlock over time
 * Resources can be replenished or crafted
+* Blocked actions queue automatically until resources recover
 * Research progress persists across page reloads and prestiges
 * Unlocked actions remain available after reloads and prestiges
 * Optional prestige/reset layer for long-term scaling

--- a/css/styles.css
+++ b/css/styles.css
@@ -292,6 +292,13 @@ body.left-collapsed #left {
     margin-top: 1rem;
 }
 
+.slot-wrapper {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
 #adventure-slots {
     display: flex;
 }
@@ -435,6 +442,11 @@ body.left-collapsed #left {
 
 .slot.blocked {
     border-color: #cc6666;
+}
+
+.queue-slot {
+    min-height: 3rem;
+    opacity: 0.8;
 }
 
 #task-list li.locked {

--- a/js/action_engine.js
+++ b/js/action_engine.js
@@ -19,6 +19,7 @@ const ActionEngine = {
             }
         }
         if (!canStart) {
+            slot.queue = { id: actionId, progress: 0, costPaid: false };
             slot.actionId = State.defaultActionId;
             slot.blocked = false;
             slot.progress = actions[State.defaultActionId].progress || 0;
@@ -44,7 +45,39 @@ const ActionEngine = {
         DeltaEngine.calculate();
         DeltaEngine.apply(delta, State.time);
         State.slots.forEach((slot, i) => {
-            if (!slot.actionId || slot.blocked) return;
+            if (slot.blocked) return;
+            if (slot.actionId === State.defaultActionId && slot.queue && slot.queue.id) {
+                const qAction = actions[slot.queue.id];
+                let canResume = true;
+                if (qAction.resourceCost && !slot.queue.costPaid) {
+                    for (const r in qAction.resourceCost) {
+                        const res = State.resources[r];
+                        if (!res || res.value < qAction.resourceCost[r]) {
+                            canResume = false;
+                            break;
+                        }
+                    }
+                }
+                if (canResume && qAction.resourceConsumption) {
+                    const missing = canAfford(qAction.resourceConsumption, delta);
+                    if (missing) canResume = false;
+                }
+                if (canResume) {
+                    if (!slot.queue.costPaid && qAction.resourceCost) {
+                        for (const r in qAction.resourceCost) {
+                            ResourceSystem.consume(State.resources[r], qAction.resourceCost[r]);
+                        }
+                        if (typeof PubSub !== 'undefined') {
+                            PubSub.publish('resources:updated');
+                        }
+                    }
+                    slot.actionId = slot.queue.id;
+                    slot.progress = slot.queue.progress;
+                    slot.text = qAction.name;
+                    slot.queue = null;
+                }
+            }
+            if (!slot.actionId) return;
             if (typeof FurnitureSystem !== 'undefined' && FurnitureSystem.use) {
                 FurnitureSystem.use(slot.actionId, delta * State.time);
                 if (!slot.actionId) return; // action may be locked and removed
@@ -54,6 +87,7 @@ const ActionEngine = {
             if (action.resourceConsumption) {
                 const missing = canAfford(action.resourceConsumption, delta);
                 if (missing) {
+                    slot.queue = { id: slot.actionId, progress: slot.progress, costPaid: true };
                     slot.actionId = State.defaultActionId;
                     slot.blocked = false;
                     slot.progress = actions[State.defaultActionId].progress || 0;
@@ -90,6 +124,7 @@ const ActionEngine = {
                         }
                     }
                     if (!canRun) {
+                        slot.queue = { id: slot.actionId, progress: slot.progress, costPaid: false };
                         slot.actionId = State.defaultActionId;
                         slot.blocked = false;
                         slot.progress = actions[State.defaultActionId].progress || 0;

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -104,17 +104,31 @@ function setupSlots() {
     if (!Array.isArray(State.slots)) setState('slots', []);
     if (State.slotCount === undefined) setState('slotCount', State.slots.length);
     while (State.slots.length < State.slotCount) {
-        pushState(['slots'], { actionId: State.defaultActionId, progress: 0, blocked: false, text: '' });
+        pushState(['slots'], {
+            actionId: State.defaultActionId,
+            progress: 0,
+            blocked: false,
+            text: '',
+            queue: null
+        });
     }
     if (State.slots.length > State.slotCount) {
         setState('slots', State.slots.slice(0, State.slotCount));
     }
     for (let i = 0; i < State.slotCount; i++) {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'slot-wrapper';
         const slot = new BaseSlot();
         const slotEl = slot.el;
         slotEl.dataset.slot = i;
         slotEl.dataset.tooltip = 'Drag an action here';
-        container.appendChild(slotEl);
+        wrapper.appendChild(slotEl);
+        const qSlot = new BaseSlot();
+        const qEl = qSlot.el;
+        qEl.dataset.queue = i;
+        qEl.classList.add('queue-slot');
+        wrapper.appendChild(qEl);
+        container.appendChild(wrapper);
         updateSlotUI(i);
     }
 }
@@ -146,7 +160,7 @@ function setupInventorySlots() {
 }
 
 function setupDragAndDrop() {
-    document.querySelectorAll('#slots .slot').forEach(slotEl => {
+    document.querySelectorAll('#slots .slot[data-slot]').forEach(slotEl => {
         slotEl.addEventListener('dragover', e => e.preventDefault());
         slotEl.addEventListener('drop', e => {
             e.preventDefault();
@@ -189,6 +203,7 @@ function updateTaskList() {
 function updateSlotUI(i) {
     const slot = State.slots[i];
     const slotEl = document.querySelector(`#slots .slot[data-slot="${i}"]`);
+    const queueEl = document.querySelector(`#slots .slot[data-queue="${i}"]`);
     if (!slotEl) return;
     const progressEl = slotEl.querySelector('progress');
     const labelEl = slotEl.querySelector('.label');
@@ -230,6 +245,33 @@ function updateSlotUI(i) {
         slotEl.style.backgroundImage = 'none';
     }
     slotEl.dataset.tooltip = buildActionTooltip(action);
+    if (queueEl) {
+        if (slot.queue && slot.queue.id) {
+            const qAction = actions[slot.queue.id];
+            queueEl.classList.remove('hidden');
+            const qp = queueEl.querySelector('progress');
+            const qLabel = queueEl.querySelector('.label');
+            if (qp) {
+                qp.max = 1;
+                qp.value = slot.queue.progress || 0;
+            }
+            if (qLabel) qLabel.textContent = qAction.name;
+            if (qAction.image) {
+                queueEl.style.backgroundImage = `url(${qAction.image})`;
+            } else {
+                queueEl.style.backgroundImage = 'none';
+            }
+            queueEl.dataset.tooltip = buildActionTooltip(qAction);
+        } else {
+            queueEl.classList.add('hidden');
+            const qp = queueEl.querySelector('progress');
+            const qLabel = queueEl.querySelector('.label');
+            if (qp) qp.value = 0;
+            if (qLabel) qLabel.textContent = '';
+            queueEl.style.backgroundImage = 'none';
+            queueEl.dataset.tooltip = '';
+        }
+    }
 }
 
 function updateAdventureSlotUI(i) {

--- a/js/state.js
+++ b/js/state.js
@@ -176,7 +176,13 @@ const State = {
 };
 
 for (let i = 0; i < State.slotCount; i++) {
-    State.slots.push({ actionId: DEFAULT_ACTION_ID, progress: 0, blocked: false, text: '' });
+    State.slots.push({
+        actionId: DEFAULT_ACTION_ID,
+        progress: 0,
+        blocked: false,
+        text: '',
+        queue: null
+    });
 }
 
 for (let i = 0; i < State.adventureSlotCount; i++) {

--- a/tests/test_action_queue.py
+++ b/tests/test_action_queue.py
@@ -1,0 +1,13 @@
+import os
+
+
+def test_queue_property_in_state():
+    with open(os.path.join('js', 'state.js')) as f:
+        text = f.read()
+    assert 'queue:' in text
+
+
+def test_queue_slot_styles_defined():
+    with open(os.path.join('css', 'styles.css')) as f:
+        text = f.read()
+    assert '.queue-slot' in text and '.slot-wrapper' in text


### PR DESCRIPTION
## Summary
- queue blocked actions when starting or mid-cycle
- resume queued actions once resources recover
- display queued actions with new slot wrapper UI
- document the new mechanic and list new styles

## Testing
- `pytest -q`
- `pytest --cov=js`

------
https://chatgpt.com/codex/tasks/task_e_688d2dcddfa883308c8c7103a149a821