### PR TITLE
Use updated resource events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@
 - Resources tab with expandable buttons showing resource modifiers.
 - Character equipment UI for managing equippable items.
 - Equipment system with equippable slots and prestige reset.
+- Emitted `prestige:updated` when prestige points are gained or reset.
 ### Changed
 - Resource buttons now display white text with labels before amounts, showing max/current and aligning amounts right.
 - Removed stats side panel and related UI initialization; main layout now uses two columns.
 - Tab order now lists Routines, Adventure, Belongings, then Character with updated icons.
 - Character image now uses a single `div` with a background image and layout auto-sizing.
+- Resources tab listens for `resources:updated`, `stats:updated`, and `prestige:updated` events.
 - Inventory tab renamed and character equipment UI now reacts to language changes.
 - Character art now renders in a dedicated Character tab element and updates only on equipment changes.
 - Added Character tab with separate character and equipment sections.

--- a/js/save_system.js
+++ b/js/save_system.js
@@ -164,6 +164,9 @@ const SaveSystem = {
         PRESTIGE_KEYS.forEach(k => {
             setState(['prestige', k, 'value'], (previousPrestige[k] || 0) + (prestigeGain[k] || 0));
         });
+        if (typeof PubSub !== 'undefined') {
+            PubSub.publish('prestige:updated');
+        }
 
         applyPrestigeBonuses();
 

--- a/js/ui/resources_tab.js
+++ b/js/ui/resources_tab.js
@@ -16,9 +16,15 @@ const ResourcesTab = {
         });
         this.container.appendChild(this._createEntry('mastery', 'mastery', State.mastery));
         if (typeof PubSub !== 'undefined') {
-            PubSub.subscribe('resource:changed', data => this.update(data.name));
-            PubSub.subscribe('stat:changed', data => this.update(data.name));
-            PubSub.subscribe('prestige:changed', data => this.update(data.name));
+            PubSub.subscribe('resources:updated', () => {
+                Object.keys(State.resources).forEach(name => this.update(name));
+            });
+            PubSub.subscribe('stats:updated', () => {
+                Object.keys(State.stats).forEach(name => this.update(name));
+            });
+            PubSub.subscribe('prestige:updated', () => {
+                Object.keys(State.prestige).forEach(name => this.update(name));
+            });
             PubSub.subscribe('mastery:changed', () => this.update('mastery'));
         }
     },

--- a/tests/test_resources_tab_ui.py
+++ b/tests/test_resources_tab_ui.py
@@ -96,3 +96,63 @@ def test_uk_translation_resources_tab():
     ui = data.get('ui', {})
     assert 'Resources' in ui
     assert 'Resource Modifiers' in ui
+
+
+def test_resources_tab_updates_on_event():
+    script = r"""
+class Elem {
+  constructor(tag){
+    this.tagName = tag;
+    this.children = [];
+    this.className = '';
+    this.dataset = {};
+    this.textContent = '';
+    this.eventListeners = {};
+    this.classList = {
+      add: c => { if (!this.className.split(' ').includes(c)) this.className += (this.className ? ' ' : '') + c; },
+      remove: c => { this.className = this.className.split(' ').filter(x => x !== c).join(' '); },
+      toggle: c => { if (this.className.split(' ').includes(c)) { this.classList.remove(c); return false; } else { this.classList.add(c); return true; } },
+      contains: c => this.className.split(' ').includes(c)
+    };
+  }
+  appendChild(ch){ this.children.push(ch); }
+  addEventListener(ev, fn){ this.eventListeners[ev] = fn; }
+  click(){ if (this.eventListeners['click']) this.eventListeners['click'](); }
+}
+const elements = { 'resource-list': new Elem('ul') };
+global.document = { getElementById: id => elements[id], createElement: tag => new Elem(tag) };
+global.State = {
+  stats: {},
+  resources: { energy: { value:5, baseMax:10, maxAdditions:[], maxMultipliers:[] } },
+  prestige: {},
+  mastery: { value:0, baseMax:Infinity, maxAdditions:[], maxMultipliers:[] },
+  statDescriptions: {},
+  resourceDescriptions: { energy: 'Use' },
+  prestigeDescriptions: {},
+  masteryDescription: ''
+};
+global.StatSystem = { max: r => r.baseMax };
+global.ResourceSystem = { max: r => r.baseMax };
+global.Lang = {
+  stat: k => k,
+  resource: k => k,
+  ui: k => k,
+  statDesc: k => null,
+  resourceDesc: k => null,
+  prestigeDesc: k => null
+};
+global.capitalize = s => s;
+global.PubSub = {
+  events: {},
+  subscribe(n, fn){ (this.events[n] = this.events[n] || []).push(fn); },
+  publish(n, d){ (this.events[n] || []).forEach(fn => fn(d)); }
+};
+const { ResourcesTab } = require('./js/ui/resources_tab.js');
+ResourcesTab.init();
+State.resources.energy.value = 7;
+PubSub.publish('resources:updated');
+console.log(JSON.stringify({ energy: ResourcesTab.entries['energy'].amount.textContent }));
+"""
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout.strip())
+    assert data['energy'] == '7/10'


### PR DESCRIPTION
## Summary
- Listen for `resources:updated`, `stats:updated`, and `prestige:updated` in the resources tab UI
- Publish `prestige:updated` after prestige values are recalculated
- Add UI test verifying resources tab updates when resource values change

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893ac41889083308a848d4dd87f1a01