### PR TITLE
Default baseMax to zero to prevent NaN resource maxima

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 ### Fixed
 - Resolved misplaced braces in the inventory UI loop that broke item rendering.
 - Resource and stat max calculations no longer fail when modifier arrays are undefined.
+- Resources without a `baseMax` now default to zero to avoid `NaN` values.
 
 ## [0.41.66] - 2025-07-14
 ### Changed

--- a/js/state.js
+++ b/js/state.js
@@ -19,11 +19,17 @@
 const VERSION = 2;
 
 const ResourceSystem = {
+    // baseMax is coerced to a number and defaults to 0
     create(value, baseMax) {
-        return { value: value, baseMax: baseMax, maxAdditions: [], maxMultipliers: [] };
+        return {
+            value: value,
+            baseMax: Number(baseMax) || 0,
+            maxAdditions: [],
+            maxMultipliers: []
+        };
     },
     max(res) {
-        let m = res.baseMax;
+        let m = Number(res.baseMax) || 0;
         (res.maxAdditions || []).forEach(a => { m += a; });
         (res.maxMultipliers || []).forEach(x => { m *= x; });
         return m;
@@ -39,11 +45,17 @@ const ResourceSystem = {
 };
 
 const StatSystem = {
+    // baseMax is coerced to a number and defaults to 0
     create(value, baseMax) {
-        return { value: value, baseMax: baseMax, maxAdditions: [], maxMultipliers: [] };
+        return {
+            value: value,
+            baseMax: Number(baseMax) || 0,
+            maxAdditions: [],
+            maxMultipliers: []
+        };
     },
     max(stat) {
-        let m = stat.baseMax;
+        let m = Number(stat.baseMax) || 0;
         (stat.maxAdditions || []).forEach(a => { m += a; });
         (stat.maxMultipliers || []).forEach(x => { m *= x; });
         return m;

--- a/tests/test_state_resources.py
+++ b/tests/test_state_resources.py
@@ -25,3 +25,26 @@ def test_max_handles_missing_arrays():
     assert data['resMax'] == 12
     assert data['statMax'] == 7
 
+
+def test_missing_base_max_defaults_to_zero():
+    script = textwrap.dedent(
+        """
+        const { ResourceSystem, StatSystem } = require('./js/state.js');
+        const res = ResourceSystem.create(5);
+        const stat = StatSystem.create(3);
+        console.log(JSON.stringify({
+            resMax: ResourceSystem.max(res),
+            statMax: StatSystem.max(stat)
+        }));
+        """
+    )
+    result = subprocess.run(
+        ['node', '-e', script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    data = json.loads(result.stdout.strip())
+    assert data['resMax'] == 0
+    assert data['statMax'] == 0
+


### PR DESCRIPTION
## Summary
- coerce `baseMax` to numbers in ResourceSystem and StatSystem
- compute max values starting from numeric `baseMax`
- test that missing `baseMax` defaults to zero

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_6893a33c6de08330ad1bc8632571037f