### PR TITLE
Enhance slot styling with transitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Resources and stats start at zero with base max ten; modifiers sum after additions; prestige and mastery remain uncapped.
 - Encounters consume resources on completion and queued actions wait for full recovery before resuming.
 - Fixed character background initialization and styling to apply background to the entire character tab section.
+- Slot elements now use CSS variables for borders and feature rounded corners, shadows, and hover transitions.
 
 ### Fixed
 - Footer stays fixed at the bottom on small screens with padding preventing overlap.

--- a/css/styles.css
+++ b/css/styles.css
@@ -6,6 +6,7 @@
     --header-text: #fff;
     --task-bg: #eee;
     --slot-bg: #333;
+    --slot-border: #ccc;
     --chip-color: #0066ff;
 }
 
@@ -377,7 +378,7 @@ main {
 
 .slot {
     flex: 1;
-    border: 4px solid #ccc;
+    border: 4px solid var(--slot-border);
     padding: 0.5rem;
     min-height: 5rem;
     position: relative;
@@ -388,10 +389,19 @@ main {
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .slot.active {
     border-color: #66cc66;
+}
+
+.slot:hover,
+.slot:focus {
+    transform: scale(1.02);
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
 }
 
 .slot .resource-tags {
@@ -692,6 +702,7 @@ body.dark {
     --header-text: #eee;
     --task-bg: #444;
     --slot-bg: #555;
+    --slot-border: #888;
     --chip-color: #3f8cff;
 }
 


### PR DESCRIPTION
## Summary
- add CSS variables for slot borders and style slots with rounded corners and shadows
- introduce hover and focus transitions for slot elements
- document slot styling improvements in changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a61a1b59208330946bceee1502b221