### PR TITLE
Style: simplify section heading appearance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Section headings no longer use background boxes and now show a pointer cursor for interactivity.
 - Moved mobile `@media (max-width: 700px)` block to the end of the stylesheet to ensure styles override correctly.
 - Character layout container now spans full width and slot groups anchor to edges.
 - Main layout now uses a three-column grid.

--- a/css/styles.css
+++ b/css/styles.css
@@ -101,11 +101,9 @@ span {
 #mastery h2,
 #resources h2,
 .section-heading {
-    background-color: var(--heading-bg);
     display: inline-block;
-    padding: var(--heading-padding);
-    border-radius: var(--heading-radius);
     margin-bottom: var(--heading-margin-bottom);
+    cursor: pointer; /* indicate clickability */
 }
 
 #stats {


### PR DESCRIPTION
## Summary
- Remove background and padding from section headings for cleaner look
- Add pointer cursor to indicate clickable headers
- Document change in changelog

## Testing
- `pytest` (fails: 2 tests)
- `pytest --cov` (fails: 2 tests, 92% coverage)


------
https://chatgpt.com/codex/tasks/task_e_68c339f2e6188330a8bd07bd0d8ef0de