### PR TITLE
Add equipment slot definitions to items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Character equipment UI for managing equippable items.
 - Equipment system with equippable slots and prestige reset.
 ### Changed
+- Equipment items now specify their equip slot.
 - Inventory screen now hides equipment items; gear is handled in the character UI.
 - Character background art now reflects equipped items instead of inventory contents.
 - Added consume buttons for consumable inventory items.

--- a/data/items.json
+++ b/data/items.json
@@ -67,6 +67,7 @@
         "name": "Stone Spear",
         "rarity": "rare",
         "type": "equipment",
+        "slot": "rightHand",
         "image": "assets/items/spear.PNG",
         "description": "Crude spear tipped with sharpened stone."
     },
@@ -75,6 +76,7 @@
         "name": "Wooden Shield",
         "rarity": "rare",
         "type": "equipment",
+        "slot": "leftHand",
         "image": "assets/items/woodshield.PNG",
         "description": "Simple shield offering basic protection."
     },
@@ -83,6 +85,7 @@
         "name": "Leather Armor",
         "rarity": "rare",
         "type": "equipment",
+        "slot": "armor",
         "image": "assets/items/leatherarmor.PNG",
         "description": "Light armor made from treated hides."
     },
@@ -99,6 +102,7 @@
         "name": "Iron Sword",
         "rarity": "rare",
         "type": "equipment",
+        "slot": "rightHand",
         "image": "assets/generated/iron_sword.png",
         "description": "A sturdy blade forged from iron."
     },
@@ -172,6 +176,7 @@
         "name": "Torch",
         "rarity": "common",
         "type": "equipment",
+        "slot": "leftHand",
         "image": "assets/user_uploaded/torch.jpg",
         "description": "Provides light when exploring dark places."
     },

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -17,6 +17,9 @@ def test_item_fields():
             assert 'health' in item['restore']
         else:
             assert 'restore' not in item or item['restore'] == {}
+        if item['type'] == 'equipment':
+            # Equipment items must define the slot they occupy
+            assert 'slot' in item
         assert 'image' in item
 
 def test_consumable_restoration_values():


### PR DESCRIPTION
## Summary
- add slot fields for all equipment items
- verify equipment items define slots with a unit test
- document slot metadata addition

## Testing
- `pip install -r requirements.txt`
- `pytest --cov` *(fails: unrecognized arguments: --cov)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892629b26a0833081eb2e507ab2f5fd