### PR TITLE
Fix character slot layout spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Character layout uses flexbox with left and right slot containers and no spacer div.
 
 ### Fixed
+- Removed duplicate gap declaration in character layout and added flex to slot containers for symmetrical columns.
 - Panels stack on small screens and the log panel avoids the fixed footer.
 - Footer stays fixed at the bottom on small screens with padding preventing overlap.
 - Character layout slots stack vertically on small screens.

--- a/css/styles.css
+++ b/css/styles.css
@@ -824,7 +824,12 @@ body[data-theme="dark"] {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: 1rem;
+}
+
+/* Equalize column widths for left and right slot groups */
+#character-slots-left,
+#character-slots-right {
+    flex: 1;
 }
 
 .character-layout .slots {


### PR DESCRIPTION
## Summary
- remove duplicate gap declaration from character layout and rely on spacing variable
- give left and right character slot containers flex: 1 for symmetric columns
- document layout adjustment in changelog

## Testing
- `pytest` *(fails: wkhtmltoimage missing, expand arrow margin-inline-start assertion, data-theme attribute missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b998cd20088330aed5b27ad844cf8e