### PR TITLE
Display resource tags on action slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 - Converted mastery points into a resource and added descriptions for all stats, resources and prestige values.
 - Resources tab with expandable buttons showing resource modifiers.
+- Action slots now show resource tags for costs and yields.
 - Character equipment UI for managing equippable items.
 - Equipment system with equippable slots and prestige reset.
 - Emitted `prestige:updated` when prestige points are gained or reset.

--- a/css/styles.css
+++ b/css/styles.css
@@ -394,6 +394,25 @@ main {
     border-color: #66cc66;
 }
 
+.slot .resource-tags {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    justify-content: center;
+    gap: 0.25rem;
+    pointer-events: none;
+}
+
+.slot .resource-tag {
+    background-color: rgba(0, 0, 0, 0.6);
+    color: #fff;
+    padding: 0 0.25rem;
+    border-radius: 3px;
+    font-size: 0.6rem;
+}
+
 .progress-wrapper {
     position: relative;
     cursor: pointer;
@@ -423,7 +442,7 @@ main {
 
 .slot .label {
     position: absolute;
-    top: 0;
+    top: 1.2rem;
     left: 0;
     right: 0;
     text-align: center;

--- a/js/slot.js
+++ b/js/slot.js
@@ -2,6 +2,9 @@ class BaseSlot {
     constructor(hasProgress = true) {
         this.el = document.createElement('div');
         this.el.className = 'slot';
+        this.resourceTags = document.createElement('div');
+        this.resourceTags.className = 'resource-tags';
+        this.el.appendChild(this.resourceTags);
         this.label = document.createElement('span');
         this.label.className = 'label';
         this.el.appendChild(this.label);

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -245,6 +245,37 @@ function updateSlotUI(i) {
         slotEl.style.backgroundImage = 'none';
     }
     slotEl.dataset.tooltip = buildActionTooltip(action);
+    const tagsEl = slotEl.querySelector('.resource-tags');
+    if (tagsEl) {
+        tagsEl.innerHTML = '';
+        const tags = [];
+        if (action.resourceCost) {
+            for (const r in action.resourceCost) {
+                const name = typeof Lang !== 'undefined' && Lang.resource ? (Lang.resource(r) || r) : r;
+                tags.push({ sign: '-', name });
+            }
+        }
+        if (action.resourceConsumption) {
+            for (const r in action.resourceConsumption) {
+                const name = typeof Lang !== 'undefined' && Lang.resource ? (Lang.resource(r) || r) : r;
+                tags.push({ sign: '-', name });
+            }
+        }
+        if (action.baseYield && action.baseYield.resources) {
+            for (const r in action.baseYield.resources) {
+                const val = action.baseYield.resources[r];
+                const sign = val >= 0 ? '+' : '-';
+                const name = typeof Lang !== 'undefined' && Lang.resource ? (Lang.resource(r) || r) : r;
+                tags.push({ sign, name });
+            }
+        }
+        for (const t of tags) {
+            const span = document.createElement('span');
+            span.className = 'resource-tag';
+            span.textContent = `${t.sign}${t.name}`;
+            tagsEl.appendChild(span);
+        }
+    }
     if (queueEl) {
         if (slot.queue && slot.queue.id) {
             const qAction = actions[slot.queue.id];

--- a/tests/test_action_queue.py
+++ b/tests/test_action_queue.py
@@ -13,6 +13,7 @@ def test_queue_slot_styles_defined():
     with open(os.path.join('css', 'styles.css')) as f:
         text = f.read()
     assert '.queue-slot' in text and '.slot-wrapper' in text
+    assert '.resource-tags' in text and '.resource-tag' in text
 
 
 def test_action_repeats_queues_and_resumes_at_max():

--- a/tests/test_slot_resource_tags.py
+++ b/tests/test_slot_resource_tags.py
@@ -1,0 +1,94 @@
+import json
+import subprocess
+
+
+def test_slot_renders_resource_tags():
+    script = r"""
+class Elem {
+    constructor(tag) {
+        this.tagName = tag;
+        this.children = [];
+        this.className = '';
+        this.style = {};
+        this.dataset = {};
+        this.textContent = '';
+        this.eventListeners = {};
+        this.classList = {
+            add: c => { if (!this.className.split(' ').includes(c)) this.className += (this.className ? ' ' : '') + c; },
+            remove: c => { this.className = this.className.split(' ').filter(x => x !== c).join(' '); },
+            toggle: (c, force) => {
+                if (force === undefined) force = !this.classList.contains(c);
+                if (force) this.classList.add(c); else this.classList.remove(c);
+            },
+            contains: c => this.className.split(' ').includes(c)
+        };
+    }
+    appendChild(ch) { this.children.push(ch); ch.parent = this; }
+    querySelector(sel) {
+        if (sel.startsWith('.')) {
+            const cls = sel.slice(1);
+            for (const ch of this.children) {
+                if (ch.className.split(' ').includes(cls)) return ch;
+                const q = ch.querySelector(sel);
+                if (q) return q;
+            }
+        } else {
+            const tag = sel.toLowerCase();
+            for (const ch of this.children) {
+                if (ch.tagName === tag) return ch;
+                const q = ch.querySelector(sel);
+                if (q) return q;
+            }
+        }
+        return null;
+    }
+}
+
+global.document = {
+    createElement: tag => new Elem(tag),
+    querySelector: sel => null
+};
+
+const { BaseSlot } = require('./js/slot.js');
+const slot = new BaseSlot();
+slot.el.dataset.slot = '0';
+const slots = new Elem('div');
+slots.id = 'slots';
+slots.appendChild(slot.el);
+
+document.querySelector = sel => {
+    if (sel === '#slots .slot[data-slot="0"]') return slot.el;
+    if (sel === '#slots .slot[data-queue="0"]') return null;
+    return null;
+};
+
+const { updateSlotUI } = require('./js/slotSetup.js');
+
+global.actions = {
+    work: {
+        name: 'Work',
+        level: 1,
+        progress: 0,
+        resourceCost: { gold: 1 },
+        resourceConsumption: { mana: 1 },
+        baseYield: { resources: { food: 2 } }
+    }
+};
+
+global.State = { slots: [{ actionId: 'work', progress: 0, blocked: false, text: '', queue: null }], defaultActionId: 'idle' };
+global.RARITY_CLASSES = ['common'];
+global.capitalize = s => s;
+global.getActionTier = () => 'common';
+global.Utils = { formatCost: () => '' };
+global.computeActionYield = a => a.baseYield || {};
+global.Lang = { ui: () => '', stat: s => s, resource: r => r };
+
+updateSlotUI(0);
+const tagsEl = slot.el.querySelector('.resource-tags');
+const texts = tagsEl.children.map(ch => ch.textContent);
+console.log(JSON.stringify(texts));
+"""
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout.strip())
+    assert data == ['-gold', '-mana', '+food']
+


### PR DESCRIPTION
## Summary
- show resource tags above action slot labels
- derive tags from costs, consumption, and yields
- document resource tags in changelog and tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893b32852188330bcbf738eccc3a7ef