### PR TITLE
Use div background for character image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Character equipment UI for managing equippable items.
 - Equipment system with equippable slots and prestige reset.
 ### Changed
+- Character image now uses a single `div` with a background image and layout auto-sizing.
 - Inventory tab renamed and character equipment UI now reacts to language changes.
 - Character art now renders in a dedicated Character tab element and updates only on equipment changes.
 - Added Character tab with separate character and equipment sections.

--- a/css/styles.css
+++ b/css/styles.css
@@ -635,7 +635,7 @@ body.dark {
 
 .character-layout {
     display: grid;
-    grid-template-columns: 1fr 2fr 1fr;
+    grid-template-columns: 1fr auto 1fr;
     gap: 1rem;
     align-items: center;
 }
@@ -645,10 +645,9 @@ body.dark {
     margin-top: 0;
 }
 
-.character-layout .character-image {
-    width: 100%;
-    max-width: 200px;
-    height: 200px;
+.character-image {
+    width: 180px;
+    height: 180px;
     background-size: contain;
     background-position: center;
     background-repeat: no-repeat;

--- a/index.html
+++ b/index.html
@@ -120,9 +120,7 @@
                             <div class="section-body">
                                 <div class="character-layout">
                                     <div id="character-slots-left" class="slots"></div>
-                                    <div id="character-image" class="character-image">
-                                        <img id="character-image" src="assets/char/new_char.png" alt="Character">
-                                    </div>
+                                    <div id="character-image" class="character-image"></div>
                                     <div id="character-slots-right" class="slots"></div>
                                 </div>
                             </div>

--- a/tests/test_character_ui.py
+++ b/tests/test_character_ui.py
@@ -48,8 +48,7 @@ const elements = {
   'character-slots-left': new Elem('div'),
   'character-slots-right': new Elem('div'),
   'equipment-items': new Elem('div'),
-  'character-image': new Elem('div')
-  'character-image': new Elem('img')
+  'character-image': new Elem('div'),
 };
 
 global.document = {


### PR DESCRIPTION
## Summary
- Render character art with a styled div instead of an img
- Adjust character layout grid and image dimensions
- Align tests and changelog with the new DOM structure

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68934c86b54c83308b80e57a09a67680