### PR TITLE
Move equipment items to character UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Changelog
 ## [0.41.67] - 2025-08-02
 ### Added
+- Character equipment UI for managing equippable items.
 - Equipment system with equippable slots and prestige reset.
 ### Changed
+- Inventory screen now hides equipment items; gear is handled in the character UI.
 - Character background art now reflects equipped items instead of inventory contents.
 - Added consume buttons for consumable inventory items.
 - Inventory now groups items by type with translated headers.

--- a/index.html
+++ b/index.html
@@ -131,6 +131,9 @@
                             <div class="section-body">
                                 <button id="inventory-filter-btn">Hide Items</button>
                                 <div id="inventory-slots" class="slots"></div>
+                                <h3 id="equipment-heading" data-i18n="Equipment">Equipment</h3>
+                                <div id="equipment-slots" class="slots"></div>
+                                <div id="equipment-items" class="slots"></div>
                             </div>
                         </div>
                     </div>
@@ -195,8 +198,10 @@
     <script src="js/age_system.js"></script>
     <script src="js/encounter.js"></script>
     <script src="js/items.js"></script>
+    <script src="js/equipment.js"></script>
     <script src="js/soft_cap.js"></script>
     <script src="js/ui/inventory.js"></script>
+    <script src="js/ui/character.js"></script>
     <script src="js/updates.js"></script>
     <script src="js/ui/updates.js"></script>
     <script src="js/tab_manager.js"></script>

--- a/js/items.js
+++ b/js/items.js
@@ -132,7 +132,7 @@ const Inventory = {
         }
         return true;
     },
