### PR TITLE
Use data-theme attribute for dark mode initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Replaced `dark` class on `<body>` with `data-theme` attribute and ensured dark mode toggling via `applyDarkMode`.
 - Header, footer, and various components now rely on spacing utilities.
 - Switched margin and positioning to logical `*-inline-*` properties for RTL support.
 - Added `left`/`right` fallbacks for footer and modal to support engines lacking logical property support.

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="css/base.css">
     <link rel="stylesheet" href="css/styles.css">
 </head>
-<body class="dark m-0">
+<body class="m-0" data-theme="dark">
     <header class="py-sm px-md">
         <h1 class="m-0">Progress Realm</h1>
         <div id="header-info">


### PR DESCRIPTION
## Summary
- Replace `dark` class with `data-theme="dark"` on `<body>`.
- Note dark mode attribute change in changelog.

## Testing
- `pytest --cov` *(fails: test_character_layout_desktop, test_character_layout_mobile, test_expand_arrow_margin_inline_start)*

------
https://chatgpt.com/codex/tasks/task_e_68b998e335048330a944198ce1657c5d