### PR TITLE
feat: show max before current in resources tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Character equipment UI for managing equippable items.
 - Equipment system with equippable slots and prestige reset.
 ### Changed
+- Resource buttons now display white text with labels before amounts, showing max/current and aligning amounts right.
 - Removed stats side panel and related UI initialization; main layout now uses two columns.
 - Tab order now lists Routines, Adventure, Belongings, then Character with updated icons.
 - Character image now uses a single `div` with a background image and layout auto-sizing.

--- a/css/styles.css
+++ b/css/styles.css
@@ -235,6 +235,12 @@ main {
     border: none;
     border-radius: 4px;
     cursor: pointer;
+    color: #fff;
+}
+
+.resource-btn .resource-amount {
+    margin-left: auto;
+    text-align: right;
 }
 
 .resource-detail {

--- a/js/ui/resources_tab.js
+++ b/js/ui/resources_tab.js
@@ -17,14 +17,14 @@ const ResourcesTab = {
         li.className = 'resource-item';
         const btn = document.createElement('button');
         btn.className = 'resource-btn';
-        const amt = document.createElement('span');
-        amt.className = 'resource-amount';
-        amt.textContent = `${res.value}/${ResourceSystem.max(res)}`;
         const label = document.createElement('span');
         label.className = 'resource-label';
         label.textContent = Lang.resource(name) || capitalize(name);
-        btn.appendChild(amt);
+        const amt = document.createElement('span');
+        amt.className = 'resource-amount';
+        amt.textContent = `${ResourceSystem.max(res)}/${res.value}`;
         btn.appendChild(label);
+        btn.appendChild(amt);
         li.appendChild(btn);
         const detail = document.createElement('div');
         detail.className = 'resource-detail hidden';
@@ -61,7 +61,7 @@ const ResourcesTab = {
             this.container.appendChild(el);
             return;
         }
-        this.entries[name].amount.textContent = `${res.value}/${ResourceSystem.max(res)}`;
+        this.entries[name].amount.textContent = `${ResourceSystem.max(res)}/${res.value}`;
         this._renderMods(name, res);
     }
 };

--- a/tests/test_resources_tab_ui.py
+++ b/tests/test_resources_tab_ui.py
@@ -53,12 +53,21 @@ ResourcesTab.init();
 const li = elements['resource-list'].children[0];
 const btn = li.children[0];
 btn.click();
-console.log(JSON.stringify({ detail: li.children[1].className, event: global.eventName }));
+console.log(JSON.stringify({
+  detail: li.children[1].className,
+  event: global.eventName,
+  first: btn.children[0].className,
+  second: btn.children[1].className,
+  text: btn.children[1].textContent
+}));
 """
     result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
     out = json.loads(result.stdout.strip())
     assert out['event'] == 'resource:changed'
     assert out['detail'] == 'resource-detail'
+    assert out['first'] == 'resource-label'
+    assert out['second'] == 'resource-amount'
+    assert out['text'] == '10/5'
 
 
 def test_uk_translation_resources_tab():


### PR DESCRIPTION
## Summary
- Display resource labels before amounts and show max/current values
- Style resource buttons with white text and right-aligned amounts
- Update resource tab UI test for new markup

## Testing
- `pytest tests/test_resources_tab_ui.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68936be1991083308e49c3d9ef89d76c