### PR TITLE
Fix slot theming for dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Character layout uses flexbox with left and right slot containers and no spacer div.
 
 ### Fixed
+- Character slots respect theme variables and dark mode defines hover and active state colors.
 - Removed duplicate border declaration in slot styling.
 - Removed duplicate gap declaration in character layout and added flex to slot containers for symmetrical columns.
 - Panels stack on small screens and the log panel avoids the fixed footer.

--- a/css/styles.css
+++ b/css/styles.css
@@ -803,6 +803,8 @@ body[data-theme="dark"] {
     --slot-border: #888;
     --chip-color: #3f8cff;
     --slot-border-color: #888;
+    --slot-border-active: #66cc66;
+    --slot-border-blocked: #cc6666;
     --slot-hover-bg: #666;
     --panel-box-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
 }
@@ -838,8 +840,8 @@ body[data-theme="dark"] {
 .character-layout .slot {
     width: 80px;
     height: 80px;
-    border: 2px solid rgba(255, 255, 255, 0.9);
-    background-color: rgba(85, 85, 85, 0.5);
+    border: 2px solid var(--slot-border-color);
+    background-color: var(--slot-bg);
     opacity: 0.8;
     padding: var(--space-xs);
     flex: 0 0 auto;

--- a/tests/test_character_layout_visual.py
+++ b/tests/test_character_layout_visual.py
@@ -24,8 +24,8 @@ def _hash(path):
     return sha.hexdigest()
 
 # Baseline screenshot hashes; update only when layout changes
-EXPECTED_DESKTOP = "5fe94d001644e61b62a3bc76769e8e2e138a684e2a68e4f63b8f9656ef5dbc39"
-EXPECTED_MOBILE = "d42594ddb21525eef2bc5747d5cdf7e83d32dd635a0e0e125dcf80f92d7652d2"
+EXPECTED_DESKTOP = "ec9d88d2816403a555a930c2846b82323985f9ec61d0f29b010ff30774477c2b"
+EXPECTED_MOBILE = "c95be88172c26083fc2b9c025a7970970e4ff9cfe8ca968bcd2e1ffcf7b4e114"
 
 
 def test_character_layout_desktop(tmp_path):

--- a/tests/test_slot_theme.py
+++ b/tests/test_slot_theme.py
@@ -1,0 +1,21 @@
+import re
+
+
+def test_character_layout_slot_uses_variables():
+    with open('css/styles.css') as f:
+        css = f.read()
+    matches = re.findall(r"\.character-layout\s+\.slot\s*\{[^}]+\}", css, re.MULTILINE)
+    block = next((m for m in matches if 'border' in m), None)
+    assert block is not None
+    assert 'border: 2px solid var(--slot-border-color);' in block
+    assert 'background-color: var(--slot-bg);' in block
+
+
+def test_dark_theme_defines_slot_state_vars():
+    with open('css/styles.css') as f:
+        css = f.read()
+    match = re.search(r"body\[data-theme=\"dark\"\]\s*\{[^}]+\}", css, re.MULTILINE)
+    assert match is not None
+    block = match.group()
+    assert '--slot-border-active:' in block
+    assert '--slot-border-blocked:' in block


### PR DESCRIPTION
## Summary
- use theme variables for character slot border and background
- define dark mode slot active and blocked colors
- add tests and update visual baselines for slot theming

## Testing
- `pip install -r requirements.txt`
- `pip install pytest pytest-cov`
- `apt-get install -y wkhtmltopdf`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_68b9e2a456fc8330adcb5a95363c93fc