### PR TITLE
Fix inventory loop braces to restore rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@
 - Removed the Recover encounter and related logic.
 - Blocked actions are queued and resume automatically once resources recover.
 
+### Fixed
+- Resolved misplaced braces in the inventory UI loop that broke item rendering.
+
 ## [0.41.66] - 2025-07-14
 ### Changed
 - Research progress now persists through prestiges.

--- a/js/ui/inventory.js
+++ b/js/ui/inventory.js
@@ -37,8 +37,11 @@ const InventoryUI = {
                 countEl.className = 'count';
                 label.textContent = capitalize(item.name);
                 countEl.textContent = item.quantity;
+                // Use the item's image if provided; otherwise clear any background
                 if (item.image) {
                     slot.style.backgroundImage = `url(${item.image})`;
+                } else {
+                    slot.style.backgroundImage = 'none';
                 }
                 slot.classList.add(`rarity-${item.rarity}`);
                 const lines = [item.description];
@@ -55,16 +58,11 @@ const InventoryUI = {
                     });
                     slot.appendChild(btn);
                 }
-            } else {
-                slot.style.backgroundImage = 'none';
-                label.textContent = '';
-                countEl.textContent = '';
-                slot.dataset.tooltip = '';
-            }
-            slot.appendChild(label);
-            slot.appendChild(countEl);
-            this.container.appendChild(slot);
-        }
+                slot.appendChild(label);
+                slot.appendChild(countEl);
+                this.container.appendChild(slot);
+            });
+        });
     }
 };
 


### PR DESCRIPTION
## Summary
- repair inventory grouping loop by pairing image fallback and closing forEach blocks
- document fix in changelog

## Testing
- `node --check js/ui/inventory.js`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689111b54a0c8330a176d8c2d4bf91ea