### PR TITLE
Handle encounter resource depletion and tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Character equipment UI for managing equippable items.
 - Equipment system with equippable slots and prestige reset.
 - Emitted `prestige:updated` when prestige points are gained or reset.
+- Regression test ensuring encounters retreat when resources are insufficient.
 ### Changed
 - Encounter resources are now consumed at completion instead of per tick and resource updates are emitted on resolve.
 - Resource tags now display +/- amounts and current/max values beneath action names.
@@ -18,6 +19,8 @@
 - Removed stats side panel and related UI initialization; main layout now uses two columns.
 - Tab order now lists Routines, Adventure, Belongings, then Character with updated icons.
 - Character image now uses a single `div` with a background image and layout auto-sizing.
+- Adventure slots now display encounter resource costs with current and max values.
+- Encounters now retreat when required resources cannot be consumed and when health, energy, or focus reach zero.
 - Resources tab listens for `resources:updated`, `stats:updated`, and `prestige:updated` events.
 - Inventory tab renamed and character equipment UI now reacts to language changes.
 - Character art now renders in a dedicated Character tab element and updates only on equipment changes.

--- a/js/adventure_engine.js
+++ b/js/adventure_engine.js
@@ -129,8 +129,12 @@ function retreat(resourceName, manual = false) {
 }
 
 function checkHealth() {
-    if (State.resources.health.value < 0.1) {
-        retreat('health');
+    const names = ['health', 'energy', 'focus'];
+    for (const name of names) {
+        const res = State.resources && State.resources[name];
+        if (res && res.value <= 0) {
+            retreat(name);
+        }
     }
 }
 

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -258,7 +258,10 @@ const EncounterGenerator = {
         const cost = encounter.getResourceCost();
         for (const r in cost) {
             const amt = Math.random() * cost[r];
-            ResourceSystem.consume(State.resources[r], amt);
+            if (!ResourceSystem.consume(State.resources[r], amt)) {
+                if (typeof retreat === 'function') retreat(r);
+                break;
+            }
         }
         if (typeof PubSub !== 'undefined') {
             PubSub.publish('resources:updated');

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -385,10 +385,39 @@ function updateAdventureSlotUI(i) {
                 parts.push(...lines);
             }
         }
+        const tagsEl = slotEl.querySelector('.resource-tags');
+        if (tagsEl) {
+            tagsEl.innerHTML = '';
+            const cost = slot.encounter.getResourceCost ? slot.encounter.getResourceCost() :
+                (slot.encounter.resourceConsumption || {});
+            for (const r in cost) {
+                const tag = document.createElement('div');
+                tag.className = 'resource-tag';
+                const left = document.createElement('span');
+                const name = typeof Lang !== 'undefined' && Lang.resource ? (Lang.resource(r) || r) : r;
+                left.textContent = `-${cost[r]} ${name}`;
+                const right = document.createElement('span');
+                let current = 0;
+                let max = Infinity;
+                const res = State.resources && State.resources[r];
+                if (res) {
+                    current = res.value;
+                    if (typeof ResourceSystem !== 'undefined' && ResourceSystem.max) {
+                        max = ResourceSystem.max(res);
+                    }
+                }
+                right.textContent = max === Infinity ? `${current}` : `${current}/${max}`;
+                tag.appendChild(left);
+                tag.appendChild(right);
+                tagsEl.appendChild(tag);
+            }
+        }
         slotEl.dataset.tooltip = parts.join('\n');
     } else {
         labelEl.textContent = slot.text || '';
         slotEl.style.backgroundImage = 'none';
+        const tagsEl = slotEl.querySelector('.resource-tags');
+        if (tagsEl) tagsEl.innerHTML = '';
         slotEl.dataset.tooltip = '';
     }
     const actionEl = document.querySelector(`#slots .slot[data-slot="${i}"]`);

--- a/tests/test_encounter_retreat_unavailable_resources.py
+++ b/tests/test_encounter_retreat_unavailable_resources.py
@@ -1,0 +1,65 @@
+import json
+import subprocess
+
+
+def run_script():
+    script = r"""
+const { State, ResourceSystem } = require('./js/state.js');
+
+global.State = State;
+State.resources = {};
+State.resources.energy = ResourceSystem.create(5, 10);
+State.resources.health = ResourceSystem.create(20, 20);
+
+global.ItemGenerator = { itemList: [], generateFromEncounter: () => null };
+global.Inventory = { add: () => {} };
+global.Lang = { log: () => '', resource: () => '' };
+global.Log = { add: () => {} };
+global.StorySystem = { trigger: () => {} };
+const events = [];
+global.PubSub = { publish: ev => events.push(ev) };
+
+global.retreatCalls = [];
+global.retreat = r => retreatCalls.push(r);
+Math.random = () => 1;
+
+const { EncounterGenerator } = require('./js/encounter.js');
+
+const encounter = {
+    id: 'test',
+    loot: {},
+    category: 'strength',
+    getResourceCost() { return { energy: 10, health: 5 }; },
+    getLootMultiplier() { return 1; },
+    getLootChance() { return 0; }
+};
+
+const calls = [];
+const originalConsume = ResourceSystem.consume;
+ResourceSystem.consume = (res, amt) => {
+    const key = Object.keys(State.resources).find(k => State.resources[k] === res);
+    calls.push({ key, amt });
+    if (res.value < amt) return false;
+    res.value -= amt;
+    return true;
+};
+
+EncounterGenerator.resolve(encounter);
+
+console.log(JSON.stringify({
+    calls,
+    retreatCalls,
+    energy: State.resources.energy.value,
+    health: State.resources.health.value
+}));
+"""
+    proc = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    return json.loads(proc.stdout.strip())
+
+
+def test_encounter_retreats_when_resources_missing():
+    data = run_script()
+    assert data['retreatCalls'] == ['energy']
+    assert data['calls'] == [{'key': 'energy', 'amt': 10}]
+    assert data['energy'] == 5
+    assert data['health'] == 20


### PR DESCRIPTION
## Summary
- show resource cost tags for active adventure encounters
- retreat when encounters can't consume required resources and watch multiple resource types
- cover retreat behaviour with a regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689513d243d8833082f29aeef16e98e9