### PR TITLE
Track max encounter level and reset on adventure start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.67] - 2025-08-06
 ### Added
+- Encounter system now tracks the highest encounter level reached and resets to level 1 when an adventure begins.
 - Toggle to show or hide encounter notifications via `showEncounterLog`.
 - Test verifying inventory consumption updates resources and emits change events.
 - Converted mastery points into a resource and added descriptions for all stats, resources and prestige values.

--- a/js/adventure_engine.js
+++ b/js/adventure_engine.js
@@ -6,6 +6,14 @@ const AdventureEngine = {
     start() {
         if (this.active) return;
         this.active = true;
+        EncounterGenerator.level = 1;
+        setState('encounterLevel', 1);
+        if (typeof EncounterGenerator.updateName === 'function') {
+            EncounterGenerator.updateName();
+        }
+        if (typeof EncounterGenerator.updateProgressBar === 'function') {
+            EncounterGenerator.updateProgressBar();
+        }
         const actionSlot = State.slots[0];
         actionSlot.actionId = null;
         actionSlot.progress = 0;

--- a/js/encounter.js
+++ b/js/encounter.js
@@ -158,6 +158,9 @@ const EncounterGenerator = {
     incrementLevel() {
         this.level = AdventureManager.incrementLevel();
         setState('encounterLevel', this.level);
+        if (State.maxEncounterLevel === undefined || this.level > State.maxEncounterLevel) {
+            setState('maxEncounterLevel', this.level);
+        }
         this.updateName();
         this.updateProgressBar();
     },

--- a/js/save_system.js
+++ b/js/save_system.js
@@ -64,6 +64,9 @@ const SaveSystem = {
                 if (State.encounterLevel === undefined) {
                     setState('encounterLevel', 1);
                 }
+                if (State.maxEncounterLevel === undefined) {
+                    setState('maxEncounterLevel', State.encounterLevel || 1);
+                }
                 if (State.encounterStreak === undefined) {
                     setState('encounterStreak', 0);
                 }
@@ -198,6 +201,7 @@ const SaveSystem = {
         setState('adventureLevels', { forest: 1 });
         setState('adventureActive', false);
         setState('encounterLevel', 1);
+        setState('maxEncounterLevel', 1);
         setState('encounterStreak', 0);
         Object.entries(preserved).forEach(([id, data]) => {
             if (actions[id]) Object.assign(actions[id], data);

--- a/js/state.js
+++ b/js/state.js
@@ -208,6 +208,7 @@ const State = {
     mastery: ResourceSystem.create(0, Infinity),
     masteryDescription: 'Earned by advancing action tiers.',
     encounterLevel: 1,
+    maxEncounterLevel: 1,
     encounterStreak: 0,
     currentAdventure: 'forest',
     adventureLevels: { forest: 1 },

--- a/js/ui/encounter.js
+++ b/js/ui/encounter.js
@@ -17,7 +17,7 @@ const EncounterUI = {
         const name = milestone ? milestone.name : EncounterGenerator.milestones[0].name;
         const el = document.getElementById('encounter-location');
         if (el) {
-            el.textContent = `${name} (Level ${EncounterGenerator.level})`;
+            el.textContent = `${name} (Level ${EncounterGenerator.level} (Max ${State.maxEncounterLevel}))`;
         }
     },
     updateProgressBar() {

--- a/tests/test_encounter_level_reset.py
+++ b/tests/test_encounter_level_reset.py
@@ -1,0 +1,36 @@
+import subprocess
+
+
+def test_encounter_level_reset_and_max_persist():
+    script = r"""
+const state = require('./js/state.js');
+const { AdventureEngine } = require('./js/adventure_engine.js');
+const { EncounterGenerator } = require('./js/encounter.js');
+
+global.State = state.State;
+global.setState = state.setState;
+global.ResourceSystem = state.ResourceSystem;
+
+global.EncounterGenerator = EncounterGenerator;
+global.PubSub = { publish: () => {} };
+global.updateSlotUI = () => {};
+global.updateAdventureSlotUI = () => {};
+
+EncounterGenerator.randomEncounter = () => null;
+EncounterGenerator.populateSlots = () => {};
+
+EncounterGenerator.incrementLevel();
+EncounterGenerator.incrementLevel();
+console.log(State.encounterLevel);
+console.log(State.maxEncounterLevel);
+
+AdventureEngine.start();
+console.log(State.encounterLevel);
+console.log(State.maxEncounterLevel);
+"""
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    lines = result.stdout.strip().splitlines()
+    assert lines[0] == '3'
+    assert lines[1] == '3'
+    assert lines[2] == '1'
+    assert lines[3] == '3'


### PR DESCRIPTION
## Summary
- Track highest encounter level via `maxEncounterLevel` state
- Reset encounter level to 1 when starting an adventure
- Show current and max encounter levels in the UI and tests

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_689601ba1498833089670cc287af57c8