### PR TITLE
Require resources at max before queued actions resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
-## [0.41.67] - 2025-07-25
+## [0.41.67] - 2025-08-02
 ### Changed
+- Queued actions now wait for all related resources to reach their maximum before starting or resuming.
 - Adventure details now show a short description when expanded.
 - Adventure list uses expandable buttons with encounter previews and cancels when resources run out.
 - Adventure tab now requires manual activation and shows encounters in the Active slot.

--- a/js/action_engine.js
+++ b/js/action_engine.js
@@ -10,9 +10,10 @@ const ActionEngine = {
         if (!action) return;
         let canStart = true;
         if (action.resourceCost) {
+            // require all cost resources to be at their maximum before starting
             for (const r in action.resourceCost) {
                 const res = State.resources[r];
-                if (!res || res.value < action.resourceCost[r]) {
+                if (!res || res.value !== ResourceSystem.max(res)) {
                     canStart = false;
                     break;
                 }
@@ -50,17 +51,24 @@ const ActionEngine = {
                 const qAction = actions[slot.queue.id];
                 let canResume = true;
                 if (qAction.resourceCost && !slot.queue.costPaid) {
+                    // resume only when cost resources are fully replenished
                     for (const r in qAction.resourceCost) {
                         const res = State.resources[r];
-                        if (!res || res.value < qAction.resourceCost[r]) {
+                        if (!res || res.value !== ResourceSystem.max(res)) {
                             canResume = false;
                             break;
                         }
                     }
                 }
                 if (canResume && qAction.resourceConsumption) {
-                    const missing = canAfford(qAction.resourceConsumption, delta);
-                    if (missing) canResume = false;
+                    // consumption resources must also be at maximum before resuming
+                    for (const r in qAction.resourceConsumption) {
+                        const res = State.resources[r];
+                        if (!res || res.value !== ResourceSystem.max(res)) {
+                            canResume = false;
+                            break;
+                        }
+                    }
                 }
                 if (canResume) {
                     if (!slot.queue.costPaid && qAction.resourceCost) {
@@ -116,9 +124,10 @@ const ActionEngine = {
                 // deduct start cost for next cycle
                 if (action.resourceCost) {
                     let canRun = true;
+                    // next cycle only begins when cost resources are back at max
                     for (const r in action.resourceCost) {
                         const res = State.resources[r];
-                        if (!res || res.value < action.resourceCost[r]) {
+                        if (!res || res.value !== ResourceSystem.max(res)) {
                             canRun = false;
                             break;
                         }

--- a/tests/test_action_queue.py
+++ b/tests/test_action_queue.py
@@ -1,4 +1,6 @@
+import json
 import os
+import subprocess
 
 
 def test_queue_property_in_state():
@@ -11,3 +13,62 @@ def test_queue_slot_styles_defined():
     with open(os.path.join('css', 'styles.css')) as f:
         text = f.read()
     assert '.queue-slot' in text and '.slot-wrapper' in text
+
+
+def test_queued_action_resumes_only_at_max():
+    script = r"""
+const { ActionEngine } = require('./js/action_engine.js');
+global.State = {
+    defaultActionId: 'idle',
+    time: 1,
+    slots: [{ actionId: 'idle', progress: 0, blocked: false, text: '', queue: null }],
+    resources: {
+        gold: { value: 5, baseMax: 10, maxAdditions: [], maxMultipliers: [] },
+        mana: { value: 9, baseMax: 10, maxAdditions: [], maxMultipliers: [] }
+    }
+};
+global.actions = {
+    idle: { name: 'Idle', progress: 0 },
+    work: { name: 'Work', progress: 0, resourceCost: { gold: 1 }, resourceConsumption: { mana: 1 } }
+};
+global.ResourceSystem = {
+    max: res => res.baseMax,
+    consume: (res, amt) => { res.value -= amt; }
+};
+global.DeltaEngine = { calculate: () => {}, apply: () => {} };
+global.updateSlotUI = () => {};
+global.FurnitureSystem = {};
+global.canAfford = () => null;
+global.scalingMultiplier = () => 1;
+global.applyYield = () => {};
+global.gainExp = () => {};
+global.PubSub = { publish: () => {} };
+global.SoftCapSystem = { apply: () => {} };
+global.checkHealth = () => {};
+global.SaveSystem = { save: () => {} };
+
+ActionEngine.start(0, 'work');
+console.log(JSON.stringify(State.slots[0]));
+ActionEngine.tick(1);
+console.log(JSON.stringify(State.slots[0]));
+State.resources.gold.value = State.resources.gold.baseMax;
+ActionEngine.tick(1);
+console.log(JSON.stringify(State.slots[0]));
+State.resources.mana.value = State.resources.mana.baseMax;
+ActionEngine.tick(0);
+console.log(JSON.stringify(State.slots[0]));
+"""
+    result = subprocess.run(
+        ['node', '-e', script], check=True, capture_output=True, text=True
+    )
+    lines = result.stdout.strip().splitlines()
+    assert len(lines) == 4
+    start_slot = json.loads(lines[0])
+    tick1_slot = json.loads(lines[1])
+    tick2_slot = json.loads(lines[2])
+    tick3_slot = json.loads(lines[3])
+    assert start_slot['actionId'] == 'idle'
+    assert start_slot['queue']['id'] == 'work'
+    assert tick1_slot['actionId'] == 'idle'
+    assert tick2_slot['actionId'] == 'idle'
+    assert tick3_slot['actionId'] == 'work'


### PR DESCRIPTION
## Summary
- use `ResourceSystem.max` so actions start only when their required resources are at maximum
- ensure queued actions resume only when all cost and consumption resources are full
- add regression test for queued action resumption requirements

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e6c95414883308049ecedc30df75c