### PR TITLE
Enforce equipment slot matching and add equip buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
-## [0.41.67] - 2025-08-02
+## [0.41.67] - 2025-08-05
 ### Added
 - Character equipment UI for managing equippable items.
 - Equipment system with equippable slots and prestige reset.
 ### Changed
+- Equipment.equip validates item slots and infers the correct slot when unspecified.
+- Character equipment items now include an Equip button.
 - Equipment items now specify their equip slot.
 - Inventory screen now hides equipment items; gear is handled in the character UI.
 - Character background art now reflects equipped items instead of inventory contents.

--- a/js/equipment.js
+++ b/js/equipment.js
@@ -6,16 +6,18 @@
 //  - pubsub.js: publishes equipment change events
 //
 // Exports:
-//  - Equipment: { equip(itemId, slot), unequip(slot) }
+//  - Equipment: { equip(itemId, slot?), unequip(slot) }
 
 const Equipment = {
     equip(itemId, slot) {
         if (!State.inventory[itemId]) return false;
         const item = ItemGenerator.itemList.find(i => i.id === itemId);
-        if (!item || item.type !== 'equipment') return false;
-        State.equipment[slot] = itemId;
+        if (!item || item.type !== 'equipment' || !item.slot) return false;
+        if (slot && slot !== item.slot) return false;
+        const targetSlot = item.slot;
+        State.equipment[targetSlot] = itemId;
         if (typeof PubSub !== 'undefined') {
-            PubSub.publish('equipment:equipped', { slot, itemId });
+            PubSub.publish('equipment:equipped', { slot: targetSlot, itemId });
             PubSub.publish('equipment:changed', State.equipment);
         }
         return true;

--- a/js/ui/character.js
+++ b/js/ui/character.js
@@ -56,12 +56,10 @@ const CharacterUI = {
             label.className = 'label';
             label.textContent = capitalize(item.name);
             itemEl.appendChild(label);
-            itemEl.addEventListener('click', () => {
-                const emptySlot = Object.entries(State.equipment).find(([, v]) => !v);
-                if (emptySlot) {
-                    Equipment.equip(item.id, emptySlot[0]);
-                }
-            });
+            const equipBtn = document.createElement('button');
+            equipBtn.textContent = Lang.ui('Equip') || 'Equip';
+            equipBtn.addEventListener('click', () => Equipment.equip(item.id));
+            itemEl.appendChild(equipBtn);
             this.itemContainer.appendChild(itemEl);
         });
     }

--- a/tests/test_character_ui.py
+++ b/tests/test_character_ui.py
@@ -1,5 +1,6 @@
 import os
 import json
+import subprocess
 
 
 def test_character_ui_mentions_equipment():
@@ -18,3 +19,65 @@ def test_character_translation_has_equipment():
         data = json.load(f)
     ui = data.get('ui', {})
     assert 'Equipment' in ui
+
+
+def test_equip_button_equips_item():
+    script = r"""
+class Elem {
+  constructor(tag) {
+    this.tagName = tag;
+    this.children = [];
+    this.className = '';
+    this.style = {};
+    this.dataset = {};
+    this.eventListeners = {};
+    this.textContent = '';
+    this._innerHTML = '';
+    this.classList = { add: () => {} };
+    Object.defineProperty(this, 'innerHTML', {
+      get: () => this._innerHTML,
+      set: v => { this._innerHTML = v; if (v === '') this.children = []; }
+    });
+  }
+  appendChild(child) { this.children.push(child); }
+  addEventListener(ev, fn) { this.eventListeners[ev] = fn; }
+  click() { if (this.eventListeners['click']) this.eventListeners['click'](); }
+}
+
+const elements = {
+  'equipment-slots': new Elem('div'),
+  'equipment-items': new Elem('div'),
+  'equipment-heading': new Elem('div')
+};
+
+global.document = {
+  getElementById(id){ return elements[id]; },
+  createElement(tag){ return new Elem(tag); }
+};
+
+global.State = {
+  equipment: { head:null, armor:null, leftHand:null, rightHand:null, pants:null, boots:null, gloves:null, ring1:null, ring2:null, necklace:null },
+  inventory: { stone_spear: { quantity: 1 } }
+};
+
+global.ItemGenerator = { itemList: [{ id:'stone_spear', type:'equipment', slot:'rightHand', name:'stone spear', rarity:'common' }] };
+global.Inventory = { getItems: () => [{ id:'stone_spear', type:'equipment', name:'stone spear', rarity:'common' }] };
+global.Lang = { ui: k => k };
+global.capitalize = s => s;
+
+const { Equipment } = require('./js/equipment.js');
+const { CharacterUI } = require('./js/ui/character.js');
+
+CharacterUI.init();
+
+const items = document.getElementById('equipment-items');
+const card = items.children[0];
+const btn = card.children.find(c => c.tagName === 'button');
+btn.click();
+
+console.log(JSON.stringify({ equipped: State.equipment.rightHand }));
+""";
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout.strip())
+    assert data['equipped'] == 'stone_spear'
+

