### PR TITLE
Add theme variables and data-theme attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.67] - 2025-08-14
 ### Added
+- Theme variables and `[data-theme]` attribute enable light and dark themes.
 - Character tab with equipment management and consumable buttons.
 - Resources tab and action slots show costs, yields, and modifiers with expandable details.
 - Adventure system tracks max encounter level, toggles notifications, and retreats on resource depletion.

--- a/css/styles.css
+++ b/css/styles.css
@@ -7,10 +7,19 @@
     --task-bg: #eee;
     --slot-bg: #333;
     --chip-color: #0066ff;
+    --slot-border-color: #ccc;
+    --slot-border-active: #66cc66;
+    --slot-border-blocked: #cc6666;
+    --slot-hover-bg: #444;
+    --panel-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    --font-size-base: 16px;
+    --font-size-sm: 0.8rem;
+    --font-size-xs: 0.6rem;
 }
 
 body {
     font-family: Arial, sans-serif;
+    font-size: var(--font-size-base);
     margin: 0;
     background-color: var(--bg-color);
     color: var(--text-color);
@@ -193,7 +202,7 @@ main {
     background: var(--panel-bg);
     padding: 1rem;
     border-radius: 4px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    box-shadow: var(--panel-box-shadow);
 }
 
 #task-list {
@@ -377,7 +386,7 @@ main {
 
 .slot {
     flex: 1;
-    border: 4px solid #ccc;
+    border: 4px solid var(--slot-border-color);
     padding: 0.5rem;
     min-height: 5rem;
     position: relative;
@@ -390,8 +399,12 @@ main {
     background-repeat: no-repeat;
 }
 
+.slot:hover {
+    background-color: var(--slot-hover-bg);
+}
+
 .slot.active {
-    border-color: #66cc66;
+    border-color: var(--slot-border-active);
 }
 
 .slot .resource-tags {
@@ -408,7 +421,7 @@ main {
     color: #fff;
     padding: 0 0.25rem;
     border-radius: 3px;
-    font-size: 0.6rem;
+    font-size: var(--font-size-xs);
 }
 
 .progress-wrapper {
@@ -444,7 +457,7 @@ main {
     left: 0;
     right: 0;
     text-align: center;
-    font-size: 0.8rem;
+    font-size: var(--font-size-sm);
     pointer-events: none;
     color: #fff;
 }
@@ -455,7 +468,7 @@ main {
     left: 0;
     right: 0;
     text-align: center;
-    font-size: 0.8rem;
+    font-size: var(--font-size-sm);
     pointer-events: none;
     color: #fff;
 }
@@ -464,7 +477,7 @@ main {
     position: absolute;
     top: 2px;
     right: 2px;
-    font-size: 0.6rem;
+    font-size: var(--font-size-xs);
     padding: 0 2px;
     border: none;
     background: rgba(0, 0, 0, 0.5);
@@ -494,7 +507,7 @@ main {
 }
 
 .slot.blocked {
-    border-color: #cc6666;
+    border-color: var(--slot-border-blocked);
 }
 
 .queue-slot {
@@ -684,7 +697,7 @@ li.unaffordable {
 .log-entry .rarity-legendary { color: #e69138; font-weight: bold; }
 .log-entry .rarity-story { color: #f1c40f; font-weight: bold; }
 
-body.dark {
+body[data-theme="dark"] {
     --bg-color: #222;
     --panel-bg: #333;
     --text-color: #eee;
@@ -693,6 +706,9 @@ body.dark {
     --task-bg: #444;
     --slot-bg: #555;
     --chip-color: #3f8cff;
+    --slot-border-color: #888;
+    --slot-hover-bg: #666;
+    --panel-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
 }
 
 .tab-headers button[data-tab="chip"] {

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <title>Progress Realm Prototype</title>
     <link rel="stylesheet" href="css/styles.css">
 </head>
-<body class="dark">
+<body data-theme="dark">
     <header>
         <h1>Progress Realm</h1>
         <div id="header-info">

--- a/js/story_core.js
+++ b/js/story_core.js
@@ -1,6 +1,6 @@
 // Misc story-related helpers
 function applyDarkMode() {
-    document.body.classList.toggle('dark', State.darkMode);
+    document.body.dataset.theme = State.darkMode ? 'dark' : 'light';
     const chk = document.getElementById('dark-mode-toggle');
     if (chk) chk.checked = State.darkMode;
 }
@@ -23,5 +23,9 @@ function openInventoryFilter() {
 
 function closeInventoryFilter() {
     PubSub.publish('modal:close', 'inventory-filter-modal');
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { applyDarkMode, openSettings, closeSettings, openInventoryFilter, closeInventoryFilter };
 }
 

--- a/tests/test_theme_attribute.py
+++ b/tests/test_theme_attribute.py
@@ -1,0 +1,31 @@
+import json
+import subprocess
+
+
+def test_index_has_data_theme():
+    with open('index.html') as f:
+        text = f.read()
+    assert 'data-theme' in text
+
+
+def test_apply_dark_mode_sets_dataset():
+    script = r"""
+class Body { constructor() { this.dataset = {}; } }
+const toggle = { checked: false };
+global.document = { body: new Body(), getElementById: id => toggle };
+global.State = { darkMode: true };
+const { applyDarkMode } = require('./js/story_core.js');
+applyDarkMode();
+const first = { theme: document.body.dataset.theme, checked: toggle.checked };
+State.darkMode = false;
+applyDarkMode();
+const second = { theme: document.body.dataset.theme, checked: toggle.checked };
+console.log(JSON.stringify({ first, second }));
+"""
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    data = json.loads(result.stdout.strip())
+    assert data['first']['theme'] == 'dark'
+    assert data['first']['checked'] is True
+    assert data['second']['theme'] == 'light'
+    assert data['second']['checked'] is False
+


### PR DESCRIPTION
## Summary
- add CSS variables for slot borders, hover colors, box shadows, and font sizes
- expose a body `[data-theme]` attribute and hook applyDarkMode to toggle it
- test theme attribute and dark mode toggling

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: AssertionError for character layout visual hash)*

------
https://chatgpt.com/codex/tasks/task_e_68a61a2564cc83308bab2bef96aca813