### PR TITLE
Use spacing variables for tab sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Resources and stats start at zero with base max ten; modifiers sum after additions; prestige and mastery remain uncapped.
 - Encounters consume resources on completion and queued actions wait for full recovery before resuming.
 - Fixed character background initialization and styling to apply background to the entire character tab section.
+- Defined reusable spacing variables and applied them to tab headings and section bodies; removed hardcoded slot spacing.
 
 ### Fixed
 - Footer stays fixed at the bottom on small screens with padding preventing overlap.

--- a/css/styles.css
+++ b/css/styles.css
@@ -7,6 +7,8 @@
     --task-bg: #eee;
     --slot-bg: #333;
     --chip-color: #0066ff;
+    --space-sm: 0.5rem;
+    --space-md: 1rem;
 }
 
 body {
@@ -309,7 +311,6 @@ main {
 .slots {
     display: flex;
     gap: 1rem;
-    margin-top: 1rem;
 }
 
 .slot-wrapper {
@@ -566,6 +567,10 @@ li.unaffordable {
     display: none;
 }
 
+.tab-section h2 {
+    margin-block-start: var(--space-sm);
+}
+
 .section-headers {
     display: flex;
     gap: 0.5rem;
@@ -653,8 +658,12 @@ li.unaffordable {
     transform: rotate(0deg);
 }
 
+.section-body {
+    margin-block-start: var(--space-md);
+}
+
 .collapsible-section .section-body {
-    margin-top: 0.5rem;
+    margin-block-start: var(--space-sm);
 }
 
 .log-container {
@@ -714,7 +723,6 @@ body.dark {
 
 .character-layout .slots {
     flex-direction: column;
-    margin-top: 0;
 }
 
 .character-layout .slot {


### PR DESCRIPTION
## Summary
- define `--space-sm` and `--space-md` CSS variables
- apply spacing to tab headings and section bodies
- drop hardcoded slot margins

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a61a1992348330848c1ec8dc62400c