### PR TITLE
Add semi-transparent styling for equipment slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Equipment slots use a translucent background and semi-transparent opacity for equipped items.
 - Character slots shrink to 60px on small screens.
 - Character tab background now uses the section container; removed separate character-image element and updated CSS/JS.
 - Layout reworked: two-column main view; character image enlarged and centered; tabs reordered with new icons.

--- a/css/styles.css
+++ b/css/styles.css
@@ -709,7 +709,9 @@ body.dark {
 .character-layout .slot {
     width: 80px;
     height: 80px;
-    border: 2px solid #ccc;
+    border: 2px solid rgba(255, 255, 255, 0.9);
+    background-color: rgba(85, 85, 85, 0.5);
+    opacity: 0.8;
     padding: 0.25rem;
     flex: 0 0 auto;
 }


### PR DESCRIPTION
## Summary
- give character equipment slots a translucent background and semi-transparent appearance
- document slot style change in changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689e141263a88330a1fbf076217e25c5