### PR TITLE
Implement queued encounters and full-resource resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ### Added
 - Activation cost for actions deducted only once on start with visible block state when insufficient resources.
 - Slot progress now resumes from previous value when reselecting an action.
+- Queued actions and adventures wait until all resources are full before resuming.
+- Retreats now store the last encounter and resume it after recovery.
 ## [0.41.66] - 2025-07-14
 ### Changed
 - Clicking a task immediately assigns it to an available slot.

--- a/js/action_engine.js
+++ b/js/action_engine.js
@@ -10,6 +10,7 @@ const ActionEngine = {
             const missing = canAfford(action.activationCost, 1, 1);
             if (missing) {
                 slot.blocked = true;
+                slot.queuedActionId = actionId;
                 slot.progress = 0;
                 slot.text = `${Lang.resource(missing) || missing} required`;
                 updateSlotUI(slotIndex);
@@ -20,6 +21,7 @@ const ActionEngine = {
             }
             if (typeof PubSub !== 'undefined') PubSub.publish('resources:updated');
         }
+        slot.queuedActionId = null;
         slot.actionId = actionId;
         slot.progress = action.exp / action.expToNext;
         slot.text = action.name;
@@ -29,6 +31,12 @@ const ActionEngine = {
         DeltaEngine.calculate();
         DeltaEngine.apply(delta, State.time);
         State.slots.forEach((slot, i) => {
+            if (slot.blocked && slot.queuedActionId) {
+                if (Utils.allResourcesFull()) {
+                    this.start(i, slot.queuedActionId);
+                }
+                return;
+            }
             if (!slot.actionId) return;
             if (typeof FurnitureSystem !== 'undefined' && FurnitureSystem.use) {
                 FurnitureSystem.use(slot.actionId, delta * State.time);

--- a/js/adventure_engine.js
+++ b/js/adventure_engine.js
@@ -20,14 +20,19 @@ const AdventureEngine = {
             }
         }
         if (this.waitResource) {
-            const res = State.resources[this.waitResource];
-            if (res && res.value < ResourceSystem.max(res)) {
+            if (!Utils.allResourcesFull()) {
                 this.activeIndex = null;
                 return;
             }
             this.waitResource = null;
         }
-        const encounter = EncounterGenerator.randomEncounter();
+        let encounter = null;
+        if (State.queuedEncounterId) {
+            encounter = EncounterGenerator.encounters.find(e => e.id === State.queuedEncounterId) || null;
+            setState('queuedEncounterId', null);
+        } else {
+            encounter = EncounterGenerator.randomEncounter();
+        }
         const slot = State.adventureSlots[i];
         slot.encounter = encounter;
         slot.duration = encounter ? encounter.getDuration() : 1;
@@ -87,6 +92,9 @@ function retreat(resourceName, manual = false) {
     const msg = Lang.log('retreat', { encounter: enc, resource: resLabel }) ||
         `You had to retreat after ${enc} because you ran out of ${resLabel}.`;
     Log.add(msg);
+    if (slot && slot.encounter) {
+        setState('queuedEncounterId', slot.encounter.id);
+    }
     AdventureEngine.waitResource = resourceName;
     if (!manual) AdventureEngine.recovering = true;
     EncounterGenerator.decrementLevel();

--- a/js/save_system.js
+++ b/js/save_system.js
@@ -35,6 +35,7 @@ const SaveSystem = {
                     State.slots.forEach(s => {
                         if (!s.actionId) s.actionId = State.defaultActionId;
                         if (s.text === undefined) s.text = '';
+                        if (s.queuedActionId === undefined) s.queuedActionId = null;
                     });
                 } else {
                     setState('slots', []);
@@ -79,6 +80,9 @@ const SaveSystem = {
                 }
                 if (!State.hideBelowRarity) {
                     setState('hideBelowRarity', 'rare');
+                }
+                if (State.queuedEncounterId === undefined) {
+                    setState('queuedEncounterId', null);
                 }
                 if (State.homeId === undefined) {
                     setState('homeId', null);
@@ -144,6 +148,10 @@ const SaveSystem = {
         setState('adventureSlots', State.adventureSlots.map(() => ({
             text: '', progress: 0, duration: 1, encounter: null, active: false
         })));
+        setState('queuedEncounterId', null);
+        State.slots.forEach((_, i) => {
+            setState(['slots', i, 'queuedActionId'], null);
+        });
         setState('encounterLevel', 1);
         setState('encounterStreak', 0);
         Object.entries(preserved).forEach(([id, data]) => {

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -61,7 +61,7 @@ function setupSlots() {
     if (!Array.isArray(State.slots)) setState('slots', []);
     if (State.slotCount === undefined) setState('slotCount', State.slots.length);
     while (State.slots.length < State.slotCount) {
-        pushState(['slots'], { actionId: State.defaultActionId, progress: 0, blocked: false, text: '' });
+        pushState(['slots'], { actionId: State.defaultActionId, progress: 0, blocked: false, text: '', queuedActionId: null });
     }
     if (State.slots.length > State.slotCount) {
         setState('slots', State.slots.slice(0, State.slotCount));

--- a/js/state.js
+++ b/js/state.js
@@ -164,6 +164,7 @@ const State = {
     masteryPoints: 0,
     encounterLevel: 1,
     encounterStreak: 0,
+    queuedEncounterId: null,
     autoProgress: true,
     darkMode: true,
     language: 'en',
@@ -173,7 +174,7 @@ const State = {
 };
 
 for (let i = 0; i < State.slotCount; i++) {
-    State.slots.push({ actionId: DEFAULT_ACTION_ID, progress: 0, blocked: false, text: '' });
+    State.slots.push({ actionId: DEFAULT_ACTION_ID, progress: 0, blocked: false, text: '', queuedActionId: null });
 }
 
 for (let i = 0; i < State.adventureSlotCount; i++) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -32,6 +32,17 @@ const Utils = {
                 return `${qty}x ${name}`;
             })
             .join(', ');
+    },
+
+    /**
+     * Check if all resources are at their maximum values.
+     * @returns {boolean}
+     */
+    allResourcesFull() {
+        return RESOURCE_KEYS.every(k => {
+            const res = State.resources[k];
+            return res && res.value >= ResourceSystem.max(res);
+        });
     }
 };
 

--- a/tests/test_queue_resume.py
+++ b/tests/test_queue_resume.py
@@ -1,0 +1,19 @@
+import os
+
+def test_state_queue_fields():
+    with open(os.path.join('js', 'state.js')) as f:
+        text = f.read()
+    assert 'queuedEncounterId' in text
+    assert 'queuedActionId' in text
+
+def test_action_engine_queue():
+    with open(os.path.join('js', 'action_engine.js')) as f:
+        text = f.read()
+    assert 'queuedActionId' in text
+    assert 'allResourcesFull' in text
+
+def test_adventure_engine_resume():
+    with open(os.path.join('js', 'adventure_engine.js')) as f:
+        text = f.read()
+    assert 'queuedEncounterId' in text
+    assert 'allResourcesFull' in text


### PR DESCRIPTION
## Summary
- queue encounters and resume the last one after recovery
- wait for all resources to be full before resuming queued actions or adventures
- support queued actions in state and engines
- document queue behaviour in changelog
- add coverage test for queue code

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-cov`
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_688d32c2ef388330a9d29c981bdc63c1