### PR TITLE
Default stats and resources to max 10 and sum capacity multipliers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 - Equipment system with equippable slots and prestige reset.
 - Emitted `prestige:updated` when prestige points are gained or reset.
 ### Changed
-- Stats and resources now initialize with zero value and zero capacity while prestige remains uncapped.
+- Stats and resources now initialize with zero value and a base max of ten while prestige remains uncapped.
+- Max capacity modifiers are now summed and applied after additions, treating absent multipliers as zero.
 - Resource buttons now display white text with labels before amounts, showing max/current and aligning amounts right.
 - Removed stats side panel and related UI initialization; main layout now uses two columns.
 - Tab order now lists Routines, Adventure, Belongings, then Character with updated icons.

--- a/data/resources.json
+++ b/data/resources.json
@@ -2,34 +2,34 @@
     "stats": {
         "strength": {
             "value": 0,
-            "baseMax": 0,
+            "baseMax": 10,
             "description": "Improves physical power."
         },
         "intelligence": {
             "value": 0,
-            "baseMax": 0,
+            "baseMax": 10,
             "description": "Powers mental acuity."
         },
         "dexterity": {
             "value": 0,
-            "baseMax": 0,
+            "baseMax": 10,
             "description": "Increases agility and precision."
         }
     },
     "resources": {
         "energy": {
             "value": 0,
-            "baseMax": 0,
+            "baseMax": 10,
             "description": "Spent to perform actions."
         },
         "focus": {
             "value": 0,
-            "baseMax": 0,
+            "baseMax": 10,
             "description": "Required for study and research."
         },
         "health": {
             "value": 0,
-            "baseMax": 0,
+            "baseMax": 10,
             "description": "Represents vitality."
         }
     },

