### PR TITLE
Fix slot border duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Character layout uses flexbox with left and right slot containers and no spacer div.
 
 ### Fixed
+- Removed duplicate border declaration in slot styling.
 - Removed duplicate gap declaration in character layout and added flex to slot containers for symmetrical columns.
 - Panels stack on small screens and the log panel avoids the fixed footer.
 - Footer stays fixed at the bottom on small screens with padding preventing overlap.

--- a/css/styles.css
+++ b/css/styles.css
@@ -443,10 +443,10 @@ main {
     margin-top: var(--space-sm);
 }
 
+/* Slot container styling */
 .slot {
     flex: 1;
     padding: var(--space-sm);
-    border: 4px solid var(--slot-border-color);
     border: 4px solid var(--slot-border);
     min-height: 5rem;
     position: relative;


### PR DESCRIPTION
## Summary
- remove duplicate border declaration in slot styling
- document the fix in the changelog

## Testing
- `pytest` (fails: test_character_layout_desktop, test_character_layout_mobile, test_expand_arrow_margin_inline_start)

------
https://chatgpt.com/codex/tasks/task_e_68b9c026bfb88330a0efe41c495c9979