### PR TITLE
Revise action queue behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.67] - 2025-08-02
 ### Changed
+- Actions now restart automatically until resources run out, then queue and wait for full recovery before resuming.
 - Action slot now resets to the default action if an encounter ends due to resource depletion.
 - Adventure encounters pause on resource depletion and resume when resources are fully restored.
 - Queued actions now wait for all related resources to reach their maximum before starting or resuming.

--- a/js/action_engine.js
+++ b/js/action_engine.js
@@ -1,4 +1,7 @@
 // Core engine driving action progression
+// Dependencies: AdventureEngine, ResourceSystem, PubSub, DeltaEngine,
+// FurnitureSystem, SoftCapSystem, SaveSystem
+// Exports: ActionEngine
 
 const ActionEngine = {
     start(slotIndex, actionId) {
@@ -10,10 +13,10 @@ const ActionEngine = {
         if (!action) return;
         let canStart = true;
         if (action.resourceCost) {
-            // require all cost resources to be at their maximum before starting
+            // ensure each cost resource can cover its initial cost
             for (const r in action.resourceCost) {
                 const res = State.resources[r];
-                if (!res || res.value !== ResourceSystem.max(res)) {
+                if (!res || res.value < action.resourceCost[r]) {
                     canStart = false;
                     break;
                 }
@@ -124,15 +127,16 @@ const ActionEngine = {
                 // deduct start cost for next cycle
                 if (action.resourceCost) {
                     let canRun = true;
-                    // next cycle only begins when cost resources are back at max
+                    // continue only while each cost resource can cover the next cycle
                     for (const r in action.resourceCost) {
                         const res = State.resources[r];
-                        if (!res || res.value !== ResourceSystem.max(res)) {
+                        if (!res || res.value < action.resourceCost[r]) {
                             canRun = false;
                             break;
                         }
                     }
                     if (!canRun) {
+                        // insufficient resources: queue action and fall back to default
                         slot.queue = { id: slot.actionId, progress: slot.progress, costPaid: false };
                         slot.actionId = State.defaultActionId;
                         slot.blocked = false;

--- a/tests/test_action_queue.py
+++ b/tests/test_action_queue.py
@@ -15,7 +15,7 @@ def test_queue_slot_styles_defined():
     assert '.queue-slot' in text and '.slot-wrapper' in text
 
 
-def test_queued_action_resumes_only_at_max():
+def test_action_repeats_queues_and_resumes_at_max():
     script = r"""
 const { ActionEngine } = require('./js/action_engine.js');
 global.State = {
@@ -23,8 +23,8 @@ global.State = {
     time: 1,
     slots: [{ actionId: 'idle', progress: 0, blocked: false, text: '', queue: null }],
     resources: {
-        gold: { value: 5, baseMax: 10, maxAdditions: [], maxMultipliers: [] },
-        mana: { value: 9, baseMax: 10, maxAdditions: [], maxMultipliers: [] }
+        gold: { value: 2, baseMax: 2, maxAdditions: [], maxMultipliers: [] },
+        mana: { value: 2, baseMax: 2, maxAdditions: [], maxMultipliers: [] }
     }
 };
 global.actions = {
@@ -38,7 +38,13 @@ global.ResourceSystem = {
 global.DeltaEngine = { calculate: () => {}, apply: () => {} };
 global.updateSlotUI = () => {};
 global.FurnitureSystem = {};
-global.canAfford = () => null;
+global.canAfford = (costs, delta) => {
+    for (const r in costs) {
+        const amt = costs[r] * State.time * delta;
+        if (State.resources[r].value < amt) return true;
+    }
+    return null;
+};
 global.scalingMultiplier = () => 1;
 global.applyYield = () => {};
 global.gainExp = () => {};
@@ -48,27 +54,32 @@ global.checkHealth = () => {};
 global.SaveSystem = { save: () => {} };
 
 ActionEngine.start(0, 'work');
-console.log(JSON.stringify(State.slots[0]));
-ActionEngine.tick(1);
-console.log(JSON.stringify(State.slots[0]));
+console.log(JSON.stringify({slot: State.slots[0], res: State.resources}));
+ActionEngine.tick(2);
+console.log(JSON.stringify({slot: State.slots[0], res: State.resources}));
 State.resources.gold.value = State.resources.gold.baseMax;
 ActionEngine.tick(1);
-console.log(JSON.stringify(State.slots[0]));
+console.log(JSON.stringify({slot: State.slots[0], res: State.resources}));
 State.resources.mana.value = State.resources.mana.baseMax;
 ActionEngine.tick(0);
-console.log(JSON.stringify(State.slots[0]));
+console.log(JSON.stringify({slot: State.slots[0], res: State.resources}));
 """
     result = subprocess.run(
         ['node', '-e', script], check=True, capture_output=True, text=True
     )
     lines = result.stdout.strip().splitlines()
     assert len(lines) == 4
-    start_slot = json.loads(lines[0])
-    tick1_slot = json.loads(lines[1])
-    tick2_slot = json.loads(lines[2])
-    tick3_slot = json.loads(lines[3])
-    assert start_slot['actionId'] == 'idle'
-    assert start_slot['queue']['id'] == 'work'
-    assert tick1_slot['actionId'] == 'idle'
-    assert tick2_slot['actionId'] == 'idle'
-    assert tick3_slot['actionId'] == 'work'
+    start_state = json.loads(lines[0])
+    tick1_state = json.loads(lines[1])
+    tick2_state = json.loads(lines[2])
+    tick3_state = json.loads(lines[3])
+    # action starts and runs immediately
+    assert start_state['slot']['actionId'] == 'work'
+    # after resources drop below cost, action queues and default runs
+    assert tick1_state['slot']['actionId'] == 'idle'
+    assert tick1_state['slot']['queue']['id'] == 'work'
+    assert tick1_state['res']['gold']['value'] == 0
+    # replenishing only gold is not enough to resume
+    assert tick2_state['slot']['actionId'] == 'idle'
+    # once all resources are at max, queued action resumes
+    assert tick3_state['slot']['actionId'] == 'work'


### PR DESCRIPTION
## Summary
- restart actions until resources can't cover cost and queue exhausted tasks before running the default
- queued actions resume only after resources are fully replenished
- test action queue lifecycle and document resource exhaustion behavior

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_689104a0ca1c833081e1bb25febbadd1