### PR TITLE
Refactor right panel into collapsible sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Inventory screen now hides equipment items; gear is handled in the character UI.
 - Character background art now reflects equipped items instead of inventory contents.
 - Added consume buttons for consumable inventory items.
+- Replaced right panel tabs with stacked Active and Log sections with collapsible headers.
 - Inventory now groups items by type with translated headers.
 - Renamed item type `food` to `consumable` and updated related logic and tests.
 - Actions now restart automatically until resources run out, then queue and wait for full recovery before resuming.

--- a/css/styles.css
+++ b/css/styles.css
@@ -601,24 +601,31 @@ li.unaffordable {
     flex-direction: column;
 }
 
-.right-tabs {
+/* Right panel collapsible sections */
+.collapsible-section .section-header {
     display: flex;
-    gap: 0.5rem;
+    align-items: center;
+    cursor: pointer;
 }
 
-.right-tabs button.active {
-    background: #333;
-    color: #fff;
+.collapsible-section .section-header .arrow {
+    display: inline-block;
+    margin-right: 0.25rem;
+    transition: transform 0.2s;
+    transform: rotate(90deg);
 }
 
-.right-view.hidden {
-    display: none;
+.collapsible-section .section-header.collapsed .arrow {
+    transform: rotate(0deg);
+}
+
+.collapsible-section .section-body {
+    margin-top: 0.5rem;
 }
 
 .log-container {
     height: 300px;
     overflow-y: auto;
-    margin-top: 0.5rem;
 }
 
 .log-view {

--- a/index.html
+++ b/index.html
@@ -162,17 +162,19 @@
         </div>
 
         <div id="right" class="panel log-panel">
-            <div class="right-tabs">
-                <button data-panel="log" class="active" data-i18n="Log">Log</button>
-                <button data-panel="active" data-i18n="Active">Active</button>
-            </div>
-            <div id="log-panel" class="right-view">
-                <div id="log-container" class="log-container">
-                    <div id="log" class="log-view"></div>
+            <div id="active-section" class="collapsible-section">
+                <h2 class="section-header"><span class="arrow">&#9654;</span><span data-i18n="Active">Active</span></h2>
+                <div class="section-body">
+                    <div id="slots" class="slots"></div>
                 </div>
             </div>
-            <div id="active-panel" class="right-view hidden">
-                <div id="slots" class="slots"></div>
+            <div id="log-section" class="collapsible-section">
+                <h2 class="section-header"><span class="arrow">&#9654;</span><span data-i18n="Log">Log</span></h2>
+                <div class="section-body">
+                    <div id="log-container" class="log-container">
+                        <div id="log" class="log-view"></div>
+                    </div>
+                </div>
             </div>
         </div>
     </main>

--- a/js/main.js
+++ b/js/main.js
@@ -137,10 +137,6 @@ async function init() {
             SaveSystem.save();
         });
     }
-    document.querySelectorAll('#right .right-tabs button').forEach(btn => {
-        btn.addEventListener('click', () => showRightPanel(btn.dataset.panel));
-    });
-    showRightPanel('log');
     const langSelect = document.getElementById('language-select');
     if (langSelect) {
         langSelect.value = State.language;

--- a/js/story_core.js
+++ b/js/story_core.js
@@ -25,14 +25,3 @@ function closeInventoryFilter() {
     PubSub.publish('modal:close', 'inventory-filter-modal');
 }
 
-function showRightPanel(panel) {
-    const logPanel = document.getElementById('log-panel');
-    const activePanel = document.getElementById('active-panel');
-    const buttons = document.querySelectorAll('#right .right-tabs button');
-    if (!logPanel || !activePanel) return;
-    logPanel.classList.toggle('hidden', panel !== 'log');
-    activePanel.classList.toggle('hidden', panel !== 'active');
-    buttons.forEach(btn => {
-        btn.classList.toggle('active', btn.dataset.panel === panel);
-    });
-}

--- a/js/ui/section_component.js
+++ b/js/ui/section_component.js
@@ -6,6 +6,9 @@ const SectionComponent = {
                 this._initButtons(el);
             }
         });
+        document.querySelectorAll('.collapsible-section').forEach(el => {
+            this._initCollapsible(el);
+        });
     },
     _initButtons(el) {
         const header = el.querySelector('h2');
@@ -13,6 +16,15 @@ const SectionComponent = {
         if (!header || !body) return;
         header.addEventListener('click', () => {
             body.classList.toggle('hidden');
+        });
+    },
+    _initCollapsible(el) {
+        const header = el.querySelector('.section-header');
+        const body = el.querySelector('.section-body');
+        if (!header || !body) return;
+        header.addEventListener('click', () => {
+            const hidden = body.classList.toggle('hidden');
+            header.classList.toggle('collapsed', hidden);
         });
     }
 };

