### PR TITLE
Add equipment system with equip/unequip and prestige reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## [0.41.67] - 2025-08-02
+### Added
+- Equipment system with equippable slots and prestige reset.
 ### Changed
 - Character background art now reflects equipped items instead of inventory contents.
 - Added consume buttons for consumable inventory items.

--- a/js/equipment.js
+++ b/js/equipment.js
@@ -1,0 +1,37 @@
+// Equipment system manages equipping items to character slots.
+//
+// Dependencies:
+//  - state.js: reads and updates State.equipment
+//  - items.js: verifies item type via ItemGenerator
+//  - pubsub.js: publishes equipment change events
+//
+// Exports:
+//  - Equipment: { equip(itemId, slot), unequip(slot) }
+
+const Equipment = {
+    equip(itemId, slot) {
+        if (!State.inventory[itemId]) return false;
+        const item = ItemGenerator.itemList.find(i => i.id === itemId);
+        if (!item || item.type !== 'equipment') return false;
+        State.equipment[slot] = itemId;
+        if (typeof PubSub !== 'undefined') {
+            PubSub.publish('equipment:equipped', { slot, itemId });
+            PubSub.publish('equipment:changed', State.equipment);
+        }
+        return true;
+    },
+    unequip(slot) {
+        const itemId = State.equipment[slot];
+        if (!itemId) return false;
+        State.equipment[slot] = null;
+        if (typeof PubSub !== 'undefined') {
+            PubSub.publish('equipment:unequipped', { slot, itemId });
+            PubSub.publish('equipment:changed', State.equipment);
+        }
+        return true;
+    }
+};
+
+if (typeof module !== 'undefined') {
+    module.exports = { Equipment };
+}

