### PR TITLE
feat: add equippable gear grid to character tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.67] - 2025-08-06
 ### Added
+- Character tab now lists owned equipment with equip buttons.
 - Encounter system now tracks the highest encounter level reached and resets to level 1 when an adventure begins.
 - Toggle to show or hide encounter notifications via `showEncounterLog`.
 - Test verifying inventory consumption updates resources and emits change events.

--- a/index.html
+++ b/index.html
@@ -107,6 +107,12 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="tab-section" data-section="equipment" data-type="slots">
+                            <h2 data-i18n="Equipment">Equipment</h2>
+                            <div class="section-body">
+                                <div id="equipment-items" class="slots"></div>
+                            </div>
+                        </div>
                     </div>
                     <div class="tab-content hidden" data-tab="inventory">
                         <div class="tab-section" data-section="home" data-type="slots">

--- a/js/ui/character.js
+++ b/js/ui/character.js
@@ -4,8 +4,10 @@ const CharacterUI = {
     init() {
         this.leftContainer = document.getElementById('character-slots-left');
         this.rightContainer = document.getElementById('character-slots-right');
+        this.itemsContainer = document.getElementById('equipment-items');
         if (typeof PubSub !== 'undefined') {
             PubSub.subscribe('equipment:changed', (_, eq) => this.updateSlots(eq));
+            PubSub.subscribe('inventory:changed', () => this.updateItems());
             // rebuild the display when the interface language changes
             PubSub.subscribe('lang:changed', () => {
                 this.updateSlots();
@@ -13,6 +15,7 @@ const CharacterUI = {
             });
         }
         this.updateSlots(State.equipment);
+        this.updateItems();
     },
     updateSlots(equipped = State.equipment) {
         if (!this.leftContainer || !this.rightContainer) return;
@@ -49,6 +52,34 @@ const CharacterUI = {
         });
         rightSlots.forEach(slot => {
             this.rightContainer.appendChild(buildSlot(slot, equipped[slot]));
+        });
+    },
+    updateItems() {
+        if (!this.itemsContainer) return;
+        const items = Inventory.getItems()
+            .filter(it => it.type === 'equipment');
+        this.itemsContainer.innerHTML = '';
+        items.forEach(item => {
+            const slot = document.createElement('div');
+            slot.className = 'slot';
+            if (item.image) {
+                slot.style.backgroundImage = `url(${item.image})`;
+            } else {
+                slot.style.backgroundImage = 'none';
+            }
+            slot.classList.add(`rarity-${item.rarity}`);
+            const label = document.createElement('span');
+            label.className = 'label';
+            label.textContent = capitalize(item.name);
+            slot.appendChild(label);
+            const btn = document.createElement('button');
+            btn.textContent = Lang.ui('Equip') || 'Equip';
+            btn.addEventListener('click', (e) => {
+                if (e) e.stopPropagation();
+                Equipment.equip(item.id);
+            });
+            slot.appendChild(btn);
+            this.itemsContainer.appendChild(slot);
         });
     }
 };

--- a/tests/test_character_ui.py
+++ b/tests/test_character_ui.py
@@ -61,6 +61,8 @@ global.State = {
 };
 
 global.ItemGenerator = { itemList: [{ id:'stone_spear', type:'equipment', slot:'head', name:'stone spear', rarity:'common' }] };
+global.Inventory = { getItems: () => [] };
+global.PubSub = { subscribe: () => {}, publish: () => {} };
 global.Lang = { ui: k => k };
 global.capitalize = s => s;
 
@@ -78,4 +80,74 @@ console.log(JSON.stringify({ head: State.equipment.head }));
     result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
     data = json.loads(result.stdout.strip())
     assert data['head'] is None
+
+
+def test_equipment_appears_and_equips():
+    script = r"""
+class Elem {
+  constructor(tag) {
+    this.tagName = tag;
+    this.children = [];
+    this.className = '';
+    this.style = {};
+    this.dataset = {};
+    this.textContent = '';
+    this._innerHTML = '';
+    this.eventListeners = {};
+    this.classList = { add: () => {} };
+    Object.defineProperty(this, 'innerHTML', {
+      get: () => this._innerHTML,
+      set: v => { this._innerHTML = v; if (v === '') this.children = []; }
+    });
+  }
+  appendChild(child) { this.children.push(child); }
+  addEventListener(ev, fn) { this.eventListeners[ev] = fn; }
+  click() { if (this.eventListeners['click']) this.eventListeners['click'](); }
+}
+
+const elements = {
+  'character-slots-left': new Elem('div'),
+  'character-slots-right': new Elem('div'),
+  'equipment-items': new Elem('div'),
+  'character-image': new Elem('div')
+};
+
+global.document = {
+  getElementById(id){ return elements[id]; },
+  createElement(tag){ return new Elem(tag); }
+};
+
+global.State = {
+  equipment: { head:null, armor:null, leftHand:null, rightHand:null, pants:null, boots:null, gloves:null, ring1:null, ring2:null, necklace:null },
+  inventory: { stone_spear: { quantity: 1 } }
+};
+
+global.ItemGenerator = { itemList: [{ id:'stone_spear', type:'equipment', slot:'rightHand', name:'Stone Spear', rarity:'common' }] };
+global.Inventory = { getItems: () => [{ id:'stone_spear', type:'equipment', name:'Stone Spear', rarity:'common' }] };
+global.Lang = { ui: k => k };
+global.capitalize = s => s;
+
+global.PubSub = {
+  subs:{},
+  subscribe(ev, fn){ (this.subs[ev] = this.subs[ev] || []).push(fn); },
+  publish(ev, data){ (this.subs[ev] || []).forEach(fn => fn(ev, data)); }
+};
+
+const { Equipment } = require('./js/equipment.js');
+const { CharacterUI } = require('./js/ui/character.js');
+
+CharacterUI.init();
+
+const grid = elements['equipment-items'];
+const card = grid.children[0];
+const button = card.children.find(c => c.tagName === 'button');
+button.click();
+const slot = elements['character-slots-right'].children[1];
+console.log(JSON.stringify({ items: grid.children.length, equipped: State.equipment.rightHand, tooltip: slot.dataset.tooltip }));
+""";
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout.strip())
+    assert data['items'] == 1
+    assert data['equipped'] == 'stone_spear'
+    assert data['tooltip'] == 'Stone Spear'
 

--- a/tests/test_inventory_sections.py
+++ b/tests/test_inventory_sections.py
@@ -18,13 +18,11 @@ def test_inventory_has_heading_without_equipment():
     assert 'Equipment' not in text
 
 
-def test_index_has_no_equipment_section():
+def test_index_has_equipment_section():
     path = 'index.html'
     with open(path) as f:
         text = f.read()
-    assert 'equipment-heading' not in text
-    assert 'equipment-slots' not in text
-    assert 'equipment-items' not in text
+    assert 'equipment-items' in text
 
 
 def test_uk_translation_sections():


### PR DESCRIPTION
## Summary
- show equipment grid in character tab with equip buttons
- render inventory equipment and refresh on inventory changes
- test equipping items from character tab

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689607673d1c83309f48ca4046b08075