### PR TITLE
Remove prestige and mastery summary panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Removed the Prestige and Mastery summary widgets from the center panel and deleted the supporting UI code, styles, and tests.
 - Removed left panel and switched main layout to a two-column grid with a wider center column.
 - Section headings no longer use background boxes and now show a pointer cursor for interactivity.
 - Moved mobile `@media (max-width: 700px)` block to the end of the stylesheet to ensure styles override correctly.

--- a/css/styles.css
+++ b/css/styles.css
@@ -98,7 +98,6 @@ span {
 /* Utility heading style */
 #stats h2,
 #stats h3,
-#mastery h2,
 #resources h2,
 .section-heading {
     display: inline-block;
@@ -111,24 +110,17 @@ span {
     color: white;
 }
 
-#stats-list,
-#prestige-block ul {
+#stats-list {
     list-style: none;
     padding: 0;
     margin: var(--space-sm) 0;
 }
 
-#stats-list li,
-#prestige-block li {
+#stats-list li {
     margin: var(--space-xs) 0;
 }
 
-#prestige-block {
-    display: none;
-}
-
-#stats-list li span,
-#prestige-block li span {
+#stats-list li span {
     background-color: rgba(0, 0, 0, 0.6);
     padding: calc(var(--space-xs) / 2) var(--space-sm);
     border-radius: 4px;
@@ -136,17 +128,14 @@ span {
     color: white;
 }
 
-#stats-list li,
-#prestige-block li {
+#stats-list li {
     color: white;
 }
 
-#mastery,
 #resources {
     color: white;
 }
 
-#mastery h2,
 #resources h2 {
     background-color: rgba(0, 0, 0, 0.6);
     display: inline-block;
@@ -155,7 +144,6 @@ span {
     margin-bottom: var(--space-sm);
 }
 
-#mastery span,
 #resources-list span {
     background-color: rgba(0, 0, 0, 0.6);
     padding: calc(var(--space-xs) / 2) var(--space-sm);

--- a/docs/refactoring_task.md
+++ b/docs/refactoring_task.md
@@ -9,7 +9,7 @@ This document outlines the steps required to modularize the JavaScript code for 
 
 ## Planned Modules
 1. **state.js** – defines the `State` object and initialization helpers.
-2. **ui.js** – handles `StatsUI`, `ResourcesUI`, `MasteryUI`, and logging.
+2. **ui.js** – handles `StatsUI`, `ResourcesUI`, and logging.
 3. **ui_handler.js** – builds stat, resource, and tab sections from JSON before handing control to the UI modules.
 4. **actions.js** – manages action loading and experience scaling.
 5. **engine.js** – contains the main game loop and tick handlers.

--- a/index.html
+++ b/index.html
@@ -65,18 +65,6 @@
 
     <main id="app">
         <div id="center" class="panel">
-            <div id="prestige-block">
-                <h2 class="section-heading" data-i18n="Prestige">Prestige</h2>
-                <ul>
-                    <li><span class="prestige-label" data-key="constitution">Constitution</span>: <span id="prestige-constitution">0</span> <span id="prestige-constitution-gain" class="delta"></span></li>
-                    <li><span class="prestige-label" data-key="wisdom">Wisdom</span>: <span id="prestige-wisdom">0</span> <span id="prestige-wisdom-gain" class="delta"></span></li>
-                    <li><span class="prestige-label" data-key="reflexes">Reflexes</span>: <span id="prestige-reflexes">0</span> <span id="prestige-reflexes-gain" class="delta"></span></li>
-                </ul>
-            </div>
-            <div id="mastery">
-                <h2 class="section-heading" data-i18n="Mastery">Mastery</h2>
-                <p><span data-i18n="Points">Points</span>: <span id="mastery-points">0</span></p>
-            </div>
             <div class="tabs">
                 <div id="tab-contents">
                     <div class="tab-content" data-tab="resources">