--- a/js/items.js
+++ b/js/items.js
@@ -92,20 +92,30 @@ const Inventory = {
         if (!State.inventory[item.id]) {
             setState(['inventory', item.id], { quantity: 1 });
         } else {
-            item.handleDuplicate(State.inventory);
+            if (item.type !== 'equipment') {
+                item.handleDuplicate(State.inventory);
+            }
             updateState(['inventory', item.id, 'quantity'], q => q + 1);
         }
         if (typeof PubSub !== 'undefined') {
             PubSub.publish('item:added', item.id);
+            // notify equipment listeners when new gear enters the inventory
+            if (item.type === 'equipment') {
+                PubSub.publish('equipment:available', item.id);
+            }
             PubSub.publish('inventory:changed', State.inventory);
         }
     },
     consume(id, qty = 1) {
+        const item = ItemGenerator.itemList.find(i => i.id === id);
+        // do not allow consuming equipment currently in use
+        if (item && item.type === 'equipment' && Object.values(State.equipment).includes(id)) {
+            return false;
+        }
         const record = State.inventory[id];
         if (!record || record.quantity < qty) return false;
         updateState(['inventory', id, 'quantity'], q => q - qty);
         if (State.inventory[id].quantity <= 0) deleteState(['inventory', id]);
-        const item = ItemGenerator.itemList.find(i => i.id === id);
         if (item && item.type === 'consumable') {
             for (const [res, amt] of Object.entries(item.restore)) {
                 if (State.resources[res]) {

--- a/js/save_system.js
+++ b/js/save_system.js
@@ -74,6 +74,21 @@ const SaveSystem = {
                 if (!State.inventory) {
                     setState('inventory', {});
                 }
+                if (!State.equipment) {
+                    // initialize equipment slots for older saves
+                    setState('equipment', {
+                        head: null,
+                        armor: null,
+                        leftHand: null,
+                        rightHand: null,
+                        pants: null,
+                        boots: null,
+                        gloves: null,
+                        ring1: null,
+                        ring2: null,
+                        necklace: null
+                    });
+                }
                 if (State.banditsAmbushSeen === undefined) {
                     setState('banditsAmbushSeen', false);
                 }
@@ -152,6 +167,19 @@ const SaveSystem = {
         setState(['age', 'days'], 0);
 
         setState('inventory', {});
+        // clear all equipped items
+        setState('equipment', {
+            head: null,
+            armor: null,
+            leftHand: null,
+            rightHand: null,
+            pants: null,
+            boots: null,
+            gloves: null,
+            ring1: null,
+            ring2: null,
+            necklace: null
+        });
         setState('homeId', null);
         setState('furniture', []);
         if (typeof PubSub !== 'undefined' && Array.isArray(FurnitureSystem.furniture)) {

--- a/js/state.js
+++ b/js/state.js
@@ -156,6 +156,18 @@ const State = {
     adventureSlots: [],
     inventorySlotCount: 8,
     inventory: {},
+    equipment: {
+        head: null,
+        armor: null,
+        leftHand: null,
+        rightHand: null,
+        pants: null,
+        boots: null,
+        gloves: null,
+        ring1: null,
+        ring2: null,
+        necklace: null
+    },
     homeId: null,
     homesOwned: [],
     furniture: [],

--- a/tests/test_equipment_module.py
+++ b/tests/test_equipment_module.py
@@ -1,0 +1,52 @@
+import json
+import subprocess
+
+def test_equip_and_unequip_publish_events():
+    script = r"""
+const { Equipment } = require('./js/equipment.js');
+const { ItemGenerator, Inventory } = require('./js/items.js');
+
+ItemGenerator.itemList = [{ id: 'stone_spear', type: 'equipment' }];
+
+global.State = {
+    equipment: { head:null, armor:null, leftHand:null, rightHand:null, pants:null, boots:null, gloves:null, ring1:null, ring2:null, necklace:null },
+    inventory: { stone_spear: { quantity: 1 } }
+};
+
+global.PubSub = { events: [], publish(name, data){ this.events.push({name, data}); } };
+
+Equipment.equip('stone_spear', 'rightHand');
+Equipment.unequip('rightHand');
+console.log(JSON.stringify({ equipment: State.equipment, events: PubSub.events }));
+""";
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout.strip())
+    assert data['equipment']['rightHand'] is None
+    names = [e['name'] for e in data['events']]
+    assert names == ['equipment:equipped', 'equipment:changed', 'equipment:unequipped', 'equipment:changed']
+
+
+def test_consume_rejects_equipped_items():
+    script = r"""
+const { ItemGenerator, Inventory } = require('./js/items.js');
+ItemGenerator.itemList = [{ id: 'stone_spear', type: 'equipment' }];
+
+global.State = {
+    equipment: { head:null, armor:null, leftHand:null, rightHand:'stone_spear', pants:null, boots:null, gloves:null, ring1:null, ring2:null, necklace:null },
+    inventory: { stone_spear: { quantity: 1 } },
+    resources: {}
+};
+
+global.updateState = function(path, fn){ const [root,id,prop]=path; if(root==='inventory' && prop==='quantity'){ State.inventory[id][prop]=fn(State.inventory[id][prop]); } };
+
+global.deleteState = function(path){ const [root,id]=path; if(root==='inventory') delete State.inventory[id]; };
+
+global.PubSub = { publish: () => {} };
+
+const result = Inventory.consume('stone_spear');
+console.log(JSON.stringify({ result, qty: State.inventory.stone_spear.quantity }));
+""";
+    res = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    data = json.loads(res.stdout.strip())
+    assert data['result'] is False
+    assert data['qty'] == 1

--- a/tests/test_prestige_equipment_reset.py
+++ b/tests/test_prestige_equipment_reset.py
@@ -1,0 +1,58 @@
+import json
+import subprocess
+
+
+def test_prestige_resets_equipment():
+    script = r"""
+const fs = require('fs');
+const vm = require('vm');
+const code = fs.readFileSync('./js/save_system.js', 'utf8');
+
+const context = {
+  State: {
+    stats:{}, resources:{}, prestige:{}, prestiging:false,
+    slots:[], adventureSlots:[{}], inventory:{}, homeId:null, homesOwned:[],
+    furniture:[], researchCompleted:[], adventureLevels:{forest:1},
+    currentAdventure:'forest', adventureActive:false, encounterLevel:1, encounterStreak:0,
+    equipment:{ head:'leather_armor', armor:null, leftHand:null, rightHand:'stone_spear', pants:null, boots:null, gloves:null, ring1:null, ring2:null, necklace:null }
+  },
+  actions: {},
+  loadBaseData: async()=>{},
+  applyPrestigeBonuses: ()=>{},
+  FurnitureSystem: { furniture: [] },
+  PubSub: { publish: ()=>{} },
+  HomeSystem: { assignDefault: ()=>{} },
+  Logger: { info: ()=>{}, error: ()=>{} },
+  VERSION:2,
+  STAT_KEYS:[],
+  RESOURCE_KEYS:[],
+  PRESTIGE_MAP:{},
+  PRESTIGE_KEYS:[],
+  localStorage: { setItem: ()=>{} },
+  window: { location: { reload: ()=>{} } }
+};
+context.setState = function(path, value){
+  if (Array.isArray(path)) {
+    let o = context.State;
+    for (let i = 0; i < path.length - 1; i++) {
+      if (!o[path[i]]) {
+        o[path[i]] = {};
+      }
+      o = o[path[i]];
+    }
+    o[path[path.length - 1]] = value;
+  } else {
+    context.State[path] = value;
+  }
+};
+
+vm.createContext(context);
+vm.runInContext(code + '\n;globalThis.SaveSystem = SaveSystem;', context);
+context.SaveSystem.save = ()=>{};
+context.SaveSystem.prestige().then(() => {
+  console.log(JSON.stringify(context.State.equipment));
+});
+""";
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout.strip())
+    assert all(v is None for v in data.values())


### PR DESCRIPTION
## Summary
- track equipment slots in global state
- add Equipment module with equip/unequip APIs and inventory integration
- reset equipment on prestige and cover with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68923f6709c883309dc1d0f70d70ee92