### PR TITLE
Refine mobile slot grid layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - Character layout uses flexbox with left and right slot containers and no spacer div.
 
 ### Fixed
+- Equipment items retain grid layout on small screens.
 - Character slots respect theme variables and dark mode defines hover and active state colors.
 - Removed duplicate border declaration in slot styling.
 - Removed duplicate gap declaration in character layout and added flex to slot containers for symmetrical columns.

--- a/css/styles.css
+++ b/css/styles.css
@@ -684,7 +684,8 @@ li.unaffordable {
     main {
         grid-template-columns: 1fr;
     }
-    .tab-content:not([data-tab="character"]) .slots {
+    /* Use a grid for slot groups on small screens; character layout overrides below */
+    .tab-content .slots {
         display: grid;
         grid-template-columns: repeat(3, 1fr);
         gap: var(--space-sm);


### PR DESCRIPTION
## Summary
- ensure all slot groups use a grid on small screens while character slots stay vertical
- document equipment grid fix in changelog

## Testing
- `pytest`
- `pytest --cov`


------
https://chatgpt.com/codex/tasks/task_e_68bb199186348330a93dba6b44717c5f