--- a/tests/test_right_panel_sections.py
+++ b/tests/test_right_panel_sections.py
@@ -1,0 +1,78 @@
+import json
+import subprocess
+
+
+def test_right_panel_sections_render():
+    with open('index.html') as f:
+        html = f.read()
+    assert 'right-tabs' not in html
+    assert '<div id="slots"' in html
+    assert '<div id="log"' in html
+    assert html.count('collapsible-section') == 2
+
+
+def test_right_panel_collapsible_behavior():
+    script = r"""
+class Elem {
+    constructor(tag) {
+        this.tagName = tag;
+        this.children = [];
+        this.className = '';
+        this.dataset = {};
+        this.eventListeners = {};
+        this.classList = {
+            add: c => { if (!this.className.split(' ').includes(c)) this.className += (this.className ? ' ' : '') + c; },
+            remove: c => { this.className = this.className.split(' ').filter(x => x !== c).join(' '); },
+            toggle: c => { if (this.className.split(' ').includes(c)) { this.classList.remove(c); return false; } else { this.classList.add(c); return true; } },
+            contains: c => this.className.split(' ').includes(c)
+        };
+    }
+    appendChild(ch) { this.children.push(ch); ch.parent = this; }
+    addEventListener(ev, fn) { this.eventListeners[ev] = fn; }
+    click() { if (this.eventListeners['click']) this.eventListeners['click'](); }
+    querySelector(sel) {
+        const cls = sel.slice(1);
+        return this.children.find(ch => ch.className.split(' ').includes(cls));
+    }
+}
+function makeSection() {
+    const section = new Elem('div');
+    section.classList.add('collapsible-section');
+    const header = new Elem('h2');
+    header.classList.add('section-header');
+    const arrow = new Elem('span');
+    arrow.classList.add('arrow');
+    header.appendChild(arrow);
+    const body = new Elem('div');
+    body.classList.add('section-body');
+    section.appendChild(header);
+    section.appendChild(body);
+    return section;
+}
+const active = makeSection();
+const log = makeSection();
+global.document = {
+    querySelectorAll: sel => sel === '.collapsible-section' ? [active, log] : []
+};
+const SectionComponent = require('./js/ui/section_component.js');
+SectionComponent.initAll();
+const header = active.querySelector('.section-header');
+const body = active.querySelector('.section-body');
+console.log(JSON.stringify({ hidden: body.classList.contains('hidden'), collapsed: header.classList.contains('collapsed') }));
+header.click();
+console.log(JSON.stringify({ hidden: body.classList.contains('hidden'), collapsed: header.classList.contains('collapsed') }));
+header.click();
+console.log(JSON.stringify({ hidden: body.classList.contains('hidden'), collapsed: header.classList.contains('collapsed') }));
+"""
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    lines = result.stdout.strip().splitlines()
+    first = json.loads(lines[0])
+    second = json.loads(lines[1])
+    third = json.loads(lines[2])
+    assert first['hidden'] is False
+    assert first['collapsed'] is False
+    assert second['hidden'] is True
+    assert second['collapsed'] is True
+    assert third['hidden'] is False
+    assert third['collapsed'] is False
+


### PR DESCRIPTION
## Summary
- split right sidebar into collapsible Active and Log sections
- drop showRightPanel logic and right-tabs styling
- add tests for concurrent rendering and collapsible behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68936d50b4808330ae48befc926f1919