### PR TITLE
Initialize stats/resources at zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Equipment system with equippable slots and prestige reset.
 - Emitted `prestige:updated` when prestige points are gained or reset.
 ### Changed
+- Stats and resources now initialize with zero value and zero capacity while prestige remains uncapped.
 - Resource buttons now display white text with labels before amounts, showing max/current and aligning amounts right.
 - Removed stats side panel and related UI initialization; main layout now uses two columns.
 - Tab order now lists Routines, Adventure, Belongings, then Character with updated icons.

--- a/data/resources.json
+++ b/data/resources.json
@@ -2,34 +2,34 @@
     "stats": {
         "strength": {
             "value": 0,
-            "baseMax": 50,
+            "baseMax": 0,
             "description": "Improves physical power."
         },
         "intelligence": {
             "value": 0,
-            "baseMax": 50,
+            "baseMax": 0,
             "description": "Powers mental acuity."
         },
         "dexterity": {
             "value": 0,
-            "baseMax": 50,
+            "baseMax": 0,
             "description": "Increases agility and precision."
         }
     },
     "resources": {
         "energy": {
-            "value": 10,
-            "baseMax": 10,
+            "value": 0,
+            "baseMax": 0,
             "description": "Spent to perform actions."
         },
         "focus": {
-            "value": 10,
-            "baseMax": 10,
+            "value": 0,
+            "baseMax": 0,
             "description": "Required for study and research."
         },
         "health": {
-            "value": 1,
-            "baseMax": 10,
+            "value": 0,
+            "baseMax": 0,
             "description": "Represents vitality."
         }
     },

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 
 
 def test_resources_structure():
@@ -9,17 +10,43 @@ def test_resources_structure():
     assert 'stats' in data
     assert 'resources' in data
     assert 'prestige' in data
-    for section in ['stats', 'resources', 'prestige']:
+
+    for section in ['stats', 'resources']:
         assert isinstance(data[section], dict)
         for entry in data[section].values():
-            assert 'value' in entry
-            assert isinstance(entry['value'], (int, float))
+            assert entry['value'] == 0
+            assert entry['baseMax'] == 0
             assert 'description' in entry
             assert isinstance(entry['description'], str)
-            if section != 'prestige':
-                assert 'baseMax' in entry
-                assert isinstance(entry['baseMax'], (int, float))
-                assert entry['baseMax'] >= entry['value']
+
+    assert isinstance(data['prestige'], dict)
+    for entry in data['prestige'].values():
+        assert 'value' in entry and entry['value'] == 0
+        assert 'description' in entry and isinstance(entry['description'], str)
+        assert 'baseMax' not in entry
+
+
+def test_prestige_resources_are_infinite():
+    script = r"""
+const fs = require('fs');
+global.Logger = { info: () => {}, error: () => {} };
+global.fetch = path => Promise.resolve({ ok: true, json: () => JSON.parse(fs.readFileSync(path, 'utf8')) });
+const { loadBaseData, State, StatSystem } = require('./js/state.js');
+loadBaseData().then(() => {
+  const out = {};
+  for (const [k, v] of Object.entries(State.prestige)) {
+    out[k] = { baseMax: String(v.baseMax), max: String(StatSystem.max(v)) };
+  }
+  console.log(JSON.stringify(out));
+});
+"""
+    result = subprocess.run(
+        ['node', '-e', script], capture_output=True, text=True, check=True
+    )
+    data = json.loads(result.stdout.strip())
+    for info in data.values():
+        assert info['baseMax'] == 'Infinity'
+        assert info['max'] == 'Infinity'
 
 
 def test_uk_translations_exist():


### PR DESCRIPTION
## Summary
- Set stats and basic resources to start with zero value and zero capacity; prestige remains uncapped
- Verify resource definitions and prestige caps via new tests
- Note initialization change in changelog

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_6893b67061ac8330996cf325c0480b28