### PR TITLE
Streamline inventory to consumables only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Adventure encounters pause on resource depletion and resume when resources are fully restored.
 - Queued actions now wait for all related resources to reach their maximum before starting or resuming.
 - Adventure details now show a short description when expanded.
+- Removed equipment listings from inventory belongings and filtered inventory UI to show only consumables and resources.
 - Adventure list uses expandable buttons with encounter previews and cancels when resources run out.
 - Items now have types and consumables restore resources instead of granting soft caps.
 - Adventure tab now requires manual activation and shows encounters in the Active slot.

--- a/index.html
+++ b/index.html
@@ -124,12 +124,6 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="tab-section" data-section="equipment" data-type="slots">
-                            <h2 data-i18n="Equipment">Equipment</h2>
-                            <div class="section-body">
-                                <div id="equipment-items" class="slots"></div>
-                            </div>
-                        </div>
                     </div>
                     <div class="tab-content hidden" data-tab="inventory">
                         <div class="tab-section" data-section="home" data-type="slots">

--- a/js/ui/character.js
+++ b/js/ui/character.js
@@ -1,16 +1,13 @@
-// CharacterUI renders equipment slots and available equipment items.
-// It listens for inventory and equipment changes via PubSub.
+// CharacterUI renders equipment slots.
+// It listens for equipment changes via PubSub.
 const CharacterUI = {
     init() {
         this.leftContainer = document.getElementById('character-slots-left');
         this.rightContainer = document.getElementById('character-slots-right');
-        this.itemContainer = document.getElementById('equipment-items');
         if (typeof PubSub !== 'undefined') {
-            PubSub.subscribe('inventory:changed', () => this.updateItems());
             PubSub.subscribe('equipment:changed', (_, eq) => this.updateSlots(eq));
         }
         this.updateSlots(State.equipment);
-        this.updateItems();
     },
     updateSlots(equipped = State.equipment) {
         if (!this.leftContainer || !this.rightContainer) return;
@@ -47,28 +44,6 @@ const CharacterUI = {
         });
         rightSlots.forEach(slot => {
             this.rightContainer.appendChild(buildSlot(slot, equipped[slot]));
-        });
-    },
-    updateItems() {
-        if (!this.itemContainer) return;
-        this.itemContainer.innerHTML = '';
-        const items = Inventory.getItems(true).filter(it => it.type === 'equipment');
-        items.forEach(item => {
-            const itemEl = document.createElement('div');
-            itemEl.className = 'slot';
-            if (item.image) {
-                itemEl.style.backgroundImage = `url(${item.image})`;
-            }
-            itemEl.classList.add(`rarity-${item.rarity}`);
-            const label = document.createElement('span');
-            label.className = 'label';
-            label.textContent = capitalize(item.name);
-            itemEl.appendChild(label);
-            const equipBtn = document.createElement('button');
-            equipBtn.textContent = Lang.ui('Equip') || 'Equip';
-            equipBtn.addEventListener('click', () => Equipment.equip(item.id));
-            itemEl.appendChild(equipBtn);
-            this.itemContainer.appendChild(itemEl);
         });
     }
 };

--- a/js/ui/inventory.js
+++ b/js/ui/inventory.js
@@ -10,7 +10,9 @@ const InventoryUI = {
     },
     update() {
         if (!this.container) return;
-        const items = Inventory.getItems(false);
+        const items = Inventory
+            .getItems(false)
+            .filter(it => it.type === 'consumable' || it.type === 'resource');
         this.container.innerHTML = '';
         const groups = {};
         // Group items by type so each section can be labeled

--- a/tests/test_character_ui.py
+++ b/tests/test_character_ui.py
@@ -8,7 +8,6 @@ def test_character_ui_mentions_equipment():
     with open(path) as f:
         text = f.read()
     assert 'Lang.ui' in text
-    assert 'inventory:changed' in text
     assert 'equipment:changed' in text
     assert 'Equipment' in text
 
@@ -22,7 +21,7 @@ def test_character_translation_has_sections():
     assert 'Character' in ui
 
 
-def test_equip_button_equips_item():
+def test_clicking_slot_unequips_item():
     script = r"""
 class Elem {
   constructor(tag) {
@@ -31,9 +30,9 @@ class Elem {
     this.className = '';
     this.style = {};
     this.dataset = {};
-    this.eventListeners = {};
     this.textContent = '';
     this._innerHTML = '';
+    this.eventListeners = {};
     this.classList = { add: () => {} };
     Object.defineProperty(this, 'innerHTML', {
       get: () => this._innerHTML,
@@ -48,7 +47,6 @@ class Elem {
 const elements = {
   'character-slots-left': new Elem('div'),
   'character-slots-right': new Elem('div'),
-  'equipment-items': new Elem('div'),
   'character-image': new Elem('img')
 };
 
@@ -58,28 +56,25 @@ global.document = {
 };
 
 global.State = {
-  equipment: { head:null, armor:null, leftHand:null, rightHand:null, pants:null, boots:null, gloves:null, ring1:null, ring2:null, necklace:null },
-  inventory: { stone_spear: { quantity: 1 } }
+  equipment: { head:'stone_spear', armor:null, leftHand:null, rightHand:null, pants:null, boots:null, gloves:null, ring1:null, ring2:null, necklace:null }
 };
 
-global.ItemGenerator = { itemList: [{ id:'stone_spear', type:'equipment', slot:'rightHand', name:'stone spear', rarity:'common' }] };
-global.Inventory = { getItems: () => [{ id:'stone_spear', type:'equipment', name:'stone spear', rarity:'common' }] };
+global.ItemGenerator = { itemList: [{ id:'stone_spear', type:'equipment', slot:'head', name:'stone spear', rarity:'common' }] };
 global.Lang = { ui: k => k };
 global.capitalize = s => s;
 
 const { Equipment } = require('./js/equipment.js');
+Equipment.unequip = slot => { State.equipment[slot] = null; };
 const { CharacterUI } = require('./js/ui/character.js');
 
 CharacterUI.init();
 
-const items = document.getElementById('equipment-items');
-const card = items.children[0];
-const btn = card.children.find(c => c.tagName === 'button');
-btn.click();
+const slot = elements['character-slots-left'].children[0];
+slot.click();
 
-console.log(JSON.stringify({ equipped: State.equipment.rightHand }));
+console.log(JSON.stringify({ head: State.equipment.head }));
 """;
     result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
     data = json.loads(result.stdout.strip())
-    assert data['equipped'] == 'stone_spear'
+    assert data['head'] is None
 

--- a/tests/test_inventory_sections.py
+++ b/tests/test_inventory_sections.py
@@ -18,6 +18,15 @@ def test_inventory_has_heading_without_equipment():
     assert 'Equipment' not in text
 
 
+def test_index_has_no_equipment_section():
+    path = 'index.html'
+    with open(path) as f:
+        text = f.read()
+    assert 'equipment-heading' not in text
+    assert 'equipment-slots' not in text
+    assert 'equipment-items' not in text
+
+
 def test_uk_translation_sections():
     path = os.path.join('data', 'lang', 'uk.json')
     with open(path) as f:


### PR DESCRIPTION
## Summary
- remove equipment section from inventory layout
- filter inventory UI to render only consumables and resources
- update character and tests for simplified inventory

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893435c0a7483308d149ffd9c2d6e03