### PR TITLE
Normalize numeric formatting to three decimals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Normalized stat, resource, and tooltip numbers to use a shared `formatNumber` helper with three-decimal precision.
 - Enlarged active slot labels and positioned resource cost tags beneath them for improved readability.
 - Removed the Prestige and Mastery summary widgets from the center panel and deleted the supporting UI code, styles, and tests.
 - Removed left panel and switched main layout to a two-column grid with a wider center column.

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -12,14 +12,14 @@ function buildActionTooltip(action) {
         if (yields.stats) {
             for (const [stat, val] of Object.entries(yields.stats)) {
                 const name = Lang.stat(stat) || capitalize(stat);
-                effects.push(`+${val.toFixed(2)} ${name}`);
+                effects.push(`+${formatNumber(val)} ${name}`);
             }
         }
         if (yields.resources) {
             for (const [res, val] of Object.entries(yields.resources)) {
                 const name = Lang.resource(res) || capitalize(res);
                 const sign = val >= 0 ? '+' : '';
-                effects.push(`${sign}${val.toFixed(2)} ${name}`);
+                effects.push(`${sign}${formatNumber(val)} ${name}`);
             }
         }
     }
@@ -365,7 +365,7 @@ function updateAdventureSlotUI(i) {
                 const item = ItemGenerator.itemList.find(i => i.id === id);
                 const name = item ? item.name : id;
                 const pct = chance * (weight / total) * 100;
-                return `${name}: ${pct.toFixed(1)}%`;
+                return `${name}: ${formatNumber(pct)}%`;
             });
             if (lines.length) {
                 parts.push((Lang.ui('Drop Chances') || 'Drop chances') + ':');

--- a/js/ui.js
+++ b/js/ui.js
@@ -21,12 +21,12 @@ const StatsUI = {
             if (li && key !== 'strength' && key !== 'intelligence') {
                 li.style.display = value > 0 ? '' : 'none';
             }
-            document.getElementById(`stat-${key}`).textContent = value.toFixed(1);
+            document.getElementById(`stat-${key}`).textContent = formatNumber(value);
             const capEl = document.getElementById(`stat-${key}-cap`);
             const cap = SoftCapSystem.statCaps[key] !== undefined
                 ? SoftCapSystem.statCaps[key]
                 : getStatMax(key);
-            if (capEl) capEl.textContent = cap.toFixed(1);
+            if (capEl) capEl.textContent = formatNumber(cap);
             document.getElementById(`stat-${key}-delta`).textContent = formatDelta(statDeltas[key]);
         });
     }

--- a/js/ui/home.js
+++ b/js/ui/home.js
@@ -136,8 +136,8 @@ const HomeUI = {
             if (furn) {
                 const ratio = Math.max(data.durability, 0) / furn.durability;
                 slot.setProgress(ratio,
-                    `${data.durability.toFixed(1)}/${furn.durability}`);
-                slot.setTooltip(`${furn.description}\nDurability: ${data.durability.toFixed(1)}/${furn.durability}`);
+                    `${formatNumber(data.durability)}/${furn.durability}`);
+                slot.setTooltip(`${furn.description}\nDurability: ${formatNumber(data.durability)}/${furn.durability}`);
             }
         });
     }

--- a/js/utils.js
+++ b/js/utils.js
@@ -45,15 +45,24 @@ function capitalize(str) {
 }
 
 /**
- * Format a delta value with sign and one decimal place.
+ * Format a number with three decimal places.
+ * @param {number|string} value
+ * @returns {string}
+ */
+function formatNumber(value) {
+    return Number(value).toFixed(3);
+}
+
+/**
+ * Format a delta value with sign and three decimal places.
  * @param {number} v
  * @returns {string}
  */
 function formatDelta(v) {
     const sign = v > 0 ? '+' : '';
-    return sign + v.toFixed(1);
+    return sign + formatNumber(v);
 }
 
 if (typeof module !== 'undefined') {
-    module.exports = { Utils, capitalize, formatDelta };
+    module.exports = { Utils, capitalize, formatNumber, formatDelta };
 }

--- a/tests/test_slot_resource_tags.py
+++ b/tests/test_slot_resource_tags.py
@@ -49,6 +49,9 @@ global.document = {
     querySelector: sel => null
 };
 
+const { formatNumber } = require('./js/utils.js');
+global.formatNumber = formatNumber;
+
 const { BaseSlot } = require('./js/slot.js');
 const slot = new BaseSlot();
 slot.el.dataset.slot = '0';


### PR DESCRIPTION
## Summary
- add a shared `formatNumber` helper that renders values with three decimal places
- update UI modules and tooltips to rely on the helper instead of inlined `toFixed` calls
- load the helper in slot resource tag tests and document the formatting change in the changelog

## Testing
- pytest *(fails: wkhtmltoimage missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c86def2e5883309ff929a234a393f7