--- a/js/main.js
+++ b/js/main.js
@@ -5,8 +5,6 @@ const TICKS_PER_SECOND = 1000 / LOGIC_TICK_MS;
 let actions = {};
 
 function updateUI() {
-    PrestigeUI.update();
-    MasteryUI.update();
     document.getElementById('age-years').textContent = State.age.years;
     document.getElementById('age-days').textContent = Math.floor(State.age.days);
     document.getElementById('max-age').textContent = State.age.max;
@@ -74,8 +72,6 @@ async function init() {
     Lang.applyToLocations(EncounterGenerator.milestones);
     SoftCapSystem.recalculateCaps(State.inventory);
     await UIHandler.init();
-    PrestigeUI.init();
-    MasteryUI.init();
     InventoryUI.init();
     HomeUI.init();
     FurnitureUI.init();
@@ -151,7 +147,6 @@ async function init() {
             Lang.applyToLocations(EncounterGenerator.milestones);
             Lang.translateUI();
             TabContainer.translate();
-            PrestigeUI.translate();
             updateTaskList();
             for (let i = 0; i < State.slotCount; i++) updateSlotUI(i);
             for (let i = 0; i < State.adventureSlotCount; i++) updateAdventureSlotUI(i);

--- a/js/ui.js
+++ b/js/ui.js
@@ -32,38 +32,6 @@ const StatsUI = {
     }
 };
 
-const PrestigeUI = {
-    list: [],
-    init() {
-        this.list = PRESTIGE_KEYS;
-        this.container = document.getElementById('prestige-block');
-        this.translate();
-        this.update();
-    },
-    translate() {
-        document.querySelectorAll('#prestige-block .prestige-label').forEach(el => {
-            const key = el.dataset.key;
-            // Try resource translation first, then stat translation
-            el.textContent = Lang.resource(key) || Lang.stat(key) || capitalize(key);
-        });
-    },
-    update() {
-        if (!this.container) return;
-        let show = false;
-        this.list.forEach(key => {
-            const val = State.prestige[key] ? State.prestige[key].value : 0;
-            const stat = Object.keys(PRESTIGE_MAP).find(k => PRESTIGE_MAP[k] === key);
-            const gain = stat ? Math.floor(Math.log10(State.stats[stat].value + 1)) : 0;
-            const el = document.getElementById(`prestige-${key}`);
-            const gainEl = document.getElementById(`prestige-${key}-gain`);
-            if (el) el.textContent = val;
-            if (gainEl) gainEl.textContent = `(+${gain})`;
-            if (val > 0) show = true;
-        });
-        this.container.style.display = show ? 'block' : 'none';
-    }
-};
-
 const ResourcesUI = {
     list: [],
     init() {
@@ -88,17 +56,6 @@ const ResourcesUI = {
             }
             document.getElementById(`res-${key}-delta`).textContent = formatDelta(resourceDeltas[key]);
         });
-    }
-};
-
-const MasteryUI = {
-    init() {
-        const el = document.getElementById('mastery-points');
-        if (el) el.textContent = State.mastery.value;
-    },
-    update() {
-        const el = document.getElementById('mastery-points');
-        if (el) el.textContent = State.mastery.value;
     }
 };
 

--- a/tests/test_prestige.py
+++ b/tests/test_prestige.py
@@ -31,12 +31,17 @@ def test_prestige_bonus_applied():
     assert 'applyPrestigeBonuses()' in text
 
 
-def test_prestige_ui_defined():
+def test_prestige_summary_removed():
     path = os.path.join('js', 'ui.js')
     with open(path) as f:
         text = f.read()
-    assert 'PrestigeUI' in text
-    assert 'prestige-block' in text
+    assert 'PrestigeUI' not in text
+    assert 'mastery-points' not in text
+
+    with open('index.html') as f:
+        html = f.read()
+    assert 'prestige-block' not in html
+    assert 'id="mastery-points"' not in html
 
 
 def test_adventure_defaults_present():


### PR DESCRIPTION
## Summary
- remove the prestige and mastery summary sections from the center panel markup
- delete the unused prestige/mastery UI helpers, styles, and adjust documentation and tests

## Testing
- pytest *(fails: `wkhtmltoimage` not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8625cb78483309736c53a6fa33a57