### PR TITLE
Fix CSS stats block closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## [0.41.67] - 2025-09-04
+## [0.41.67] - 2025-09-05
 ### Added
 - Dedicated left panel for prestige and mastery information.
 - Base stylesheet with shared variables, spacing utilities, and typography rules.
@@ -34,6 +34,7 @@
 - Character layout uses flexbox with left and right slot containers and no spacer div.
 
 ### Fixed
+- Fixed missing closing brace in `#stats` rule so the global typography comment is outside the selector.
 - Character slots respect theme variables and dark mode defines hover and active state colors.
 - Removed duplicate border declaration in slot styling.
 - Removed duplicate gap declaration in character layout and added flex to slot containers for symmetrical columns.

--- a/css/styles.css
+++ b/css/styles.css
@@ -72,7 +72,8 @@ footer {
 
 #stats {
     color: white;
-  
+}
+
 /* Global typography */
 h2 {
     font-size: var(--font-h2);


### PR DESCRIPTION
## Summary
- close `#stats` CSS rule so global typography comment is outside the block
- update changelog for the fix

## Testing
- `pytest` *(fails: FileNotFoundError: No such file or directory: 'wkhtmltoimage')*

------
https://chatgpt.com/codex/tasks/task_e_68bb135231d4833098619fd285ac98de