### PR TITLE
Add consumable inventory button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.67] - 2025-08-02
 ### Changed
+- Added consume buttons for consumable inventory items.
 - Actions now restart automatically until resources run out, then queue and wait for full recovery before resuming.
 - Action slot now resets to the default action if an encounter ends due to resource depletion.
 - Adventure encounters pause on resource depletion and resume when resources are fully restored.

--- a/css/styles.css
+++ b/css/styles.css
@@ -418,6 +418,17 @@ body.left-collapsed #left {
     color: #fff;
 }
 
+.slot .consume-btn {
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    font-size: 0.6rem;
+    padding: 0 2px;
+    border: none;
+    background: rgba(0, 0, 0, 0.5);
+    cursor: pointer;
+}
+
 .tooltip {
     position: absolute;
     background: #333;

--- a/js/items.js
+++ b/js/items.js
@@ -129,6 +129,8 @@ const Inventory = {
                 id,
                 name: itemData.name || id,
                 rarity: itemData.rarity || 'common',
+                // expose item type for UI logic like consumable buttons
+                type: itemData.type || 'resource',
                 quantity: data.quantity,
                 image: itemData.image,
                 description: itemData.description || '',

--- a/js/ui/inventory.js
+++ b/js/ui/inventory.js
@@ -31,6 +31,17 @@ const InventoryUI = {
                 const lines = [item.description];
                 if (item.effect) lines.push(item.effect);
                 slot.dataset.tooltip = lines.join('\n');
+                // add a button to consume items directly from the inventory
+                if (item.type === 'consumable') {
+                    const btn = document.createElement('button');
+                    btn.textContent = '🍽️';
+                    btn.className = 'consume-btn';
+                    btn.addEventListener('click', (e) => {
+                        e.stopPropagation();
+                        Inventory.consume(item.id);
+                    });
+                    slot.appendChild(btn);
+                }
             } else {
                 slot.style.backgroundImage = 'none';
                 label.textContent = '';

--- a/tests/test_inventory_consume.py
+++ b/tests/test_inventory_consume.py
@@ -1,0 +1,27 @@
+import json
+import subprocess
+
+
+# ensure consume reduces stored quantity for consumable items
+def test_inventory_consume_decreases_quantity():
+    script = r"""
+const { ItemGenerator, Inventory } = require('./js/items.js');
+global.State = { inventory: { potion: { quantity: 2 } }, resources: {} };
+global.updateState = function(path, fn) {
+    const [root, id, prop] = path;
+    if (root === 'inventory' && prop === 'quantity') {
+        State.inventory[id][prop] = fn(State.inventory[id][prop]);
+    }
+};
+global.deleteState = function(path) {
+    const [root, id] = path;
+    if (root === 'inventory') delete State.inventory[id];
+};
+global.ItemGenerator = { itemList: [{ id: 'potion', type: 'consumable' }] };
+global.PubSub = { publish: () => {} };
+Inventory.consume('potion');
+console.log(JSON.stringify(State.inventory));
+""";
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    state = json.loads(result.stdout.strip())
+    assert state['potion']['quantity'] == 1


### PR DESCRIPTION
## Summary
- expose item type to Inventory.getItems
- add consume button for consumable inventory items and style
- test Inventory.consume reduces quantity

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68910ebb03d48330be79c6879e16472f