### PR TITLE
Add test for Inventory.consume resource updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.67] - 2025-08-06
 ### Added
+- Test verifying inventory consumption updates resources and emits change events.
 - Converted mastery points into a resource and added descriptions for all stats, resources and prestige values.
 - Resources tab with expandable buttons showing resource modifiers.
 - Action slots now show resource tags for costs and yields.

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 
 
 def test_item_fields():
@@ -30,3 +31,48 @@ def test_consumable_restoration_values():
     assert rabbit['restore']['health'] > 1
     berries = next(i for i in data if i['id'] == 'berries')
     assert set(berries['restore'].keys()) == {'health', 'energy', 'focus'}
+
+
+def test_inventory_consume_updates_resources_and_events():
+    script = r"""
+const { ItemGenerator, Inventory } = require('./js/items.js');
+global.State = {
+    inventory: { berries: { quantity: 2 } },
+    resources: {
+        health: { value: 0 },
+        energy: { value: 0 },
+        focus: { value: 0 }
+    },
+    equipment: {}
+};
+global.updateState = function(path, fn) {
+    const [root, id, prop] = path;
+    if (root === 'inventory' && prop === 'quantity') {
+        State.inventory[id][prop] = fn(State.inventory[id][prop]);
+    }
+};
+global.deleteState = function(path) {
+    const [root, id] = path;
+    if (root === 'inventory') delete State.inventory[id];
+};
+global.ResourceSystem = {
+    add: (res, amt) => { res.value += amt; }
+};
+ItemGenerator.itemList = [
+    { id: 'berries', type: 'consumable', restore: { health: 1, energy: 1, focus: 1 } }
+];
+const events = [];
+global.PubSub = { publish: (event) => events.push(event) };
+
+Inventory.consume('berries');
+
+console.log(JSON.stringify({ inventory: State.inventory, resources: State.resources, events }));
+""";
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout.strip())
+    assert data['inventory']['berries']['quantity'] == 1
+    assert data['resources']['health']['value'] == 1
+    assert data['resources']['energy']['value'] == 1
+    assert data['resources']['focus']['value'] == 1
+    assert 'inventory:changed' in data['events']
+    assert 'resources:updated' in data['events']


### PR DESCRIPTION
## Summary
- add test to ensure consuming items updates resources and emits events
- document test addition in changelog

## Testing
- `pytest tests/test_items.py::test_inventory_consume_updates_resources_and_events -q`
- `pytest --cov -q`

------
https://chatgpt.com/codex/tasks/task_e_6894f195a39883308b0402ed08b83744