### PR TITLE
Adjust tab section list spacing

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -647,6 +647,11 @@ li.unaffordable {
     flex-wrap: wrap;
     gap: 0.5rem;
 }
+.tab-section ul {
+    margin: 0;
+    padding-left: 0;
+    list-style: none;
+}
 
 .tab-section.hidden {
     display: none;


### PR DESCRIPTION
## Summary
- add a list reset rule for tab sections so resource and action lists align with their borders

## Testing
- pytest *(fails: wkhtmltoimage is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8755ac64c8330947569939c9b453b