### PR TITLE
Fix: stack character layout slots vertically on mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Encounters consume resources on completion and queued actions wait for full recovery before resuming.
 
 ### Fixed
+- Character layout slots stack vertically on small screens.
 - Equipped gear clears on prestige and character art updates from equipment.
 - Resource and stat max calculations handle missing modifiers and defaults.
 - Inventory and resource UIs refresh correctly and hide equipment items.

--- a/css/styles.css
+++ b/css/styles.css
@@ -592,6 +592,11 @@ li.unaffordable {
         grid-template-columns: repeat(3, 1fr);
         gap: 0.5rem;
     }
+    /* Stack character slots vertically on narrow screens */
+    .character-layout .slots {
+        display: flex;
+        flex-direction: column;
+    }
     #inventory-slots {
         grid-template-columns: repeat(3, 1fr);
     }


### PR DESCRIPTION
## Summary
- ensure character layout slots stack vertically on small screens
- note layout change in changelog

## Testing
- `pytest --cov`

------
https://chatgpt.com/codex/tasks/task_e_689c9e87d4948330bb3a5fcbf7a55aae