### PR TITLE
feat: add item types and consumable restoration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 - Adventure details now show a short description when expanded.
 - Adventure list uses expandable buttons with encounter previews and cancels when resources run out.
+- Items now have types and consumables restore resources instead of granting soft caps.
 - Adventure tab now requires manual activation and shows encounters in the Active slot.
 - Current encounter now appears in the action slot while adventuring.
 - Action buttons show level progress with a darkening background instead of text.

--- a/data/items.json
+++ b/data/items.json
@@ -1,231 +1,191 @@
 [
-  {
-    "id": "herb",
-    "name": "Herb",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "focus": 1
+    {
+        "id": "herb",
+        "name": "Herb",
+        "rarity": "common",
+        "type": "food",
+        "restore": {
+            "health": 1,
+            "focus": 1
+        },
+        "image": "assets/items/herb.png",
+        "description": "A collection of useful medicinal plants."
     },
-    "image": "assets/items/herb.png",
-    "description": "A collection of useful medicinal plants."
-  },
-  {
-    "id": "rabbit_meat",
-    "name": "Rabbit Meat",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "strength": 1
+    {
+        "id": "rabbit_meat",
+        "name": "Rabbit Meat",
+        "rarity": "common",
+        "type": "food",
+        "restore": {
+            "health": 5
+        },
+        "image": "assets/items/rabbit.png",
+        "description": "Fresh meat from a hunted rabbit."
     },
-    "image": "assets/items/rabbit.png",
-    "description": "Fresh meat from a hunted rabbit."
-  },
-  {
-    "id": "wolf_pelt",
-    "name": "Wolf Pelt",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "health": 2
+    {
+        "id": "wolf_pelt",
+        "name": "Wolf Pelt",
+        "rarity": "rare",
+        "type": "resource",
+        "image": "assets/items/wolfpelt.png",
+        "description": "Thick hide taken from a wolf."
     },
-    "image": "assets/items/wolfpelt.png",
-    "description": "Thick hide taken from a wolf."
-  },
-  {
-    "id": "wood_log",
-    "name": "Wood Log",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "energy": 1
+    {
+        "id": "wood_log",
+        "name": "Wood Log",
+        "rarity": "common",
+        "type": "resource",
+        "image": "assets/items/woodlog.PNG",
+        "description": "Sturdy timber cut from local trees."
     },
-    "image": "assets/items/woodlog.PNG",
-    "description": "Sturdy timber cut from local trees."
-  },
-  {
-    "id": "stone_piece",
-    "name": "Stone Piece",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "strength": 0.5
+    {
+        "id": "stone_piece",
+        "name": "Stone Piece",
+        "rarity": "common",
+        "type": "resource",
+        "image": "assets/items/stone.PNG",
+        "description": "A chunk of stone useful for building."
     },
-    "image": "assets/items/stone.PNG",
-    "description": "A chunk of stone useful for building."
-  },
-  {
-    "id": "boar_tusk",
-    "name": "Boar Tusk",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "health": 1
+    {
+        "id": "boar_tusk",
+        "name": "Boar Tusk",
+        "rarity": "rare",
+        "type": "resource",
+        "image": "assets/items/boartusk.PNG",
+        "description": "A sharp tusk prized by craftsmen."
     },
-    "image": "assets/items/boartusk.PNG",
-    "description": "A sharp tusk prized by craftsmen."
-  },
-  {
-    "id": "ore_chunk",
-    "name": "Rare Ore",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "strength": 2
+    {
+        "id": "ore_chunk",
+        "name": "Rare Ore",
+        "rarity": "rare",
+        "type": "resource",
+        "image": "assets/items/Ore.PNG",
+        "description": "Raw ore ready for smelting."
     },
-    "image": "assets/items/Ore.PNG",
-    "description": "Raw ore ready for smelting."
-  },
-  {
-    "id": "stone_spear",
-    "name": "Stone Spear",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "strength": 1.5
+    {
+        "id": "stone_spear",
+        "name": "Stone Spear",
+        "rarity": "rare",
+        "type": "equipment",
+        "image": "assets/items/spear.PNG",
+        "description": "Crude spear tipped with sharpened stone."
     },
-    "image": "assets/items/spear.PNG",
-    "description": "Crude spear tipped with sharpened stone."
-  },
-  {
-    "id": "wooden_shield",
-    "name": "Wooden Shield",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "health": 1
+    {
+        "id": "wooden_shield",
+        "name": "Wooden Shield",
+        "rarity": "rare",
+        "type": "equipment",
+        "image": "assets/items/woodshield.PNG",
+        "description": "Simple shield offering basic protection."
     },
-    "image": "assets/items/woodshield.PNG",
-    "description": "Simple shield offering basic protection."
-  },
-  {
-    "id": "leather_armor",
-    "name": "Leather Armor",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "health": 2
+    {
+        "id": "leather_armor",
+        "name": "Leather Armor",
+        "rarity": "rare",
+        "type": "equipment",
+        "image": "assets/items/leatherarmor.PNG",
+        "description": "Light armor made from treated hides."
     },
-    "image": "assets/items/leatherarmor.PNG",
-    "description": "Light armor made from treated hides."
-  },
-  {
-    "id": "gem",
-    "name": "Gem",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "focus": 2
+    {
+        "id": "gem",
+        "name": "Gem",
+        "rarity": "rare",
+        "type": "resource",
+        "image": "assets/items/gem.PNG",
+        "description": "A shimmering gemstone of unknown origin."
     },
-    "image": "assets/items/gem.PNG",
-    "description": "A shimmering gemstone of unknown origin."
-  },
-  {
-    "id": "iron_sword",
-    "name": "Iron Sword",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "strength": 2
+    {
+        "id": "iron_sword",
+        "name": "Iron Sword",
+        "rarity": "rare",
+        "type": "equipment",
+        "image": "assets/generated/iron_sword.png",
+        "description": "A sturdy blade forged from iron."
     },
-    "image": "assets/generated/iron_sword.png",
-    "description": "A sturdy blade forged from iron."
-  },
-  {
-    "id": "sturdy_bark",
-    "name": "Sturdy Bark",
-    "rarity": "rare",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "health": 1
+    {
+        "id": "sturdy_bark",
+        "name": "Sturdy Bark",
+        "rarity": "rare",
+        "type": "resource",
+        "image": "assets/user_uploaded/AQADB_gxG_UwMUt-.jpg",
+        "description": "Thick bark that can reinforce armor."
     },
-    "image": "assets/user_uploaded/AQADB_gxG_UwMUt-.jpg",
-    "description": "Thick bark that can reinforce armor."
-  },
-  {
-    "id": "water_flask",
-    "name": "Water Flask",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "energy": 1
+    {
+        "id": "water_flask",
+        "name": "Water Flask",
+        "rarity": "common",
+        "type": "food",
+        "restore": {
+            "health": 1,
+            "energy": 2
+        },
+        "image": "assets/user_uploaded/water_flask.jpg",
+        "description": "A simple container filled with fresh water."
     },
-    "image": "assets/user_uploaded/water_flask.jpg",
-    "description": "A simple container filled with fresh water."
-  },
-  {
-    "id": "iron_ore",
-    "name": "Iron Ore",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "strength": 1
+    {
+        "id": "iron_ore",
+        "name": "Iron Ore",
+        "rarity": "common",
+        "type": "resource",
+        "image": "assets/user_uploaded/iron_ore.jpg",
+        "description": "Unrefined iron waiting to be smelted."
     },
-    "image": "assets/user_uploaded/iron_ore.jpg",
-    "description": "Unrefined iron waiting to be smelted."
-  },
-  {
-    "id": "feather",
-    "name": "Feather",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "dexterity": 1
+    {
+        "id": "feather",
+        "name": "Feather",
+        "rarity": "common",
+        "type": "resource",
+        "image": "assets/user_uploaded/feather.jpg",
+        "description": "Soft plumage useful for fletching arrows."
     },
-    "image": "assets/user_uploaded/feather.jpg",
-    "description": "Soft plumage useful for fletching arrows."
-  },
-  {
-    "id": "clay",
-    "name": "Clay",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "dexterity": 1
+    {
+        "id": "clay",
+        "name": "Clay",
+        "rarity": "common",
+        "type": "resource",
+        "image": "assets/user_uploaded/clay.jpg",
+        "description": "Moist earth that can be shaped and fired."
     },
-    "image": "assets/user_uploaded/clay.jpg",
-    "description": "Moist earth that can be shaped and fired."
-  },
-  {
-    "id": "berries",
-    "name": "Berries",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "energy": 1
+    {
+        "id": "berries",
+        "name": "Berries",
+        "rarity": "common",
+        "type": "food",
+        "restore": {
+            "health": 1,
+            "energy": 1,
+            "focus": 1
+        },
+        "image": "assets/user_uploaded/berries.jpg",
+        "description": "A handful of ripe forest berries."
     },
-    "image": "assets/user_uploaded/berries.jpg",
-    "description": "A handful of ripe forest berries."
-  },
-  {
-    "id": "money",
-    "name": "Money",
-    "rarity": "common",
-    "effectType": "none",
-    "effectValue": {},
-    "image": "assets/user_uploaded/money.jpg",
-    "description": "A few coins of questionable value."
-  },
-  {
-    "id": "torch",
-    "name": "Torch",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "intelligence": 1
+    {
+        "id": "money",
+        "name": "Money",
+        "rarity": "common",
+        "type": "resource",
+        "image": "assets/user_uploaded/money.jpg",
+        "description": "A few coins of questionable value."
     },
-    "image": "assets/user_uploaded/torch.jpg",
-    "description": "Provides light when exploring dark places."
-  },
-  {
-    "id": "cooked_fish",
-    "name": "Cooked Fish",
-    "rarity": "common",
-    "effectType": "increaseSoftcap",
-    "effectValue": {
-      "intelligence": 1
+    {
+        "id": "torch",
+        "name": "Torch",
+        "rarity": "common",
+        "type": "equipment",
+        "image": "assets/user_uploaded/torch.jpg",
+        "description": "Provides light when exploring dark places."
     },
-    "image": "assets/user_uploaded/cooked_fish.jpg",
-    "description": "Freshly cooked fish that restores vigor."
-  }
+    {
+        "id": "cooked_fish",
+        "name": "Cooked Fish",
+        "rarity": "common",
+        "type": "food",
+        "restore": {
+            "health": 3,
+            "energy": 2
+        },
+        "image": "assets/user_uploaded/cooked_fish.jpg",
+        "description": "Freshly cooked fish that restores vigor."
+    }
 ]
+

--- a/js/items.js
+++ b/js/items.js
@@ -1,29 +1,27 @@
 // Agents: ItemGenerator and Inventory work together to manage loot. Encounters
-// call `Inventory.add()` with items produced here. Effects like softcap boosts
-// are handled by SoftCapSystem after items are acquired.
+// call `Inventory.add()` with items produced here. Consumable items restore
+// resources directly when used.
 class Item {
     constructor(data) {
         this.id = data.id;
         this.name = data.name;
         this.description = data.description || '';
         this.rarity = data.rarity || 'common';
-        this.effectType = data.effectType;
-        this.effectValue = data.effectValue;
+        this.type = data.type || 'resource';
+        this.restore = data.restore || {};
         this.image = data.image || null;
     }
 
     getEffectDescription() {
-        if (this.effectType === 'increaseSoftcap' && this.effectValue) {
-            const key = Object.keys(this.effectValue)[0];
-            const resName = Lang.resource(key) || key;
-            const tpl = Lang.effect('increaseSoftcap') || 'Improves {resource} cap';
-            return tpl.replace('{resource}', resName);
+        if (this.type === 'food' && this.restore) {
+            const parts = [];
+            for (const [key, val] of Object.entries(this.restore)) {
+                const resName = Lang.resource(key) || key;
+                parts.push(`+${val} ${resName}`);
+            }
+            return `Restores ${parts.join(', ')}`;
         }
         return '';
-    }
-
-    applyEffect() {
-        // Effect application now handled by SoftCapSystem.recalculateCaps
     }
 
     handleDuplicate() {
@@ -97,7 +95,6 @@ const Inventory = {
             item.handleDuplicate(State.inventory);
             updateState(['inventory', item.id, 'quantity'], q => q + 1);
         }
-        SoftCapSystem.recalculateCaps(State.inventory);
         if (typeof PubSub !== 'undefined') {
             PubSub.publish('item:added', item.id);
             PubSub.publish('inventory:changed', State.inventory);
@@ -108,7 +105,17 @@ const Inventory = {
         if (!record || record.quantity < qty) return false;
         updateState(['inventory', id, 'quantity'], q => q - qty);
         if (State.inventory[id].quantity <= 0) deleteState(['inventory', id]);
-        SoftCapSystem.recalculateCaps(State.inventory);
+        const item = ItemGenerator.itemList.find(i => i.id === id);
+        if (item && item.type === 'food') {
+            for (const [res, amt] of Object.entries(item.restore)) {
+                if (State.resources[res]) {
+                    ResourceSystem.add(State.resources[res], amt * qty);
+                }
+            }
+            if (typeof PubSub !== 'undefined') {
+                PubSub.publish('resources:updated');
+            }
+        }
         if (typeof PubSub !== 'undefined') {
             PubSub.publish('item:consumed', { id, quantity: qty });
             PubSub.publish('inventory:changed', State.inventory);

--- a/js/soft_cap.js
+++ b/js/soft_cap.js
@@ -5,23 +5,9 @@ const SoftCapSystem = {
     statCaps: {},
     resourceCaps: {},
     falloff: 0.5,
-    recalculateCaps(inventory) {
+    recalculateCaps() {
         this.statCaps = { ...this.baseStatCaps };
         this.resourceCaps = { ...this.baseResourceCaps };
-        if (!inventory) return;
-        for (const [id, record] of Object.entries(inventory)) {
-            const item = ItemGenerator.itemList.find(i => i.id === id);
-            if (!item || item.effectType !== 'increaseSoftcap') continue;
-            const qty = record.quantity || 0;
-            for (const key in item.effectValue) {
-                const value = item.effectValue[key] * Math.log(qty + 1);
-                if (this.statCaps[key] !== undefined) {
-                    this.statCaps[key] += value;
-                } else {
-                    this.resourceCaps[key] = (this.resourceCaps[key] || (this.baseResourceCaps[key] || 0)) + value;
-                }
-            }
-        }
         for (const r in this.resourceCaps) {
             if (State.resources[r]) {
                 setState(['resources', r, 'baseMax'], this.resourceCaps[r]);
@@ -30,8 +16,6 @@ const SoftCapSystem = {
         for (const s in this.statCaps) {
             if (State.stats[s]) {
                 setState(['stats', s, 'baseMax'], this.statCaps[s]);
-                // statCaps should reflect prestige multipliers for UI and
-                // softcap calculations
                 this.statCaps[s] = StatSystem.max(State.stats[s]);
             }
         }

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -10,19 +10,20 @@ def test_item_fields():
         assert 'id' in item
         assert 'name' in item
         assert 'rarity' in item
-        assert 'effectType' in item
-        assert 'effectValue' in item
-        assert isinstance(item['effectValue'], dict)
+        assert 'type' in item
+        if item['type'] == 'food':
+            assert 'restore' in item
+            assert isinstance(item['restore'], dict)
+            assert 'health' in item['restore']
+        else:
+            assert 'restore' not in item or item['restore'] == {}
         assert 'image' in item
 
-
-def test_effect_formula_log():
+def test_food_restoration_values():
     path = os.path.join('data', 'items.json')
     with open(path) as f:
         data = json.load(f)
-    herb = next(i for i in data if i['id'] == 'herb')
-    qty = 1
-    effect_val = herb['effectValue']['focus']
-    import math
-    effect = effect_val * math.log(qty + 1)
-    assert effect > 0
+    rabbit = next(i for i in data if i['id'] == 'rabbit_meat')
+    assert rabbit['restore']['health'] > 1
+    berries = next(i for i in data if i['id'] == 'berries')
+    assert set(berries['restore'].keys()) == {'health', 'energy', 'focus'}


### PR DESCRIPTION
## Summary
- categorize items as food, equipment or resources
- food items restore health and other resources on consumption
- remove soft cap bonuses from inventory items

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_688e84e7dea083308fb6539e5de45115