### PR TITLE
Fix character slot grid alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Equipped gear clears on prestige and character art updates from equipment.
 - Resource and stat max calculations handle missing modifiers and defaults.
 - Inventory and resource UIs refresh correctly and hide equipment items.
+- Character slot containers stay in correct left and right grid columns.
 ## [0.41.66] - 2025-07-14
 ### Changed
 - Research progress now persists through prestiges.

--- a/css/styles.css
+++ b/css/styles.css
@@ -714,3 +714,12 @@ body.dark {
     flex: 0 0 auto;
 }
 
+/* Position left and right character slots */
+#character-slots-left {
+    grid-column: 1;
+}
+
+#character-slots-right {
+    grid-column: 3;
+}
+

--- a/index.html
+++ b/index.html
@@ -102,6 +102,8 @@
                             <div class="section-body">
                                 <div class="character-layout">
                                     <div id="character-slots-left" class="slots"></div>
+                                    <!-- Spacer for middle grid column -->
+                                    <div></div>
                                     <div id="character-slots-right" class="slots"></div>
                                 </div>
                             </div>


### PR DESCRIPTION
## Summary
- assign character slot containers to their intended grid columns
- add spacer element for clearer three-column layout
- document character slot alignment fix in changelog

## Testing
- `pip install -r requirements.txt`
- `pytest --cov` *(fails: FileNotFoundError: wkhtmltoimage)*

------
https://chatgpt.com/codex/tasks/task_e_689e14190a448330baf3ee9be322fb65