### PR TITLE
Fix: shrink character slots on small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Character slots shrink to 60px on small screens.
 - Character tab background now uses the section container; removed separate character-image element and updated CSS/JS.
 - Layout reworked: two-column main view; character image enlarged and centered; tabs reordered with new icons.
 - Resources and stats start at zero with base max ten; modifiers sum after additions; prestige and mastery remain uncapped.

--- a/css/styles.css
+++ b/css/styles.css
@@ -597,6 +597,10 @@ li.unaffordable {
         display: flex;
         flex-direction: column;
     }
+    .character-layout .slot {
+        width: 60px;
+        height: 60px;
+    }
     #inventory-slots {
         grid-template-columns: repeat(3, 1fr);
     }


### PR DESCRIPTION
## Summary
- Reduce character slot size to 60x60px on screens narrower than 700px
- Document responsive character slot sizing in changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689cc5842e0c8330b5364da4a7f96694