### PR TITLE
Refactor character background to track equipment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.67] - 2025-08-02
 ### Changed
+- Character background art now reflects equipped items instead of inventory contents.
 - Added consume buttons for consumable inventory items.
 - Inventory now groups items by type with translated headers.
 - Renamed item type `food` to `consumable` and updated related logic and tests.

--- a/js/ui/char_bg.js
+++ b/js/ui/char_bg.js
@@ -1,6 +1,5 @@
-// Agents: UI helper for the left panel background image. Called from init() in
-// main.js whenever the inventory changes so the character reflects equipped
-// gear. Purely cosmetic and not tied into game mechanics.
+// Agents: UI helper for the left panel background image. Character art updates
+// when equipment changes. Purely cosmetic and not tied into game mechanics.
 const CharacterBackground = {
     baseImage: 'assets/char/new_char.png',
     equippedImage: 'assets/char/leather+woodshield+spear.png',
@@ -9,18 +8,19 @@ const CharacterBackground = {
     init() {
         this.container = document.getElementById('left');
         if (typeof PubSub !== 'undefined') {
-            PubSub.subscribe('inventory:changed', () => this.update());
+            PubSub.subscribe('equipment:changed', (_, equipped) => this.update(equipped));
         }
-        this.update();
+        this.update([]);
     },
-    update() {
+    update(equipped = []) {
         if (!this.container) return;
+        const equippedSet = new Set(equipped);
         const fullGear = ['leather_armor', 'wooden_shield', 'iron_sword', 'gem'];
         const spearSet = ['leather_armor', 'wooden_shield', 'stone_spear'];
 
-        if (fullGear.every(item => Inventory.hasItem(item))) {
+        if (fullGear.every(item => equippedSet.has(item))) {
             this.container.style.backgroundImage = `url(${this.fullGearImage})`;
-        } else if (spearSet.every(item => Inventory.hasItem(item))) {
+        } else if (spearSet.every(item => equippedSet.has(item))) {
             this.container.style.backgroundImage = `url(${this.equippedImage})`;
         } else {
             this.container.style.backgroundImage = `url(${this.baseImage})`;

--- a/tests/test_char_bg.py
+++ b/tests/test_char_bg.py
@@ -1,0 +1,23 @@
+import json
+import subprocess
+
+
+def test_char_background_uses_equipped_items():
+    script = r"""
+const { CharacterBackground } = require('./js/ui/char_bg.js');
+CharacterBackground.container = { style: {} };
+CharacterBackground.update([]);
+const base = CharacterBackground.container.style.backgroundImage;
+CharacterBackground.container = { style: {} };
+CharacterBackground.update(['leather_armor','wooden_shield','stone_spear']);
+const spear = CharacterBackground.container.style.backgroundImage;
+CharacterBackground.container = { style: {} };
+CharacterBackground.update(['leather_armor','wooden_shield','iron_sword','gem']);
+const full = CharacterBackground.container.style.backgroundImage;
+console.log(JSON.stringify([base, spear, full]));
+""";
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    images = json.loads(result.stdout.strip())
+    assert images[0].endswith('new_char.png)')
+    assert images[1].endswith('leather+woodshield+spear.png)')
+    assert images[2].endswith('set+sword.png)')


### PR DESCRIPTION
## Summary
- update character art based on equipped items instead of inventory contents
- drop inventory:changed subscription in favor of equipment events
- add tests covering character background selection

## Testing
- `pytest`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_68923cf420388330886ce018e6aa27df