### PR TITLE
Ensure equipment resets on prestige

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 - Default home now falls back to "Hut in the Woods" if the saved home is missing.
 
 ### Fixed
+- Equipped items now reset to empty slots after prestiging.
 - Mastery resource is rebuilt on load so saved values and modifiers persist.
 - Home slot now updates correctly after reloads and prestiges.
 - Action slots falling back to the Rest action now begin progress automatically.

--- a/js/save_system.js
+++ b/js/save_system.js
@@ -1,4 +1,21 @@
 // Handles save/load and prestige mechanics
+
+function defaultEquipment() {
+    // Returns a fresh equipment object with all slots empty.
+    return {
+        head: null,
+        armor: null,
+        leftHand: null,
+        rightHand: null,
+        pants: null,
+        boots: null,
+        gloves: null,
+        ring1: null,
+        ring2: null,
+        necklace: null
+    };
+}
+
 const SaveSystem = {
     save() {
         const actionData = {};
@@ -77,18 +94,7 @@ const SaveSystem = {
                 }
                 if (!State.equipment) {
                     // initialize equipment slots for older saves
-                    setState('equipment', {
-                        head: null,
-                        armor: null,
-                        leftHand: null,
-                        rightHand: null,
-                        pants: null,
-                        boots: null,
-                        gloves: null,
-                        ring1: null,
-                        ring2: null,
-                        necklace: null
-                    });
+                    setState('equipment', defaultEquipment());
                 }
                 if (State.banditsAmbushSeen === undefined) {
                     setState('banditsAmbushSeen', false);
@@ -175,18 +181,7 @@ const SaveSystem = {
 
         setState('inventory', {});
         // clear all equipped items
-        setState('equipment', {
-            head: null,
-            armor: null,
-            leftHand: null,
-            rightHand: null,
-            pants: null,
-            boots: null,
-            gloves: null,
-            ring1: null,
-            ring2: null,
-            necklace: null
-        });
+        setState('equipment', defaultEquipment());
         setState('homeId', null);
         setState('furniture', []);
         if (typeof PubSub !== 'undefined' && Array.isArray(FurnitureSystem.furniture)) {

--- a/tests/test_prestige_equipment_reset.py
+++ b/tests/test_prestige_equipment_reset.py
@@ -53,6 +53,20 @@ context.SaveSystem.prestige().then(() => {
   console.log(JSON.stringify(context.State.equipment));
 });
 """;
-    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    result = subprocess.run(
+        ['node', '-e', script], capture_output=True, text=True, check=True
+    )
     data = json.loads(result.stdout.strip())
-    assert all(v is None for v in data.values())
+    expected = {
+        'head': None,
+        'armor': None,
+        'leftHand': None,
+        'rightHand': None,
+        'pants': None,
+        'boots': None,
+        'gloves': None,
+        'ring1': None,
+        'ring2': None,
+        'necklace': None,
+    }
+    assert data == expected


### PR DESCRIPTION
## Summary
- centralize default equipment slots and clear them after prestiging
- test that SaveSystem.prestige removes all equipped items
- document helper and update changelog

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_6894f193add483309b2dd2129f95484d