### PR TITLE
Feat: enlarge character image and update layout visuals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Emitted `prestige:updated` when prestige points are gained or reset.
 - Regression test ensuring encounters retreat when resources are insufficient.
 ### Changed
+- Enlarged character image to 240px and set 80px equipment slots for a balanced character layout.
+- Visual layout test now compares screenshot hashes to avoid storing binary baselines.
 - Encounter resources are now consumed at completion instead of per tick and resource updates are emitted on resolve.
 - Resource tags now display +/- amounts and current/max values beneath action names.
 - Stats and resources now initialize with zero value and a base max of ten while prestige remains uncapped.

--- a/css/styles.css
+++ b/css/styles.css
@@ -684,7 +684,7 @@ body.dark {
 
 .character-layout {
     display: grid;
-    grid-template-columns: 1fr auto 1fr;
+    grid-template-columns: 1fr 240px 1fr;
     gap: 1rem;
     align-items: center;
 }
@@ -694,10 +694,21 @@ body.dark {
     margin-top: 0;
 }
 
+.character-layout .slot {
+    width: 80px;
+    height: 80px;
+    border: 2px solid #ccc;
+    padding: 0.25rem;
+    flex: 0 0 auto;
+}
+
 .character-image {
-    width: 180px;
-    height: 180px;
     background-size: contain;
     background-position: center;
     background-repeat: no-repeat;
+}
+
+#character-image {
+    width: 240px;
+    height: 240px;
 }

--- a/tests/test_character_layout_visual.py
+++ b/tests/test_character_layout_visual.py
@@ -1,0 +1,40 @@
+import subprocess
+import os
+import hashlib
+
+BASE_URL = f"file://{os.path.abspath('index.html')}"
+
+
+def _capture(width, height, path):
+    subprocess.run([
+        'wkhtmltoimage',
+        '--enable-local-file-access',
+        '--width', str(width),
+        '--height', str(height),
+        '--format', 'png',
+        BASE_URL,
+        str(path)
+    ], check=True)
+
+
+def _hash(path):
+    sha = hashlib.sha256()
+    with open(path, 'rb') as f:
+        sha.update(f.read())
+    return sha.hexdigest()
+
+
+EXPECTED_DESKTOP = "a68e4ce1298595f115a0271da5fdf4fe3157258af16ebab1b81ae881da990477"
+EXPECTED_MOBILE = "30c175693870051d592602a78d1f5bd195c72597364a2ccd9193baed7de69d16"
+
+
+def test_character_layout_desktop(tmp_path):
+    new_file = tmp_path / 'desktop.png'
+    _capture(800, 400, new_file)
+    assert _hash(new_file) == EXPECTED_DESKTOP
+
+
+def test_character_layout_mobile(tmp_path):
+    new_file = tmp_path / 'mobile.png'
+    _capture(375, 600, new_file)
+    assert _hash(new_file) == EXPECTED_MOBILE


### PR DESCRIPTION
## Summary
- enlarge character portrait to 240px and fix equipment slot sizing
- grid center column widened for balanced layout
- add screenshot-based tests using hash comparison instead of binary baselines

## Testing
- `pip install -r requirements.txt`
- `apt-get install -y wkhtmltopdf`
- `wkhtmltoimage --version`
- `pytest tests/test_character_layout_visual.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68963f274e88833085a610f83bd3ccab