### PR TITLE
Fix: use logical margin for delta alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Replaced `margin-left` with `margin-inline-start` in `.delta` rule for proper LTR and RTL alignment.
 - Header, footer, and various components now rely on spacing utilities.
 - Switched margin and positioning to logical `*-inline-*` properties for RTL support.
 - Added `left`/`right` fallbacks for footer and modal to support engines lacking logical property support.

--- a/css/styles.css
+++ b/css/styles.css
@@ -679,7 +679,8 @@ li.unaffordable {
 .delta {
     color: #666;
     font-size: 0.8rem;
-    margin-left: var(--space-xs);
+    /* Use logical margin to support LTR and RTL layouts */
+    margin-inline-start: var(--space-xs);
 }
 
 @media (max-width: 700px) {


### PR DESCRIPTION
## Summary
- replace `.delta` margin-left with margin-inline-start for directional spacing
- note CSS update in changelog

## Testing
- `pytest` *(fails: test_character_layout_desktop, test_character_layout_mobile, test_expand_arrow_margin_inline_start, test_index_has_data_theme)*

------
https://chatgpt.com/codex/tasks/task_e_68b998d9ff0883309a4e36450af66b15