### PR TITLE
Simplify body layout for footer alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Simplified body layout to three rows so the main section fills remaining height and the footer stays at the bottom.
 - Header, footer, and various components now rely on spacing utilities.
 - Switched margin and positioning to logical `*-inline-*` properties for RTL support.
 - Added `left`/`right` fallbacks for footer and modal to support engines lacking logical property support.

--- a/css/styles.css
+++ b/css/styles.css
@@ -40,7 +40,7 @@ body {
     background-color: var(--bg-color);
     color: var(--text-color);
     display: grid;
-    grid-template-rows: auto auto 1fr auto;
+    grid-template-rows: auto 1fr auto;
     height: 100vh;
 }
 


### PR DESCRIPTION
## Summary
- simplify body grid to three rows so main area grows and footer anchors to bottom
- document layout adjustment in changelog

## Testing
- `pytest` *(fails: FileNotFoundError and assertion errors)*
- `python -m playwright install chromium` *(fails: Download failed: server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b998c1e80483309c6294e2a46b990a