### PR TITLE
Add encounter log visibility toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.67] - 2025-08-06
 ### Added
+- Toggle to show or hide encounter notifications via `showEncounterLog`.
 - Test verifying inventory consumption updates resources and emits change events.
 - Converted mastery points into a resource and added descriptions for all stats, resources and prestige values.
 - Resources tab with expandable buttons showing resource modifiers.

--- a/index.html
+++ b/index.html
@@ -171,6 +171,7 @@
             <div id="log-section" class="collapsible-section">
                 <h2 class="section-header"><span class="arrow">&#9654;</span><span data-i18n="Log">Log</span></h2>
                 <div class="section-body">
+                    <label><input id="encounter-log-toggle" type="checkbox" checked> Show encounter notifications</label>
                     <div id="log-container" class="log-container">
                         <div id="log" class="log-view"></div>
                     </div>

--- a/js/adventure_engine.js
+++ b/js/adventure_engine.js
@@ -122,7 +122,7 @@ function retreat(resourceName, manual = false) {
     const resLabel = Lang.resource(resourceName) || resourceName;
     const msg = Lang.log('retreat', { encounter: enc, resource: resLabel }) ||
         `You had to retreat after ${enc} because you ran out of ${resLabel}.`;
-    Log.add(msg);
+    if (State.showEncounterLog) Log.add(msg);
     EncounterGenerator.decrementLevel();
     EncounterGenerator.resetProgress();
     AdventureEngine.cancel(manual);

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -236,7 +236,7 @@ const EncounterGenerator = {
         if (encounter.id === 'banditsAmbush') {
             const msg = Lang.log('banditsAmbushWin') ||
                 'You survived the bandits ambush and claimed your reward.';
-            Log.add(msg);
+            if (State.showEncounterLog) Log.add(msg);
             if (!State.banditsAmbushSeen) {
                 StorySystem.trigger('banditsAmbushVictory');
             }
@@ -249,7 +249,7 @@ const EncounterGenerator = {
                     const encHTML = `<span class="rarity-${encounter.rarity}"><b>${encounter.name}</b></span>`;
                     const msg = Lang.log('foundItem', { item: itemHTML, encounter: encHTML }) ||
                         `You found ${itemHTML} during ${encHTML}!`;
-                    Log.add(msg);
+                    if (State.showEncounterLog) Log.add(msg);
                     Inventory.add(item);
                 }
             }

--- a/js/main.js
+++ b/js/main.js
@@ -169,6 +169,14 @@ async function init() {
             SaveSystem.save();
         });
     }
+    const encounterLogToggle = document.getElementById('encounter-log-toggle');
+    if (encounterLogToggle) {
+        encounterLogToggle.checked = State.showEncounterLog;
+        encounterLogToggle.addEventListener('change', () => {
+            setState('showEncounterLog', encounterLogToggle.checked);
+            SaveSystem.save();
+        });
+    }
     document.getElementById('reset-btn').addEventListener('click', () => SaveSystem.reset());
     const prestigeBtn = document.getElementById('prestige-btn');
     if (prestigeBtn) {

--- a/js/state.js
+++ b/js/state.js
@@ -215,6 +215,7 @@ const State = {
     autoProgress: true,
     darkMode: true,
     language: 'en',
+    showEncounterLog: true,
     hideRarityEnabled: false,
     hideBelowRarity: 'rare',
     defaultActionId: DEFAULT_ACTION_ID,

--- a/tests/test_encounter_log_toggle.py
+++ b/tests/test_encounter_log_toggle.py
@@ -1,0 +1,28 @@
+import subprocess
+
+
+def test_encounter_log_toggle():
+    script = r"""
+const { EncounterGenerator } = require('./js/encounter.js');
+function run(show) {
+    global.State = { banditsAmbushSeen: true, showEncounterLog: show, resources: {} };
+    let count = 0;
+    global.Log = { add: () => { count++; } };
+    global.Lang = { log: () => null };
+    global.ItemGenerator = { itemList: [], generateFromEncounter: () => null };
+    global.Inventory = { add: () => {} };
+    global.ResourceSystem = { consume: () => {} };
+    global.PubSub = { publish: () => {} };
+    global.StorySystem = { trigger: () => {} };
+    const enc = { id: 'banditsAmbush', loot: {}, name: 'Bandits', getLootMultiplier: () => 1, getLootChance: () => 0, getResourceCost: () => ({}) };
+    EncounterGenerator.resolve(enc);
+    console.log(count);
+}
+run(true);
+run(false);
+"""
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    lines = result.stdout.strip().splitlines()
+    assert lines[0] == '1'
+    assert lines[1] == '0'
+


### PR DESCRIPTION
## Summary
- Add `showEncounterLog` state flag and UI checkbox to show or hide encounter notifications
- Guard encounter logging behind the new setting and persist changes
- Test that turning off notifications suppresses encounter log messages

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689509da305483308cd1e41049a951e3