### PR TITLE
Fix mobile panel layout and footer overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixed character background initialization and styling to apply background to the entire character tab section.
 
 ### Fixed
+- Panels stack on small screens and the log panel avoids the fixed footer.
 - Footer stays fixed at the bottom on small screens with padding preventing overlap.
 - Character layout slots stack vertically on small screens.
 - Equipped gear clears on prestige and character art updates from equipment.

--- a/css/styles.css
+++ b/css/styles.css
@@ -194,6 +194,8 @@ main {
     padding: 1rem;
     border-radius: 4px;
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    width: 100%;
+    box-sizing: border-box;
 }
 
 #task-list {
@@ -607,6 +609,9 @@ li.unaffordable {
     #adventure-slots {
         display: flex;
         flex-direction: column;
+    }
+    .log-panel {
+        margin-bottom: 4rem;
     }
     /* Keep footer fixed on small screens */
     footer {


### PR DESCRIPTION
## Summary
- Ensure panels span full width with border-box sizing
- Prevent fixed footer from covering log panel on mobile
- Document mobile panel fix in changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a61a22081883308d4afd55ccfda6ee