--- a/js/state.js
+++ b/js/state.js
@@ -19,20 +19,20 @@
 const VERSION = 2;
 
 const ResourceSystem = {
-    // baseMax is coerced to a number and defaults to 0
+    // baseMax is coerced to a number and defaults to 10
     create(value, baseMax) {
         return {
             value: value,
-            baseMax: Number(baseMax) || 0,
+            baseMax: Number(baseMax ?? 10),
             maxAdditions: [],
             maxMultipliers: []
         };
     },
     max(res) {
-        let m = Number(res.baseMax) || 0;
-        (res.maxAdditions || []).forEach(a => { m += a; });
-        (res.maxMultipliers || []).forEach(x => { m *= x; });
-        return m;
+        const base = Number(res.baseMax ?? 0);
+        const additions = (res.maxAdditions || []).reduce((s, a) => s + a, 0);
+        const mult = 1 + (res.maxMultipliers || [0]).reduce((s, x) => s + x, 0);
+        return (base + additions) * mult;
     },
     add(res, amt) {
         res.value = Math.min(res.value + amt, this.max(res));
@@ -45,20 +45,20 @@ const ResourceSystem = {
 };
 
 const StatSystem = {
-    // baseMax is coerced to a number and defaults to 0
+    // baseMax is coerced to a number and defaults to 10
     create(value, baseMax) {
         return {
             value: value,
-            baseMax: Number(baseMax) || 0,
+            baseMax: Number(baseMax ?? 10),
             maxAdditions: [],
             maxMultipliers: []
         };
     },
     max(stat) {
-        let m = Number(stat.baseMax) || 0;
-        (stat.maxAdditions || []).forEach(a => { m += a; });
-        (stat.maxMultipliers || []).forEach(x => { m *= x; });
-        return m;
+        const base = Number(stat.baseMax ?? 0);
+        const additions = (stat.maxAdditions || []).reduce((s, a) => s + a, 0);
+        const mult = 1 + (stat.maxMultipliers || [0]).reduce((s, x) => s + x, 0);
+        return (base + additions) * mult;
     },
     add(stat, amt) {
         stat.value = Math.min(stat.value + amt, this.max(stat));
@@ -81,10 +81,10 @@ function ensureResource(name, value, max) {
     const res = State.resources[name];
     if (!res || typeof res.value !== "number") {
         State.resources[name] = ResourceSystem.create(value, max);
-    } else {
-        if (!Array.isArray(res.maxAdditions)) res.maxAdditions = [];
-        if (!Array.isArray(res.maxMultipliers)) res.maxMultipliers = [];
     }
+    const r = State.resources[name];
+    if (!Array.isArray(r.maxAdditions)) r.maxAdditions = [];
+    if (!Array.isArray(r.maxMultipliers) || r.maxMultipliers.length === 0) r.maxMultipliers = [0];
 }
 
 function getStatValue(name) {
@@ -104,10 +104,10 @@ function ensureStat(name, value, max) {
     const stat = State.stats[name];
     if (!stat || typeof stat.value !== "number") {
         State.stats[name] = StatSystem.create(value, max);
-    } else {
-        if (!Array.isArray(stat.maxAdditions)) stat.maxAdditions = [];
-        if (!Array.isArray(stat.maxMultipliers)) stat.maxMultipliers = [];
     }
+    const s = State.stats[name];
+    if (!Array.isArray(s.maxAdditions)) s.maxAdditions = [];
+    if (!Array.isArray(s.maxMultipliers) || s.maxMultipliers.length === 0) s.maxMultipliers = [0];
 }
 
 function ensureMastery() {
@@ -116,7 +116,7 @@ function ensureMastery() {
         : 0;
     State.mastery = ResourceSystem.create(savedValue, Infinity);
     if (!Array.isArray(State.mastery.maxAdditions)) State.mastery.maxAdditions = [];
-    if (!Array.isArray(State.mastery.maxMultipliers)) State.mastery.maxMultipliers = [];
+    if (!Array.isArray(State.mastery.maxMultipliers) || State.mastery.maxMultipliers.length === 0) State.mastery.maxMultipliers = [0];
 }
 
 function _pathParts(path) {

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -15,7 +15,7 @@ def test_resources_structure():
         assert isinstance(data[section], dict)
         for entry in data[section].values():
             assert entry['value'] == 0
-            assert entry['baseMax'] == 0
+            assert entry['baseMax'] == 10
             assert 'description' in entry
             assert isinstance(entry['description'], str)
 

--- a/tests/test_state_resources.py
+++ b/tests/test_state_resources.py
@@ -26,15 +26,21 @@ def test_max_handles_missing_arrays():
     assert data['statMax'] == 7
 
 
-def test_missing_base_max_defaults_to_zero():
+def test_missing_base_max_defaults_to_ten_and_zero_multiplier_no_effect():
     script = textwrap.dedent(
         """
         const { ResourceSystem, StatSystem } = require('./js/state.js');
         const res = ResourceSystem.create(5);
         const stat = StatSystem.create(3);
+        const resMult = ResourceSystem.create(5);
+        resMult.maxMultipliers = [0];
+        const statMult = StatSystem.create(3);
+        statMult.maxMultipliers = [0];
         console.log(JSON.stringify({
             resMax: ResourceSystem.max(res),
-            statMax: StatSystem.max(stat)
+            statMax: StatSystem.max(stat),
+            resMultMax: ResourceSystem.max(resMult),
+            statMultMax: StatSystem.max(statMult)
         }));
         """
     )
@@ -45,6 +51,8 @@ def test_missing_base_max_defaults_to_zero():
         check=True,
     )
     data = json.loads(result.stdout.strip())
-    assert data['resMax'] == 0
-    assert data['statMax'] == 0
+    assert data['resMax'] == 10
+    assert data['statMax'] == 10
+    assert data['resMultMax'] == 10
+    assert data['statMultMax'] == 10
 


### PR DESCRIPTION
## Summary
- Give stats and resources a base max of 10 in resource data
- Default baseMax to 10 in ResourceSystem/StatSystem and sum multipliers after additions
- Ensure maxMultipliers arrays start with 0 and cover in tests

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893be75d03c8330b245e38bf7e1054d