### PR TITLE
Enhance resource tags with amounts and totals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Equipment system with equippable slots and prestige reset.
 - Emitted `prestige:updated` when prestige points are gained or reset.
 ### Changed
+- Resource tags now display +/- amounts and current/max values beneath action names.
 - Stats and resources now initialize with zero value and a base max of ten while prestige remains uncapped.
 - Max capacity modifiers are now summed and applied after additions, treating absent multipliers as zero.
 - Resource buttons now display white text with labels before amounts, showing max/current and aligning amounts right.

--- a/css/styles.css
+++ b/css/styles.css
@@ -395,17 +395,15 @@ main {
 }
 
 .slot .resource-tags {
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
     display: flex;
-    justify-content: center;
+    flex-direction: column;
     gap: 0.25rem;
     pointer-events: none;
 }
 
 .slot .resource-tag {
+    display: flex;
+    justify-content: space-between;
     background-color: rgba(0, 0, 0, 0.6);
     color: #fff;
     padding: 0 0.25rem;

--- a/js/slot.js
+++ b/js/slot.js
@@ -2,12 +2,12 @@ class BaseSlot {
     constructor(hasProgress = true) {
         this.el = document.createElement('div');
         this.el.className = 'slot';
-        this.resourceTags = document.createElement('div');
-        this.resourceTags.className = 'resource-tags';
-        this.el.appendChild(this.resourceTags);
         this.label = document.createElement('span');
         this.label.className = 'label';
         this.el.appendChild(this.label);
+        this.resourceTags = document.createElement('div');
+        this.resourceTags.className = 'resource-tags';
+        this.el.appendChild(this.resourceTags);
         if (hasProgress) {
             this.progressWrapper = document.createElement('div');
             this.progressWrapper.className = 'progress-wrapper';

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -247,33 +247,69 @@ function updateSlotUI(i) {
     slotEl.dataset.tooltip = buildActionTooltip(action);
     const tagsEl = slotEl.querySelector('.resource-tags');
     if (tagsEl) {
+        // Build tags for all costs, consumptions and yields
         tagsEl.innerHTML = '';
         const tags = [];
         if (action.resourceCost) {
             for (const r in action.resourceCost) {
+                const amt = action.resourceCost[r];
                 const name = typeof Lang !== 'undefined' && Lang.resource ? (Lang.resource(r) || r) : r;
-                tags.push({ sign: '-', name });
+                tags.push({ sign: '-', amount: amt, name, type: 'resource', key: r });
             }
         }
         if (action.resourceConsumption) {
             for (const r in action.resourceConsumption) {
+                const amt = action.resourceConsumption[r];
                 const name = typeof Lang !== 'undefined' && Lang.resource ? (Lang.resource(r) || r) : r;
-                tags.push({ sign: '-', name });
+                tags.push({ sign: '-', amount: amt, name, type: 'resource', key: r });
             }
         }
-        if (action.baseYield && action.baseYield.resources) {
-            for (const r in action.baseYield.resources) {
-                const val = action.baseYield.resources[r];
+        const yields = typeof computeActionYield === 'function' ? (computeActionYield(action) || {}) : (action.baseYield || {});
+        if (yields.resources) {
+            for (const r in yields.resources) {
+                const val = yields.resources[r];
                 const sign = val >= 0 ? '+' : '-';
                 const name = typeof Lang !== 'undefined' && Lang.resource ? (Lang.resource(r) || r) : r;
-                tags.push({ sign, name });
+                tags.push({ sign, amount: Math.abs(val), name, type: 'resource', key: r });
+            }
+        }
+        if (yields.stats) {
+            for (const s in yields.stats) {
+                const val = yields.stats[s];
+                const sign = val >= 0 ? '+' : '-';
+                const name = typeof Lang !== 'undefined' && Lang.stat ? (Lang.stat(s) || s) : s;
+                tags.push({ sign, amount: Math.abs(val), name, type: 'stat', key: s });
             }
         }
         for (const t of tags) {
-            const span = document.createElement('span');
-            span.className = 'resource-tag';
-            span.textContent = `${t.sign}${t.name}`;
-            tagsEl.appendChild(span);
+            const tag = document.createElement('div');
+            tag.className = 'resource-tag';
+            const left = document.createElement('span');
+            left.textContent = `${t.sign}${t.amount} ${t.name}`;
+            const right = document.createElement('span');
+            let current = 0;
+            let max = Infinity;
+            if (t.type === 'resource') {
+                const res = State.resources && State.resources[t.key];
+                if (res) {
+                    current = res.value;
+                    if (typeof ResourceSystem !== 'undefined' && ResourceSystem.max) {
+                        max = ResourceSystem.max(res);
+                    }
+                }
+            } else {
+                const stat = State.stats && State.stats[t.key];
+                if (stat) {
+                    current = stat.value;
+                    if (typeof StatSystem !== 'undefined' && StatSystem.max) {
+                        max = StatSystem.max(stat);
+                    }
+                }
+            }
+            right.textContent = max === Infinity ? `${current}` : `${current}/${max}`;
+            tag.appendChild(left);
+            tag.appendChild(right);
+            tagsEl.appendChild(tag);
         }
     }
     if (queueEl) {

--- a/tests/test_slot_resource_tags.py
+++ b/tests/test_slot_resource_tags.py
@@ -71,11 +71,24 @@ global.actions = {
         progress: 0,
         resourceCost: { gold: 1 },
         resourceConsumption: { mana: 1 },
-        baseYield: { resources: { food: 2 } }
+        baseYield: { resources: { food: 2 }, stats: { strength: 3 } }
     }
 };
 
-global.State = { slots: [{ actionId: 'work', progress: 0, blocked: false, text: '', queue: null }], defaultActionId: 'idle' };
+global.ResourceSystem = { max: r => r.baseMax };
+global.StatSystem = { max: s => s.baseMax };
+global.State = {
+    slots: [{ actionId: 'work', progress: 0, blocked: false, text: '', queue: null }],
+    defaultActionId: 'idle',
+    resources: {
+        gold: { value: 5, baseMax: 10 },
+        mana: { value: 3, baseMax: 5 },
+        food: { value: 7, baseMax: 15 }
+    },
+    stats: {
+        strength: { value: 8, baseMax: 20 }
+    }
+};
 global.RARITY_CLASSES = ['common'];
 global.capitalize = s => s;
 global.getActionTier = () => 'common';
@@ -85,10 +98,10 @@ global.Lang = { ui: () => '', stat: s => s, resource: r => r };
 
 updateSlotUI(0);
 const tagsEl = slot.el.querySelector('.resource-tags');
-const texts = tagsEl.children.map(ch => ch.textContent);
+const texts = tagsEl.children.map(ch => ch.children.map(c => c.textContent));
 console.log(JSON.stringify(texts));
 """
     result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
     data = json.loads(result.stdout.strip())
-    assert data == ['-gold', '-mana', '+food']
+    assert data == [['-1 gold', '5/10'], ['-1 mana', '3/5'], ['+2 food', '7/15'], ['+3 strength', '8/20']]
 


### PR DESCRIPTION
## Summary
- Render resource tags below slot labels and show +/- amounts with current/max values for resources and stats.
- Refactor `updateSlotUI` to compute cost, consumption, and yield tags including state values.
- Style resource tag lists as vertical columns with flex layouts and update tests accordingly.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893c189ed448330aef3aa9608c5ece8