### PR TITLE
Fix: expand character layout width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Character layout container now spans full width and slot groups anchor to edges.
 - Main layout now uses a three-column grid.
 - Character slot containers explicitly use flex column layout with equal widths across viewports.
 - Moved `.hidden` utility to the base stylesheet for earlier loading.

--- a/css/styles.css
+++ b/css/styles.css
@@ -824,6 +824,7 @@ body[data-theme="dark"] {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    width: 100%;
 }
 
 /* Equalize column widths for left and right slot groups */


### PR DESCRIPTION
## Summary
- Ensure character layout flex container spans full width
- Keep left and right character slots flexed so they stick to edges

## Testing
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb1351737883308d6faf56bb5916a6