### PR TITLE
Rename food item type to consumable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.67] - 2025-08-02
 ### Changed
+- Renamed item type `food` to `consumable` and updated related logic and tests.
 - Actions now restart automatically until resources run out, then queue and wait for full recovery before resuming.
 - Action slot now resets to the default action if an encounter ends due to resource depletion.
 - Adventure encounters pause on resource depletion and resume when resources are fully restored.

--- a/data/items.json
+++ b/data/items.json
@@ -3,7 +3,7 @@
         "id": "herb",
         "name": "Herb",
         "rarity": "common",
-        "type": "food",
+        "type": "consumable",
         "restore": {
             "health": 1,
             "focus": 1
@@ -15,7 +15,7 @@
         "id": "rabbit_meat",
         "name": "Rabbit Meat",
         "rarity": "common",
-        "type": "food",
+        "type": "consumable",
         "restore": {
             "health": 5
         },
@@ -114,7 +114,7 @@
         "id": "water_flask",
         "name": "Water Flask",
         "rarity": "common",
-        "type": "food",
+        "type": "consumable",
         "restore": {
             "health": 1,
             "energy": 2
@@ -150,7 +150,7 @@
         "id": "berries",
         "name": "Berries",
         "rarity": "common",
-        "type": "food",
+        "type": "consumable",
         "restore": {
             "health": 1,
             "energy": 1,
@@ -179,7 +179,7 @@
         "id": "cooked_fish",
         "name": "Cooked Fish",
         "rarity": "common",
-        "type": "food",
+        "type": "consumable",
         "restore": {
             "health": 3,
             "energy": 2

--- a/js/items.js
+++ b/js/items.js
@@ -13,7 +13,7 @@ class Item {
     }
 
     getEffectDescription() {
-        if (this.type === 'food' && this.restore) {
+        if (this.type === 'consumable' && this.restore) {
             const parts = [];
             for (const [key, val] of Object.entries(this.restore)) {
                 const resName = Lang.resource(key) || key;
@@ -106,7 +106,7 @@ const Inventory = {
         updateState(['inventory', id, 'quantity'], q => q - qty);
         if (State.inventory[id].quantity <= 0) deleteState(['inventory', id]);
         const item = ItemGenerator.itemList.find(i => i.id === id);
-        if (item && item.type === 'food') {
+        if (item && item.type === 'consumable') {
             for (const [res, amt] of Object.entries(item.restore)) {
                 if (State.resources[res]) {
                     ResourceSystem.add(State.resources[res], amt * qty);

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -11,7 +11,7 @@ def test_item_fields():
         assert 'name' in item
         assert 'rarity' in item
         assert 'type' in item
-        if item['type'] == 'food':
+        if item['type'] == 'consumable':
             assert 'restore' in item
             assert isinstance(item['restore'], dict)
             assert 'health' in item['restore']
@@ -19,7 +19,7 @@ def test_item_fields():
             assert 'restore' not in item or item['restore'] == {}
         assert 'image' in item
 
-def test_food_restoration_values():
+def test_consumable_restoration_values():
     path = os.path.join('data', 'items.json')
     with open(path) as f:
         data = json.load(f)


### PR DESCRIPTION
## Summary
- rename item type `food` to `consumable` in item data
- update item logic and inventory consumption checks to use the `consumable` type
- adjust tests and changelog for the new `consumable` terminology

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68910eaae55c8330bc19fc0abc4b5638