### PR TITLE
feat: resume adventures after resource depletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.67] - 2025-07-25
 ### Changed
+- Adventure encounters pause on resource depletion and resume when resources are fully restored.
 - Adventure details now show a short description when expanded.
 - Adventure list uses expandable buttons with encounter previews and cancels when resources run out.
 - Adventure tab now requires manual activation and shows encounters in the Active slot.

--- a/js/action_engine.js
+++ b/js/action_engine.js
@@ -3,7 +3,7 @@
 const ActionEngine = {
     start(slotIndex, actionId) {
         if (typeof AdventureEngine !== 'undefined' && AdventureEngine.active) {
-            AdventureEngine.cancel();
+            AdventureEngine.cancel(true);
         }
         const slot = State.slots[slotIndex];
         const action = actions[actionId];

--- a/js/adventure_engine.js
+++ b/js/adventure_engine.js
@@ -17,8 +17,8 @@ const AdventureEngine = {
             PubSub.publish('adventure:started');
         }
     },
-    cancel() {
-        if (!this.active) return;
+    cancel(manual = false) {
+        if (!this.active && !manual) return;
         this.active = false;
         if (this.activeIndex !== null) {
             const slot = State.adventureSlots[this.activeIndex];
@@ -36,6 +36,9 @@ const AdventureEngine = {
         setState(['slots', 0, 'blocked'], false);
         updateSlotUI(0);
         EncounterGenerator.populateSlots();
+        if (manual) {
+            State.adventureSlots.forEach(s => { s.queue = null; });
+        }
         if (typeof PubSub !== 'undefined') {
             PubSub.publish('adventure:stopped');
         }
@@ -52,7 +55,30 @@ const AdventureEngine = {
         updateAdventureSlotUI(i);
     },
     tick(delta) {
-        if (!this.active) return;
+        if (!this.active) {
+            for (let i = 0; i < State.adventureSlots.length; i++) {
+                const slot = State.adventureSlots[i];
+                if (slot.queue) {
+                    const cost = slot.queue.encounter.getResourceCost();
+                    const ready = Object.keys(cost).every(r => {
+                        const res = State.resources[r];
+                        return res && res.value >= ResourceSystem.max(res);
+                    });
+                    if (ready) {
+                        slot.encounter = slot.queue.encounter;
+                        slot.progress = slot.queue.progress;
+                        slot.duration = slot.encounter.getDuration();
+                        slot.queue = null;
+                        slot.active = true;
+                        this.active = true;
+                        this.activeIndex = i;
+                        updateAdventureSlotUI(i);
+                    }
+                    break;
+                }
+            }
+            return;
+        }
         if (this.activeIndex === null) {
             this.startSlot(0);
             return;
@@ -62,7 +88,14 @@ const AdventureEngine = {
         const cost = slot.encounter.getResourceCost();
         const missing = canAfford(cost, delta);
         if (missing) {
-            retreat(missing);
+            slot.queue = { encounter: slot.encounter, progress: slot.progress };
+            slot.encounter = null;
+            slot.progress = 0;
+            slot.active = false;
+            this.active = false;
+            const idx = this.activeIndex;
+            this.activeIndex = null;
+            updateAdventureSlotUI(idx);
             return;
         }
         if (slot.progress >= 1) {
@@ -93,7 +126,7 @@ const AdventureEngine = {
         }
         checkHealth();
     }
-};
+  };
 
 function retreat(resourceName, manual = false) {
     const slot = AdventureEngine.activeIndex !== null ?
@@ -105,7 +138,7 @@ function retreat(resourceName, manual = false) {
     Log.add(msg);
     EncounterGenerator.decrementLevel();
     EncounterGenerator.resetProgress();
-    AdventureEngine.cancel();
+    AdventureEngine.cancel(manual);
 }
 
 function checkHealth() {

--- a/js/state.js
+++ b/js/state.js
@@ -186,7 +186,7 @@ for (let i = 0; i < State.slotCount; i++) {
 }
 
 for (let i = 0; i < State.adventureSlotCount; i++) {
-    State.adventureSlots.push({ text: '', progress: 0, duration: 1, encounter: null, active: false });
+    State.adventureSlots.push({ text: '', progress: 0, duration: 1, encounter: null, active: false, queue: null });
 }
 
 async function loadBaseData() {

--- a/js/ui/adventure.js
+++ b/js/ui/adventure.js
@@ -8,7 +8,7 @@ const AdventureUI = {
         const returnBtn = document.getElementById('return-btn');
         if (returnBtn) {
             returnBtn.addEventListener('click', () => {
-                AdventureEngine.cancel();
+                AdventureEngine.cancel(true);
                 this.update();
             });
         }

--- a/tests/test_adventure_buttons.py
+++ b/tests/test_adventure_buttons.py
@@ -17,7 +17,7 @@ def test_adventure_ui_expandable():
 def test_retreat_stops_adventure():
     with open(os.path.join('js', 'adventure_engine.js')) as f:
         text = f.read()
-    assert 'AdventureEngine.cancel();' in text
+    assert 'AdventureEngine.cancel(manual);' in text
     assert 'State.defaultActionId' in text
 
 

--- a/tests/test_adventure_queue.py
+++ b/tests/test_adventure_queue.py
@@ -1,0 +1,87 @@
+import json
+import subprocess
+
+
+def run_script():
+    script = r"""
+const { State, ResourceSystem } = require('./js/state.js');
+const { canAfford } = require('./js/action_utils.js');
+
+global.State = State;
+global.ResourceSystem = ResourceSystem;
+global.actions = { rest: { progress: 0, name: 'Rest' } };
+global.updateSlotUI = () => {};
+global.setState = () => {};
+global.updateState = () => {};
+global.updateAdventureSlotUI = () => {};
+global.EncounterGenerator = {
+    randomEncounter: () => null,
+    resolve: () => {},
+    updateProgressBar: () => {},
+    incrementLevel: () => {},
+    decrementLevel: () => {},
+    resetProgress: () => {},
+    populateSlots: () => {}
+};
+global.canAfford = canAfford;
+const { AdventureEngine } = require('./js/adventure_engine.js');
+
+const slot = State.adventureSlots[0];
+slot.encounter = {
+    id: 'test',
+    getDuration() { return 1; },
+    getResourceCost() { return { energy: 1 }; }
+};
+slot.duration = 1;
+slot.progress = 0.5;
+slot.active = true;
+
+State.resources.energy = ResourceSystem.create(0, 10);
+State.resources.health = ResourceSystem.create(100, 100);
+AdventureEngine.active = true;
+AdventureEngine.activeIndex = 0;
+
+function snapshot() {
+    return {
+        engineActive: AdventureEngine.active,
+        activeIndex: AdventureEngine.activeIndex,
+        slotActive: slot.active,
+        queue: slot.queue ? { encounterId: slot.queue.encounter.id, progress: slot.queue.progress } : null,
+        encounter: slot.encounter ? slot.encounter.id : null,
+        progress: slot.progress,
+        resource: State.resources.energy.value
+    };
+}
+
+const results = [];
+AdventureEngine.tick(1);
+results.push(snapshot());
+AdventureEngine.tick(1);
+results.push(snapshot());
+State.resources.energy.value = ResourceSystem.max(State.resources.energy);
+AdventureEngine.tick(1);
+results.push(snapshot());
+
+console.log(JSON.stringify(results));
+"""
+    proc = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    return json.loads(proc.stdout.strip())
+
+
+def test_encounter_queue_and_resume():
+    results = run_script()
+    first, second, third = results
+
+    assert first['queue']['encounterId'] == 'test'
+    assert first['queue']['progress'] == 0.5
+    assert first['engineActive'] is False
+    assert first['encounter'] is None
+
+    assert second['queue'] == first['queue']
+    assert second['engineActive'] is False
+
+    assert third['queue'] is None
+    assert third['engineActive'] is True
+    assert third['encounter'] == 'test'
+    assert third['progress'] == 0.5
+


### PR DESCRIPTION
## Summary
- queue active encounter and progress on resource depletion
- resume queued encounters once all required resources refill
- ensure manual adventure cancellation clears any queued encounter

## Testing
- `pip install -r requirements.txt`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_688e6c961b3c8330a4e6059de7da25f4