### PR TITLE
Refine character tab background container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## [0.41.67] - 2025-08-06
+## [0.41.67] - 2025-08-14
 ### Added
 - Character tab with equipment management and consumable buttons.
 - Resources tab and action slots show costs, yields, and modifiers with expandable details.
@@ -12,6 +12,7 @@
 - Layout reworked: two-column main view; character image enlarged and centered; tabs reordered with new icons.
 - Resources and stats start at zero with base max ten; modifiers sum after additions; prestige and mastery remain uncapped.
 - Encounters consume resources on completion and queued actions wait for full recovery before resuming.
+- Fixed character background initialization and styling to apply background to the entire character tab section.
 
 ### Fixed
 - Character layout slots stack vertically on small screens.

--- a/css/styles.css
+++ b/css/styles.css
@@ -691,14 +691,17 @@ body.dark {
     color: var(--chip-color);
 }
 
+.tab-section[data-section="character"] {
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: contain;
+}
+
 .character-layout {
     display: grid;
     grid-template-columns: 1fr 240px 1fr;
     gap: 1rem;
     align-items: center;
-    background-repeat: no-repeat;
-    background-position: center;
-    background-size: contain;
 }
 
 .character-layout .slots {

--- a/js/ui/char_bg.js
+++ b/js/ui/char_bg.js
@@ -6,7 +6,7 @@ const CharacterBackground = {
     fullGearImage: 'assets/char/set+sword.png',
     container: null,
     init() {
-        this.container = document.querySelector('.tab-section[data-section="character"] .character-layout');
+        this.container = document.querySelector('.tab-section[data-section="character"]');
         if (!this.container) return;
         this.container.style.backgroundImage = `url(${this.baseImage})`;
         if (typeof PubSub !== 'undefined') {


### PR DESCRIPTION
## Summary
- Apply character background to the entire Character tab section
- Simplify `.character-layout` to grid responsibilities only
- Clarify changelog for character tab background styling

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e1415bc5083308bf426d4583eb58c