### PR TITLE
Remove left stats panel and related UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
-## [0.41.67] - 2025-08-05
+## [0.41.67] - 2025-08-06
 ### Added
 - Character equipment UI for managing equippable items.
 - Equipment system with equippable slots and prestige reset.
 ### Changed
+- Removed stats side panel and related UI initialization; main layout now uses two columns.
 - Tab order now lists Routines, Adventure, Belongings, then Character with updated icons.
 - Character image now uses a single `div` with a background image and layout auto-sizing.
 - Inventory tab renamed and character equipment UI now reacts to language changes.

--- a/css/styles.css
+++ b/css/styles.css
@@ -182,19 +182,11 @@ footer {
 
 main {
     display: grid;
-    grid-template-columns: minmax(180px, 1fr) 2fr minmax(180px, 1fr);
+    grid-template-columns: 2fr minmax(180px, 1fr);
     gap: 1rem;
     padding: 1rem;
     padding-bottom: 3rem;
     align-items: start;
-}
-
-body.left-collapsed main {
-    grid-template-columns: 2fr minmax(180px, 1fr);
-}
-
-body.left-collapsed #left {
-    display: none;
 }
 
 .panel {

--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
                 <button data-speed="2">2x</button>
                 <button data-speed="10">10x</button>
             </span>
-            <button id="toggle-left" data-i18n="Hide Stats">Hide Stats</button>
             <button id="settings-btn" title="Settings">⚙️</button>
         </div>
     </header>
@@ -64,31 +63,6 @@
     </div>
 
     <main id="app">
-        <div id="left" class="panel">
-            <section id="stats">
-                <h2 data-i18n="Stats">Stats</h2>
-                <ul id="stats-list"></ul>
-
-                <section id="prestige-block">
-                    <h3 data-i18n="Prestige">Prestige</h3>
-                    <ul>
-                        <li><span class="prestige-label" data-key="constitution">Constitution</span>: <span id="prestige-constitution">0</span> <span id="prestige-constitution-gain" class="delta">(+0)</span></li>
-                        <li><span class="prestige-label" data-key="wisdom">Wisdom</span>: <span id="prestige-wisdom">0</span> <span id="prestige-wisdom-gain" class="delta">(+0)</span></li>
-                        <li><span class="prestige-label" data-key="reflexes">Reflexes</span>: <span id="prestige-reflexes">0</span> <span id="prestige-reflexes-gain" class="delta">(+0)</span></li>
-                    </ul>
-                </section>
-            </section>
-
-            <section id="mastery">
-                <h2><span data-i18n="Mastery Points">Mastery Points</span>: <span id="mastery-points">0</span></h2>
-            </section>
-
-            <section id="resources">
-                <h2 data-i18n="Resources">Resources</h2>
-                <ul id="resources-list"></ul>
-            </section>
-        </div>
-
         <div id="center" class="panel">
             <div class="tabs">
                 <div id="tab-contents">

--- a/js/main.js
+++ b/js/main.js
@@ -5,9 +5,6 @@ const TICKS_PER_SECOND = 1000 / LOGIC_TICK_MS;
 let actions = {};
 
 function updateUI() {
-    StatsUI.update();
-    ResourcesUI.update();
-    MasteryUI.update();
     PrestigeUI.update();
     document.getElementById('age-years').textContent = State.age.years;
     document.getElementById('age-days').textContent = Math.floor(State.age.days);
@@ -76,7 +73,6 @@ async function init() {
     Lang.applyToLocations(EncounterGenerator.milestones);
     SoftCapSystem.recalculateCaps(State.inventory);
     await UIHandler.init();
-    MasteryUI.init();
     PrestigeUI.init();
     InventoryUI.init();
     HomeUI.init();
@@ -100,11 +96,7 @@ async function init() {
     TabContainer.init();
     Lang.translateUI();
     TabContainer.translate();
-    const toggleBtn = document.getElementById('toggle-left');
     StorySystem.init();
-    if (toggleBtn) {
-        toggleBtn.addEventListener('click', toggleLeftPanel);
-    }
     const settingsBtn = document.getElementById('settings-btn');
     if (settingsBtn) {
         settingsBtn.addEventListener('click', openSettings);
@@ -161,9 +153,7 @@ async function init() {
             Lang.applyToLocations(EncounterGenerator.milestones);
             Lang.translateUI();
             TabContainer.translate();
-            StatsUI.translate();
             PrestigeUI.translate();
-            ResourcesUI.translate();
             updateTaskList();
             for (let i = 0; i < State.slotCount; i++) updateSlotUI(i);
             for (let i = 0; i < State.adventureSlotCount; i++) updateAdventureSlotUI(i);
@@ -195,8 +185,6 @@ async function init() {
             updateUI();
             updateTaskList();
         });
-        PubSub.subscribe('stats:updated', updateUI);
-        PubSub.subscribe('mastery:changed', updateUI);
         PubSub.subscribe('age:advanced', updateUI);
         PubSub.subscribe('action:levelUp', updateTaskList);
         PubSub.subscribe('action:exp', updateTaskList);

--- a/js/story_core.js
+++ b/js/story_core.js
@@ -1,15 +1,4 @@
 // Misc story-related helpers
-function toggleLeftPanel() {
-    const body = document.body;
-    body.classList.toggle('left-collapsed');
-    const btn = document.getElementById('toggle-left');
-    if (btn) {
-        btn.textContent = body.classList.contains('left-collapsed') ?
-            (Lang.ui('Show Stats') || 'Show Stats') :
-            (Lang.ui('Hide Stats') || 'Hide Stats');
-    }
-}
-
 function applyDarkMode() {
     document.body.classList.toggle('dark', State.darkMode);
     const chk = document.getElementById('dark-mode-toggle');

--- a/js/ui_handler.js
+++ b/js/ui_handler.js
@@ -1,19 +1,8 @@
 const UIHandler = {
     async init() {
         await this.loadTabs();
-        StatsUI.init();
-        ResourcesUI.init();
-        this.buildStats();
-        this.buildResources();
         if (typeof CharacterUI !== 'undefined') {
             CharacterUI.init();
-        }
-        if (typeof PubSub !== 'undefined') {
-            // rebuild lists when the interface language changes
-            PubSub.subscribe('lang:changed', () => {
-                this.buildStats();
-                this.buildResources();
-            });
         }
     },
     async loadTabs() {
@@ -27,45 +16,5 @@ const UIHandler = {
             console.error('Failed to load UI layout', e);
             TabManager.load([]);
         }
-    },
-    buildStats() {
-        const listEl = document.getElementById('stats-list');
-        if (!listEl) return;
-        listEl.innerHTML = '';
-        StatsUI.list.forEach(key => {
-            const li = document.createElement('li');
-            const label = document.createElement('span');
-            label.className = 'stat-label';
-            label.dataset.key = key;
-            label.textContent = Lang.stat(key) || capitalize(key);
-            li.appendChild(label);
-            li.insertAdjacentHTML('beforeend',
-                `: <span id="stat-${key}">0</span>/<span id="stat-${key}-cap">0</span>` +
-                ` (<span id="stat-${key}-delta" class="delta">0</span>/s)`);
-            listEl.appendChild(li);
-        });
-    },
-    buildResources() {
-        const listEl = document.getElementById('resources-list');
-        if (!listEl) return;
-        listEl.innerHTML = '';
-        ResourcesUI.list.forEach(key => {
-            const li = document.createElement('li');
-            const label = document.createElement('span');
-            label.className = 'resource-label';
-            label.dataset.key = key;
-            label.textContent = Lang.resource(key) || capitalize(key);
-            li.appendChild(label);
-            const bar = document.createElement('div');
-            bar.className = `resource-bar ${key}-bar`;
-            const fill = document.createElement('div');
-            fill.className = 'resource-bar-fill';
-            fill.id = `res-${key}-fill`;
-            bar.appendChild(fill);
-            li.appendChild(bar);
-            li.insertAdjacentHTML('beforeend',
-                ` (<span id="res-${key}-delta" class="delta">0</span>/s)`);
-            listEl.appendChild(li);
-        });
     }
 };


### PR DESCRIPTION
## Summary
- remove stats side panel and its Hide Stats toggle
- drop StatsUI, ResourcesUI, and MasteryUI hooks
- simplify layout to two-column grid without left panel

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689359f6602c833081689498ea03af8a