### PR TITLE
Group inventory items by type with translated headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.67] - 2025-08-02
 ### Changed
+- Inventory now groups items by type with translated headers.
 - Actions now restart automatically until resources run out, then queue and wait for full recovery before resuming.
 - Action slot now resets to the default action if an encounter ends due to resource depletion.
 - Adventure encounters pause on resource depletion and resume when resources are fully restored.

--- a/css/styles.css
+++ b/css/styles.css
@@ -320,6 +320,11 @@ body.left-collapsed #left {
     grid-template-columns: repeat(6, 1fr);
 }
 
+#inventory-slots > h3 {
+    grid-column: 1 / -1;
+    margin: 0.5rem 0;
+}
+
 
 #encounter-location {
     font-style: italic;

--- a/data/lang/uk.json
+++ b/data/lang/uk.json
@@ -36,7 +36,9 @@
     "Continue": "Продовжити",
     "Language": "Мова",
     "Drop Chances": "Шанс здобичі",
-    "Guaranteed Loot": "Гарантована здобич"
+    "Guaranteed Loot": "Гарантована здобич",
+    "Consumables": "Витратні матеріали",
+    "Equipment": "Спорядження"
   },
   "actions": {
     "studying": { "name": "Навчання" },

--- a/js/items.js
+++ b/js/items.js
@@ -129,6 +129,7 @@ const Inventory = {
                 id,
                 name: itemData.name || id,
                 rarity: itemData.rarity || 'common',
+                type: itemData.type || 'resource',
                 quantity: data.quantity,
                 image: itemData.image,
                 description: itemData.description || '',

--- a/js/ui/inventory.js
+++ b/js/ui/inventory.js
@@ -11,17 +11,30 @@ const InventoryUI = {
     update() {
         if (!this.container) return;
         const items = Inventory.getItems();
-        const count = items.length;
         this.container.innerHTML = '';
-        for (let i = 0; i < count; i++) {
-            const slot = document.createElement('div');
-            slot.className = 'slot';
-            const label = document.createElement('span');
-            label.className = 'label';
-            const countEl = document.createElement('span');
-            countEl.className = 'count';
-            if (items[i]) {
-                const item = items[i];
+        const groups = {};
+        // Group items by type so each section can be labeled
+        items.forEach(item => {
+            if (!groups[item.type]) groups[item.type] = [];
+            groups[item.type].push(item);
+        });
+        const typeLabels = {
+            food: 'Consumables',
+            equipment: 'Equipment',
+            resource: 'Resources'
+        };
+        Object.keys(groups).forEach(type => {
+            const heading = document.createElement('h3');
+            const labelKey = typeLabels[type] || type;
+            heading.textContent = Lang.ui(labelKey) || labelKey;
+            this.container.appendChild(heading);
+            groups[type].forEach(item => {
+                const slot = document.createElement('div');
+                slot.className = 'slot';
+                const label = document.createElement('span');
+                label.className = 'label';
+                const countEl = document.createElement('span');
+                countEl.className = 'count';
                 label.textContent = capitalize(item.name);
                 countEl.textContent = item.quantity;
                 if (item.image) {
@@ -31,16 +44,11 @@ const InventoryUI = {
                 const lines = [item.description];
                 if (item.effect) lines.push(item.effect);
                 slot.dataset.tooltip = lines.join('\n');
-            } else {
-                slot.style.backgroundImage = 'none';
-                label.textContent = '';
-                countEl.textContent = '';
-                slot.dataset.tooltip = '';
-            }
-            slot.appendChild(label);
-            slot.appendChild(countEl);
-            this.container.appendChild(slot);
-        }
+                slot.appendChild(label);
+                slot.appendChild(countEl);
+                this.container.appendChild(slot);
+            });
+        });
     }
 };
 

--- a/tests/test_inventory_sections.py
+++ b/tests/test_inventory_sections.py
@@ -1,0 +1,27 @@
+import os
+import os
+import json
+
+def test_getitems_includes_type():
+    path = os.path.join('js', 'items.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'type: itemData.type' in text
+
+
+def test_inventory_has_headings():
+    path = os.path.join('js', 'ui', 'inventory.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'Lang.ui' in text
+    assert 'Consumables' in text
+    assert 'Equipment' in text
+
+
+def test_uk_translation_sections():
+    path = os.path.join('data', 'lang', 'uk.json')
+    with open(path) as f:
+        data = json.load(f)
+    ui = data.get('ui', {})
+    assert 'Consumables' in ui
+    assert 'Equipment' in ui


### PR DESCRIPTION
## Summary
- include item `type` in inventory listings
- group inventory display by item type with localized headings
- add Ukrainian translations and style for new inventory sections

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68910ebb387c8330b23bdc705c28614b