### PR TITLE
Add left sidebar and three-column layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.41.67] - 2025-09-04
 ### Added
+- Dedicated left panel for prestige and mastery information.
 - Base stylesheet with shared variables, spacing utilities, and typography rules.
 - Theme variables and `[data-theme]` attribute enable light and dark themes.
 - Character tab with equipment management and consumable buttons.
@@ -9,6 +10,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Main layout now uses a three-column grid.
 - Character slot containers explicitly use flex column layout with equal widths across viewports.
 - Moved `.hidden` utility to the base stylesheet for earlier loading.
 - Updated `.expand-arrow` to use `margin-inline-start` with a `margin-left` fallback.

--- a/css/styles.css
+++ b/css/styles.css
@@ -243,7 +243,7 @@ span {
 
 main {
     display: grid;
-    grid-template-columns: 2fr minmax(180px, 1fr);
+    grid-template-columns: minmax(180px, 1fr) 2fr minmax(180px, 1fr);
     gap: var(--space-md);
     padding: var(--space-md);
     padding-bottom: calc(var(--space-md) * 3);

--- a/index.html
+++ b/index.html
@@ -64,6 +64,20 @@
     </div>
 
     <main id="app">
+        <div id="left" class="panel">
+            <div id="prestige-block">
+                <h2 class="section-heading" data-i18n="Prestige">Prestige</h2>
+                <ul>
+                    <li><span class="prestige-label" data-key="constitution">Constitution</span>: <span id="prestige-constitution">0</span> <span id="prestige-constitution-gain" class="delta"></span></li>
+                    <li><span class="prestige-label" data-key="wisdom">Wisdom</span>: <span id="prestige-wisdom">0</span> <span id="prestige-wisdom-gain" class="delta"></span></li>
+                    <li><span class="prestige-label" data-key="reflexes">Reflexes</span>: <span id="prestige-reflexes">0</span> <span id="prestige-reflexes-gain" class="delta"></span></li>
+                </ul>
+            </div>
+            <div id="mastery">
+                <h2 class="section-heading" data-i18n="Mastery">Mastery</h2>
+                <p><span data-i18n="Points">Points</span>: <span id="mastery-points">0</span></p>
+            </div>
+        </div>
         <div id="center" class="panel">
             <div class="tabs">
                 <div id="tab-contents">

--- a/js/main.js
+++ b/js/main.js
@@ -6,6 +6,7 @@ let actions = {};
 
 function updateUI() {
     PrestigeUI.update();
+    MasteryUI.update();
     document.getElementById('age-years').textContent = State.age.years;
     document.getElementById('age-days').textContent = Math.floor(State.age.days);
     document.getElementById('max-age').textContent = State.age.max;
@@ -74,6 +75,7 @@ async function init() {
     SoftCapSystem.recalculateCaps(State.inventory);
     await UIHandler.init();
     PrestigeUI.init();
+    MasteryUI.init();
     InventoryUI.init();
     HomeUI.init();
     FurnitureUI.init();

--- a/tests/test_character_layout_visual.py
+++ b/tests/test_character_layout_visual.py
@@ -24,8 +24,8 @@ def _hash(path):
     return sha.hexdigest()
 
 # Baseline screenshot hashes; update only when layout changes
-EXPECTED_DESKTOP = "5fe94d001644e61b62a3bc76769e8e2e138a684e2a68e4f63b8f9656ef5dbc39"
-EXPECTED_MOBILE = "d42594ddb21525eef2bc5747d5cdf7e83d32dd635a0e0e125dcf80f92d7652d2"
+EXPECTED_DESKTOP = "192f40d1503a21a2d277185a92f1cb68d4a7f6c4e2b163f78acc8a2fe1edb180"
+EXPECTED_MOBILE = "172207dc7642c41470ba437cab837cfdb69dfbfd5e10dd503cb7681ac22014e6"
 
 
 def test_character_layout_desktop(tmp_path):

--- a/tests/test_layout_panels.py
+++ b/tests/test_layout_panels.py
@@ -1,0 +1,15 @@
+import os
+
+
+def test_left_panel_present():
+    path = os.path.join('index.html')
+    with open(path) as f:
+        html = f.read()
+    assert '<div id="left"' in html
+
+
+def test_three_column_grid():
+    path = os.path.join('css', 'styles.css')
+    with open(path) as f:
+        css = f.read()
+    assert 'grid-template-columns: minmax(180px, 1fr) 2fr minmax(180px, 1fr);' in css


### PR DESCRIPTION
## Summary
- add dedicated left panel with mastery and prestige sections
- expand main grid to three columns and hook up left panel updates
- refresh layout tests and add checks for new panel

## Testing
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_68b9e2a4b7e0833095f653c247e7b5ff