### PR TITLE
Refactor character tab background handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Character tab background now uses the section container; removed separate character-image element and updated CSS/JS.
 - Layout reworked: two-column main view; character image enlarged and centered; tabs reordered with new icons.
 - Resources and stats start at zero with base max ten; modifiers sum after additions; prestige and mastery remain uncapped.
 - Encounters consume resources on completion and queued actions wait for full recovery before resuming.

--- a/css/styles.css
+++ b/css/styles.css
@@ -687,6 +687,9 @@ body.dark {
     grid-template-columns: 1fr 240px 1fr;
     gap: 1rem;
     align-items: center;
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
 }
 
 .character-layout .slots {
@@ -702,13 +705,3 @@ body.dark {
     flex: 0 0 auto;
 }
 
-.character-image {
-    background-size: contain;
-    background-position: center;
-    background-repeat: no-repeat;
-}
-
-#character-image {
-    width: 240px;
-    height: 240px;
-}

--- a/index.html
+++ b/index.html
@@ -102,7 +102,6 @@
                             <div class="section-body">
                                 <div class="character-layout">
                                     <div id="character-slots-left" class="slots"></div>
-                                    <div id="character-image" class="character-image"></div>
                                     <div id="character-slots-right" class="slots"></div>
                                 </div>
                             </div>

--- a/js/ui/char_bg.js
+++ b/js/ui/char_bg.js
@@ -6,7 +6,7 @@ const CharacterBackground = {
     fullGearImage: 'assets/char/set+sword.png',
     container: null,
     init() {
-        this.container = document.getElementById('character-image');
+        this.container = document.querySelector('.tab-section[data-section="character"] .character-layout');
         if (!this.container) return;
         this.container.style.backgroundImage = `url(${this.baseImage})`;
         if (typeof PubSub !== 'undefined') {

--- a/tests/test_char_bg.py
+++ b/tests/test_char_bg.py
@@ -8,7 +8,7 @@ class Elem {
   constructor(){ this.style = {}; }
 }
 const elem = new Elem();
-global.document = { getElementById: () => elem };
+global.document = { querySelector: () => elem };
 global.PubSub = {
   events: {},
   subscribe(ev, fn){ this.events[ev] = fn; },

--- a/tests/test_character_ui.py
+++ b/tests/test_character_ui.py
@@ -47,8 +47,7 @@ class Elem {
 const elements = {
   'character-slots-left': new Elem('div'),
   'character-slots-right': new Elem('div'),
-  'equipment-items': new Elem('div'),
-  'character-image': new Elem('div')
+  'equipment-items': new Elem('div')
 };
 
 global.document = {
@@ -108,8 +107,7 @@ class Elem {
 const elements = {
   'character-slots-left': new Elem('div'),
   'character-slots-right': new Elem('div'),
-  'equipment-items': new Elem('div'),
-  'character-image': new Elem('div')
+  'equipment-items': new Elem('div')
 };
 
 global.document = {


### PR DESCRIPTION
## Summary
- remove redundant `character-image` element and apply background to character section container
- update CharacterBackground to target section layout via querySelector
- adjust styles and tests for new container

## Testing
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_689b8b76b96883309231be705be4adeb