### PR TITLE
Fix resource and stat max calculations for missing modifier arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 
 ### Fixed
 - Resolved misplaced braces in the inventory UI loop that broke item rendering.
+- Resource and stat max calculations no longer fail when modifier arrays are undefined.
 
 ## [0.41.66] - 2025-07-14
 ### Changed

--- a/js/state.js
+++ b/js/state.js
@@ -24,8 +24,8 @@ const ResourceSystem = {
     },
     max(res) {
         let m = res.baseMax;
-        res.maxAdditions.forEach(a => { m += a; });
-        res.maxMultipliers.forEach(x => { m *= x; });
+        (res.maxAdditions || []).forEach(a => { m += a; });
+        (res.maxMultipliers || []).forEach(x => { m *= x; });
         return m;
     },
     add(res, amt) {
@@ -44,8 +44,8 @@ const StatSystem = {
     },
     max(stat) {
         let m = stat.baseMax;
-        stat.maxAdditions.forEach(a => { m += a; });
-        stat.maxMultipliers.forEach(x => { m *= x; });
+        (stat.maxAdditions || []).forEach(a => { m += a; });
+        (stat.maxMultipliers || []).forEach(x => { m *= x; });
         return m;
     },
     add(stat, amt) {
@@ -66,8 +66,12 @@ function setResourceValue(name, val) {
     r.value = Math.min(val, getResourceMax(name));
 }
 function ensureResource(name, value, max) {
-    if (!State.resources[name] || typeof State.resources[name].value !== "number") {
+    const res = State.resources[name];
+    if (!res || typeof res.value !== "number") {
         State.resources[name] = ResourceSystem.create(value, max);
+    } else {
+        if (!Array.isArray(res.maxAdditions)) res.maxAdditions = [];
+        if (!Array.isArray(res.maxMultipliers)) res.maxMultipliers = [];
     }
 }
 
@@ -85,8 +89,12 @@ function setStatValue(name, val) {
 }
 
 function ensureStat(name, value, max) {
-    if (!State.stats[name] || typeof State.stats[name].value !== "number") {
+    const stat = State.stats[name];
+    if (!stat || typeof stat.value !== "number") {
         State.stats[name] = StatSystem.create(value, max);
+    } else {
+        if (!Array.isArray(stat.maxAdditions)) stat.maxAdditions = [];
+        if (!Array.isArray(stat.maxMultipliers)) stat.maxMultipliers = [];
     }
 }
 

--- a/tests/test_state_resources.py
+++ b/tests/test_state_resources.py
@@ -1,0 +1,27 @@
+import json
+import subprocess
+import textwrap
+
+
+def test_max_handles_missing_arrays():
+    script = textwrap.dedent(
+        """
+        const { ResourceSystem, StatSystem } = require('./js/state.js');
+        const res = { value: 0, baseMax: 12 };
+        const stat = { value: 0, baseMax: 7 };
+        console.log(JSON.stringify({
+            resMax: ResourceSystem.max(res),
+            statMax: StatSystem.max(stat)
+        }));
+        """
+    )
+    result = subprocess.run(
+        ['node', '-e', script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    data = json.loads(result.stdout.strip())
+    assert data['resMax'] == 12
+    assert data['statMax'] == 7
+


### PR DESCRIPTION
## Summary
- avoid errors when resources or stats lack maxAdditions/maxMultipliers
- ensure loaded resources/stats initialize missing modifier arrays
- add regression test for max calculations

## Testing
- `pip install -r requirements.txt`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_68939c031cc883308e2339a60aeed9c1