-    getItems() {
+    getItems(includeEquipment = true) {
         const items = Object.entries(State.inventory).map(([id, data]) => {
             const itemData = ItemGenerator.itemList.find(i => i.id === id) || {};
             return {
@@ -156,9 +156,12 @@ const Inventory = {
             return a.name.localeCompare(b.name);
         });
         let result = items;
+        if (!includeEquipment) {
+            result = result.filter(it => it.type !== 'equipment');
+        }
         if (State.hideRarityEnabled) {
             const threshold = RARITY_CLASSES.indexOf(State.hideBelowRarity);
-            result = items.filter(it => RARITY_CLASSES.indexOf(it.rarity) >= threshold);
+            result = result.filter(it => RARITY_CLASSES.indexOf(it.rarity) >= threshold);
         }
 
         return result;

--- a/js/main.js
+++ b/js/main.js
@@ -79,6 +79,9 @@ async function init() {
     MasteryUI.init();
     PrestigeUI.init();
     InventoryUI.init();
+    if (typeof CharacterUI !== 'undefined') {
+        CharacterUI.init();
+    }
     HomeUI.init();
     FurnitureUI.init();
     ResearchUI.init();

--- a/js/ui/character.js
+++ b/js/ui/character.js
@@ -1,0 +1,72 @@
+// CharacterUI renders equipment slots and available equipment items.
+// It listens for inventory and equipment changes via PubSub.
+const CharacterUI = {
+    init() {
+        this.slotContainer = document.getElementById('equipment-slots');
+        this.itemContainer = document.getElementById('equipment-items');
+        this.heading = document.getElementById('equipment-heading');
+        if (this.heading) {
+            this.heading.textContent = Lang.ui('Equipment') || 'Equipment';
+        }
+        if (typeof PubSub !== 'undefined') {
+            PubSub.subscribe('inventory:changed', () => this.updateItems());
+            PubSub.subscribe('equipment:changed', (_, eq) => this.updateSlots(eq));
+        }
+        this.updateSlots(State.equipment);
+        this.updateItems();
+    },
+    updateSlots(equipped = State.equipment) {
+        if (!this.slotContainer) return;
+        this.slotContainer.innerHTML = '';
+        Object.entries(equipped).forEach(([slot, itemId]) => {
+            const slotEl = document.createElement('div');
+            slotEl.className = 'slot';
+            slotEl.dataset.slot = slot;
+            const label = document.createElement('span');
+            label.className = 'label';
+            label.textContent = Lang.ui(slot) || capitalize(slot);
+            slotEl.appendChild(label);
+            if (itemId) {
+                const item = ItemGenerator.itemList.find(i => i.id === itemId);
+                if (item && item.image) {
+                    slotEl.style.backgroundImage = `url(${item.image})`;
+                }
+                slotEl.dataset.tooltip = capitalize(item ? item.name : itemId);
+            }
+            slotEl.addEventListener('click', () => {
+                if (State.equipment[slot]) {
+                    Equipment.unequip(slot);
+                }
+            });
+            this.slotContainer.appendChild(slotEl);
+        });
+    },
+    updateItems() {
+        if (!this.itemContainer) return;
+        this.itemContainer.innerHTML = '';
+        const items = Inventory.getItems(true).filter(it => it.type === 'equipment');
+        items.forEach(item => {
+            const itemEl = document.createElement('div');
+            itemEl.className = 'slot';
+            if (item.image) {
+                itemEl.style.backgroundImage = `url(${item.image})`;
+            }
+            itemEl.classList.add(`rarity-${item.rarity}`);
+            const label = document.createElement('span');
+            label.className = 'label';
+            label.textContent = capitalize(item.name);
+            itemEl.appendChild(label);
+            itemEl.addEventListener('click', () => {
+                const emptySlot = Object.entries(State.equipment).find(([, v]) => !v);
+                if (emptySlot) {
+                    Equipment.equip(item.id, emptySlot[0]);
+                }
+            });
+            this.itemContainer.appendChild(itemEl);
+        });
+    }
+};
+
+if (typeof module !== 'undefined') {
+    module.exports = { CharacterUI };
+}

--- a/js/ui/inventory.js
+++ b/js/ui/inventory.js
@@ -10,7 +10,7 @@ const InventoryUI = {
     },
     update() {
         if (!this.container) return;
-        const items = Inventory.getItems();
+        const items = Inventory.getItems(false);
         this.container.innerHTML = '';
         const groups = {};
         // Group items by type so each section can be labeled
@@ -19,8 +19,7 @@ const InventoryUI = {
             groups[item.type].push(item);
         });
         const typeLabels = {
-            food: 'Consumables',
-            equipment: 'Equipment',
+            consumable: 'Consumables',
             resource: 'Resources'
         };
         Object.keys(groups).forEach(type => {

--- a/tests/test_character_ui.py
+++ b/tests/test_character_ui.py
@@ -1,0 +1,20 @@
+import os
+import json
+
+
+def test_character_ui_mentions_equipment():
+    path = os.path.join('js', 'ui', 'character.js')
+    with open(path) as f:
+        text = f.read()
+    assert 'Lang.ui' in text
+    assert 'inventory:changed' in text
+    assert 'equipment:changed' in text
+    assert 'Equipment' in text
+
+
+def test_character_translation_has_equipment():
+    path = os.path.join('data', 'lang', 'uk.json')
+    with open(path) as f:
+        data = json.load(f)
+    ui = data.get('ui', {})
+    assert 'Equipment' in ui

--- a/tests/test_inventory_sections.py
+++ b/tests/test_inventory_sections.py
@@ -1,6 +1,6 @@
 import os
-import os
 import json
+
 
 def test_getitems_includes_type():
     path = os.path.join('js', 'items.js')
@@ -9,13 +9,13 @@ def test_getitems_includes_type():
     assert 'type: itemData.type' in text
 
 
-def test_inventory_has_headings():
+def test_inventory_has_heading_without_equipment():
     path = os.path.join('js', 'ui', 'inventory.js')
     with open(path) as f:
         text = f.read()
     assert 'Lang.ui' in text
     assert 'Consumables' in text
-    assert 'Equipment' in text
+    assert 'Equipment' not in text
 
 
 def test_uk_translation_sections():
@@ -24,4 +24,3 @@ def test_uk_translation_sections():
         data = json.load(f)
     ui = data.get('ui', {})
     assert 'Consumables' in ui
-    assert 'Equipment' in ui


### PR DESCRIPTION
## Summary
- Filter equipment out of Inventory.getItems and InventoryUI.
- Add CharacterUI module for equipping gear and update initialization and HTML.
- Update tests for inventory and new character equipment UI.

## Testing
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_689241b2ee0483309e8561c1cade20bf