### PR TITLE
Add character tab with equipment layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Character equipment UI for managing equippable items.
 - Equipment system with equippable slots and prestige reset.
 ### Changed
+- Added Character tab with separate character and equipment sections.
 - Equipment.equip validates item slots and infers the correct slot when unspecified.
 - Character equipment items now include an Equip button.
 - Equipment items now specify their equip slot.

--- a/css/styles.css
+++ b/css/styles.css
@@ -637,3 +637,20 @@ body.dark {
 .tab-headers button[data-tab="chip"] {
     color: var(--chip-color);
 }
+
+.character-layout {
+    display: grid;
+    grid-template-columns: 1fr 2fr 1fr;
+    gap: 1rem;
+    align-items: center;
+}
+
+.character-layout .slots {
+    flex-direction: column;
+    margin-top: 0;
+}
+
+.character-layout img {
+    width: 100%;
+    max-width: 200px;
+}

--- a/data/lang/uk.json
+++ b/data/lang/uk.json
@@ -38,7 +38,8 @@
     "Drop Chances": "Шанс здобичі",
     "Guaranteed Loot": "Гарантована здобич",
     "Consumables": "Витратні матеріали",
-    "Equipment": "Спорядження"
+    "Equipment": "Спорядження",
+    "Character": "Персонаж"
   },
   "actions": {
     "studying": { "name": "Навчання" },

--- a/data/ui.json
+++ b/data/ui.json
@@ -31,6 +31,28 @@
             ]
         },
         {
+            "id": "character",
+            "name": "Character",
+            "hidden": false,
+            "locked": false,
+            "sections": [
+                {
+                    "id": "character",
+                    "name": "Character",
+                    "type": "slots",
+                    "hidden": false,
+                    "locked": false
+                },
+                {
+                    "id": "equipment",
+                    "name": "Equipment",
+                    "type": "slots",
+                    "hidden": false,
+                    "locked": false
+                }
+            ]
+        },
+        {
             "id": "inventory",
             "name": "Belongings",
             "hidden": false,

--- a/index.html
+++ b/index.html
@@ -113,6 +113,24 @@
                             <div id="adventure-slots" class="slots"></div>
                         </div>
                     </div>
+                    <div class="tab-content hidden" data-tab="character">
+                        <div class="tab-section" data-section="character" data-type="slots">
+                            <h2 data-i18n="Character">Character</h2>
+                            <div class="section-body">
+                                <div class="character-layout">
+                                    <div id="character-slots-left" class="slots"></div>
+                                    <img id="character-image" src="assets/char/new_char.png" alt="character">
+                                    <div id="character-slots-right" class="slots"></div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="tab-section" data-section="equipment" data-type="slots">
+                            <h2 data-i18n="Equipment">Equipment</h2>
+                            <div class="section-body">
+                                <div id="equipment-items" class="slots"></div>
+                            </div>
+                        </div>
+                    </div>
                     <div class="tab-content hidden" data-tab="inventory">
                         <div class="tab-section" data-section="home" data-type="slots">
                             <h2 data-i18n="Available Homes">Available Homes</h2>
@@ -131,9 +149,6 @@
                             <div class="section-body">
                                 <button id="inventory-filter-btn">Hide Items</button>
                                 <div id="inventory-slots" class="slots"></div>
-                                <h3 id="equipment-heading" data-i18n="Equipment">Equipment</h3>
-                                <div id="equipment-slots" class="slots"></div>
-                                <div id="equipment-items" class="slots"></div>
                             </div>
                         </div>
                     </div>

--- a/js/main.js
+++ b/js/main.js
@@ -79,9 +79,6 @@ async function init() {
     MasteryUI.init();
     PrestigeUI.init();
     InventoryUI.init();
-    if (typeof CharacterUI !== 'undefined') {
-        CharacterUI.init();
-    }
     HomeUI.init();
     FurnitureUI.init();
     ResearchUI.init();

--- a/js/tab_manager.js
+++ b/js/tab_manager.js
@@ -7,6 +7,7 @@ const TabManager = {
     icons: {
         routines: '🏠',
         adventure: '⚔️',
+        character: '🧍',
         inventory: '🎒',
         automation: '🤖',
         chip: '💡'

--- a/js/ui/character.js
+++ b/js/ui/character.js
@@ -2,12 +2,9 @@
 // It listens for inventory and equipment changes via PubSub.
 const CharacterUI = {
     init() {
-        this.slotContainer = document.getElementById('equipment-slots');
+        this.leftContainer = document.getElementById('character-slots-left');
+        this.rightContainer = document.getElementById('character-slots-right');
         this.itemContainer = document.getElementById('equipment-items');
-        this.heading = document.getElementById('equipment-heading');
-        if (this.heading) {
-            this.heading.textContent = Lang.ui('Equipment') || 'Equipment';
-        }
         if (typeof PubSub !== 'undefined') {
             PubSub.subscribe('inventory:changed', () => this.updateItems());
             PubSub.subscribe('equipment:changed', (_, eq) => this.updateSlots(eq));
@@ -16,9 +13,12 @@ const CharacterUI = {
         this.updateItems();
     },
     updateSlots(equipped = State.equipment) {
-        if (!this.slotContainer) return;
-        this.slotContainer.innerHTML = '';
-        Object.entries(equipped).forEach(([slot, itemId]) => {
+        if (!this.leftContainer || !this.rightContainer) return;
+        this.leftContainer.innerHTML = '';
+        this.rightContainer.innerHTML = '';
+        const leftSlots = ['head', 'leftHand', 'ring1', 'pants', 'boots'];
+        const rightSlots = ['armor', 'rightHand', 'gloves', 'ring2', 'necklace'];
+        const buildSlot = (slot, itemId) => {
             const slotEl = document.createElement('div');
             slotEl.className = 'slot';
             slotEl.dataset.slot = slot;
@@ -30,6 +30,8 @@ const CharacterUI = {
                 const item = ItemGenerator.itemList.find(i => i.id === itemId);
                 if (item && item.image) {
                     slotEl.style.backgroundImage = `url(${item.image})`;
+                } else {
+                    slotEl.style.backgroundImage = 'none';
                 }
                 slotEl.dataset.tooltip = capitalize(item ? item.name : itemId);
             }
@@ -38,7 +40,13 @@ const CharacterUI = {
                     Equipment.unequip(slot);
                 }
             });
-            this.slotContainer.appendChild(slotEl);
+            return slotEl;
+        };
+        leftSlots.forEach(slot => {
+            this.leftContainer.appendChild(buildSlot(slot, equipped[slot]));
+        });
+        rightSlots.forEach(slot => {
+            this.rightContainer.appendChild(buildSlot(slot, equipped[slot]));
         });
     },
     updateItems() {

--- a/js/ui_handler.js
+++ b/js/ui_handler.js
@@ -3,6 +3,9 @@ const UIHandler = {
         await this.loadTabs();
         StatsUI.init();
         ResourcesUI.init();
+        if (typeof CharacterUI !== 'undefined') {
+            CharacterUI.init();
+        }
         this.buildStats();
         this.buildResources();
     },

--- a/tests/test_character_ui.py
+++ b/tests/test_character_ui.py
@@ -13,12 +13,13 @@ def test_character_ui_mentions_equipment():
     assert 'Equipment' in text
 
 
-def test_character_translation_has_equipment():
+def test_character_translation_has_sections():
     path = os.path.join('data', 'lang', 'uk.json')
     with open(path) as f:
         data = json.load(f)
     ui = data.get('ui', {})
     assert 'Equipment' in ui
+    assert 'Character' in ui
 
 
 def test_equip_button_equips_item():
@@ -45,9 +46,10 @@ class Elem {
 }
 
 const elements = {
-  'equipment-slots': new Elem('div'),
+  'character-slots-left': new Elem('div'),
+  'character-slots-right': new Elem('div'),
   'equipment-items': new Elem('div'),
-  'equipment-heading': new Elem('div')
+  'character-image': new Elem('img')
 };
 
 global.document = {


### PR DESCRIPTION
## Summary
- Introduce a dedicated Character tab with character and equipment sections, removing gear UI from Inventory.
- Render character slots around a central image and display owned gear in a grid.
- Initialize character UI through UIHandler and add a character tab icon.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689270926ad08330bac49c3138c81f36