### PR TITLE
Ensure hidden class loads early via base stylesheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Moved `.hidden` utility to the base stylesheet for earlier loading.
+- Updated `.expand-arrow` to use `margin-inline-start` with a `margin-left` fallback.
 - Replaced `dark` class on `<body>` with `data-theme` attribute and ensured dark mode toggling via `applyDarkMode`.
 - Replaced `margin-left` with `margin-inline-start` in `.delta` rule for proper LTR and RTL alignment.
 - Simplified body layout to three rows so the main section fills remaining height and the footer stays at the bottom.

--- a/css/base.css
+++ b/css/base.css
@@ -36,3 +36,8 @@ h1, h2, h3, h4, h5, h6 {
 .p-md { padding: var(--space-md) !important; }
 .px-md { padding-left: var(--space-md) !important; padding-right: var(--space-md) !important; }
 .py-sm { padding-top: var(--space-sm) !important; padding-bottom: var(--space-sm) !important; }
+
+/* Utility class to hide elements before full styles load */
+.hidden {
+    display: none !important;
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -203,10 +203,6 @@ span {
     background-color: #ff4d4d;
 }
 
-.hidden {
-    display: none !important;
-}
-
 .modal {
     position: fixed;
     top: 0;
@@ -616,6 +612,7 @@ li.unaffordable {
 
 .expand-arrow {
     cursor: pointer;
+    margin-inline-start: var(--space-xs);
     margin-left: var(--space-xs);
 }
 


### PR DESCRIPTION
## Summary
- Move `.hidden` utility from `styles.css` to `base.css` so hidden elements render correctly before full styles load
- Use `margin-inline-start` with fallback in `.expand-arrow` for RTL safety
- Verified tab panes default to `tab-content hidden`

## Testing
- `pytest` *(fails: character layout visual hash mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68b9c021057c8330b302df45c3c8cbc3