### PR TITLE
Add expandable resources tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.67] - 2025-08-06
 ### Added
+- Resources tab with expandable buttons showing resource modifiers.
 - Character equipment UI for managing equippable items.
 - Equipment system with equippable slots and prestige reset.
 ### Changed

--- a/css/styles.css
+++ b/css/styles.css
@@ -217,6 +217,33 @@ main {
     gap: 0.5rem;
 }
 
+#resource-list {
+    list-style: none;
+    padding: 0;
+}
+
+.resource-item {
+    margin-bottom: 0.5rem;
+}
+
+.resource-btn {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    background: var(--task-bg);
+    padding: 0.5rem;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+.resource-detail {
+    margin-top: 0.25rem;
+    background: var(--task-bg);
+    padding: 0.5rem;
+    border-radius: 4px;
+}
+
 #task-list li {
     background: var(--task-bg);
     margin-bottom: 0.5rem;

--- a/data/lang/uk.json
+++ b/data/lang/uk.json
@@ -3,6 +3,7 @@
     "Stats": "Статистика",
     "Prestige": "Престиж",
     "Resources": "Ресурси",
+    "Resource Modifiers": "Модифікатори ресурсу",
     "Available Actions": "Доступні дії",
     "Action Slots": "Слоти дій",
     "Adventure": "Пригода",

--- a/data/ui.json
+++ b/data/ui.json
@@ -1,6 +1,21 @@
 {
     "tabs": [
         {
+            "id": "resources",
+            "name": "Resources",
+            "hidden": false,
+            "locked": false,
+            "sections": [
+                {
+                    "id": "resources",
+                    "name": "Resources",
+                    "type": "buttons",
+                    "hidden": false,
+                    "locked": false
+                }
+            ]
+        },
+        {
             "id": "routines",
             "name": "Routines",
             "hidden": false,

--- a/index.html
+++ b/index.html
@@ -66,7 +66,15 @@
         <div id="center" class="panel">
             <div class="tabs">
                 <div id="tab-contents">
-                    <div class="tab-content" data-tab="routines">
+                    <div class="tab-content" data-tab="resources">
+                        <div class="tab-section" data-section="resources" data-type="buttons">
+                            <h2 data-i18n="Resources">Resources</h2>
+                            <div class="section-body">
+                                <ul id="resource-list"></ul>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="tab-content hidden" data-tab="routines">
                         <div class="tab-section" data-section="actions" data-type="buttons">
                             <h2 data-i18n="Available Actions">Available Actions</h2>
                             <div class="section-body">
@@ -202,6 +210,7 @@
     <script src="js/ui/furniture.js"></script>
     <script src="js/ui/home.js"></script>
     <script src="js/ui/research.js"></script>
+    <script src="js/ui/resources_tab.js"></script>
     <script src="js/prestige.js"></script>
     <script src="js/action_utils.js"></script>
     <script src="js/engine.js"></script>

--- a/js/tab_manager.js
+++ b/js/tab_manager.js
@@ -5,6 +5,7 @@ const TabManager = {
     activeSections: {},
     _sectionButtons: {},
     icons: {
+        resources: '💰',
         routines: '⚡',
         adventure: '🌲',
         inventory: '📦',

--- a/js/ui/resources_tab.js
+++ b/js/ui/resources_tab.js
@@ -1,0 +1,72 @@
+const ResourcesTab = {
+    container: null,
+    entries: {},
+    init() {
+        this.container = document.getElementById('resource-list');
+        if (!this.container) return;
+        Object.keys(State.resources).forEach(name => {
+            const el = this._createEntry(name, State.resources[name]);
+            this.container.appendChild(el);
+        });
+        if (typeof PubSub !== 'undefined') {
+            PubSub.subscribe('resource:changed', data => this.update(data.name));
+        }
+    },
+    _createEntry(name, res) {
+        const li = document.createElement('li');
+        li.className = 'resource-item';
+        const btn = document.createElement('button');
+        btn.className = 'resource-btn';
+        const amt = document.createElement('span');
+        amt.className = 'resource-amount';
+        amt.textContent = `${res.value}/${ResourceSystem.max(res)}`;
+        const label = document.createElement('span');
+        label.className = 'resource-label';
+        label.textContent = Lang.resource(name) || capitalize(name);
+        btn.appendChild(amt);
+        btn.appendChild(label);
+        li.appendChild(btn);
+        const detail = document.createElement('div');
+        detail.className = 'resource-detail hidden';
+        const mods = document.createElement('ul');
+        mods.className = 'resource-mods';
+        detail.appendChild(mods);
+        li.appendChild(detail);
+        btn.addEventListener('click', () => {
+            detail.classList.toggle('hidden');
+        });
+        this.entries[name] = { amount: amt, mods: mods };
+        this._renderMods(name, res);
+        return li;
+    },
+    _renderMods(name, res) {
+        const list = this.entries[name].mods;
+        list.innerHTML = '';
+        res.maxAdditions.forEach(a => {
+            const li = document.createElement('li');
+            li.textContent = `+${a}`;
+            list.appendChild(li);
+        });
+        res.maxMultipliers.forEach(m => {
+            const li = document.createElement('li');
+            li.textContent = `×${m}`;
+            list.appendChild(li);
+        });
+    },
+    update(name) {
+        const res = State.resources[name];
+        if (!res) return;
+        if (!this.entries[name]) {
+            const el = this._createEntry(name, res);
+            this.container.appendChild(el);
+            return;
+        }
+        this.entries[name].amount.textContent = `${res.value}/${ResourceSystem.max(res)}`;
+        this._renderMods(name, res);
+    }
+};
+
+if (typeof module !== 'undefined') {
+    module.exports = { ResourcesTab };
+}
+

--- a/js/ui_handler.js
+++ b/js/ui_handler.js
@@ -4,6 +4,9 @@ const UIHandler = {
         if (typeof CharacterUI !== 'undefined') {
             CharacterUI.init();
         }
+        if (typeof ResourcesTab !== 'undefined') {
+            ResourcesTab.init();
+        }
     },
     async loadTabs() {
         try {

--- a/tests/test_resources_tab_ui.py
+++ b/tests/test_resources_tab_ui.py
@@ -1,0 +1,70 @@
+import json
+import os
+import subprocess
+
+
+def test_resources_tab_in_ui_json():
+    path = os.path.join('data', 'ui.json')
+    with open(path) as f:
+        data = json.load(f)
+    tab = next((t for t in data['tabs'] if t['id'] == 'resources'), None)
+    assert tab is not None
+    assert tab['sections'][0]['type'] == 'buttons'
+
+
+def test_resources_tab_markup_and_script():
+    with open('index.html') as f:
+        html = f.read()
+    assert 'data-tab="resources"' in html
+    assert 'id="resource-list"' in html
+    assert 'js/ui/resources_tab.js' in html
+
+
+def test_resources_tab_toggle_behavior():
+    script = r"""
+class Elem {
+  constructor(tag){
+    this.tagName = tag;
+    this.children = [];
+    this.className = '';
+    this.dataset = {};
+    this.textContent = '';
+    this.eventListeners = {};
+    this.classList = {
+      add: c => { if (!this.className.split(' ').includes(c)) this.className += (this.className ? ' ' : '') + c; },
+      remove: c => { this.className = this.className.split(' ').filter(x => x !== c).join(' '); },
+      toggle: c => { if (this.className.split(' ').includes(c)) { this.classList.remove(c); return false; } else { this.classList.add(c); return true; } },
+      contains: c => this.className.split(' ').includes(c)
+    };
+  }
+  appendChild(ch){ this.children.push(ch); }
+  addEventListener(ev, fn){ this.eventListeners[ev] = fn; }
+  click(){ if (this.eventListeners['click']) this.eventListeners['click'](); }
+}
+const elements = { 'resource-list': new Elem('ul') };
+global.document = { getElementById: id => elements[id], createElement: tag => new Elem(tag) };
+global.State = { resources: { energy: { value: 5, baseMax: 10, maxAdditions: [2], maxMultipliers: [2] } } };
+global.ResourceSystem = { max: r => r.baseMax };
+global.Lang = { resource: k => k };
+global.capitalize = s => s;
+global.PubSub = { subscribe: (ev, fn) => { global.eventName = ev; } };
+const { ResourcesTab } = require('./js/ui/resources_tab.js');
+ResourcesTab.init();
+const li = elements['resource-list'].children[0];
+const btn = li.children[0];
+btn.click();
+console.log(JSON.stringify({ detail: li.children[1].className, event: global.eventName }));
+"""
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    out = json.loads(result.stdout.strip())
+    assert out['event'] == 'resource:changed'
+    assert out['detail'] == 'resource-detail'
+
+
+def test_uk_translation_resources_tab():
+    path = os.path.join('data', 'lang', 'uk.json')
+    with open(path) as f:
+        data = json.load(f)
+    ui = data.get('ui', {})
+    assert 'Resources' in ui
+    assert 'Resource Modifiers' in ui


### PR DESCRIPTION
## Summary
- Add resources tab in UI layout and HTML with new script for resource buttons.
- Implement `ResourcesTab` module to render resources, toggle modifier details and react to `resource:changed` events.
- Style resource buttons to match existing actions and add translations for Ukrainian.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68935e1a838c8330a83d31c82be85e0e