--- a/tests/test_equipment_module.py
+++ b/tests/test_equipment_module.py
@@ -6,7 +6,7 @@ def test_equip_and_unequip_publish_events():
 const { Equipment } = require('./js/equipment.js');
 const { ItemGenerator, Inventory } = require('./js/items.js');
 
-ItemGenerator.itemList = [{ id: 'stone_spear', type: 'equipment' }];
+ItemGenerator.itemList = [{ id: 'stone_spear', type: 'equipment', slot: 'rightHand' }];
 
 global.State = {
     equipment: { head:null, armor:null, leftHand:null, rightHand:null, pants:null, boots:null, gloves:null, ring1:null, ring2:null, necklace:null },
@@ -29,7 +29,7 @@ console.log(JSON.stringify({ equipment: State.equipment, events: PubSub.events }
 def test_consume_rejects_equipped_items():
     script = r"""
 const { ItemGenerator, Inventory } = require('./js/items.js');
-ItemGenerator.itemList = [{ id: 'stone_spear', type: 'equipment' }];
+ItemGenerator.itemList = [{ id: 'stone_spear', type: 'equipment', slot: 'rightHand' }];
 
 global.State = {
     equipment: { head:null, armor:null, leftHand:null, rightHand:'stone_spear', pants:null, boots:null, gloves:null, ring1:null, ring2:null, necklace:null },
@@ -50,3 +50,46 @@ console.log(JSON.stringify({ result, qty: State.inventory.stone_spear.quantity }
     data = json.loads(res.stdout.strip())
     assert data['result'] is False
     assert data['qty'] == 1
+
+
+def test_equip_rejects_mismatched_slot():
+    script = r"""
+const { Equipment } = require('./js/equipment.js');
+const { ItemGenerator } = require('./js/items.js');
+
+ItemGenerator.itemList = [{ id: 'stone_spear', type: 'equipment', slot: 'rightHand' }];
+
+global.State = {
+    equipment: { head:null, armor:null, leftHand:null, rightHand:null, pants:null, boots:null, gloves:null, ring1:null, ring2:null, necklace:null },
+    inventory: { stone_spear: { quantity: 1 } }
+};
+
+const result = Equipment.equip('stone_spear', 'leftHand');
+console.log(JSON.stringify({ result, equip: State.equipment }));
+""";
+    res = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    data = json.loads(res.stdout.strip())
+    assert data['result'] is False
+    assert data['equip']['rightHand'] is None
+
+
+def test_equip_uses_item_slot_when_slot_missing():
+    script = r"""
+const { Equipment } = require('./js/equipment.js');
+const { ItemGenerator } = require('./js/items.js');
+
+ItemGenerator.itemList = [{ id: 'stone_spear', type: 'equipment', slot: 'rightHand' }];
+
+global.State = {
+    equipment: { head:null, armor:null, leftHand:null, rightHand:null, pants:null, boots:null, gloves:null, ring1:null, ring2:null, necklace:null },
+    inventory: { stone_spear: { quantity: 1 } }
+};
+
+const result = Equipment.equip('stone_spear');
+console.log(JSON.stringify({ result, equip: State.equipment }));
+""";
+    res = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    data = json.loads(res.stdout.strip())
+    assert data['result'] is True
+    assert data['equip']['rightHand'] == 'stone_spear'
+


### PR DESCRIPTION
## Summary
- Load item slot from `ItemGenerator` and auto-select the correct slot when equipping
- Render an Equip button on each equipment card that calls `Equipment.equip`
- Test slot enforcement and UI button-driven equipping

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892650cc2488330b9c3f4f3239ff5a0