### PR TITLE
Format resource and encounter numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Resource and encounter displays now format all values with the shared `formatNumber` helper for consistency.
 - Normalized stat, resource, and tooltip numbers to use a shared `formatNumber` helper with three-decimal precision.
 - Enlarged active slot labels and positioned resource cost tags beneath them for improved readability.
 - Removed the Prestige and Mastery summary widgets from the center panel and deleted the supporting UI code, styles, and tests.

--- a/js/ui/encounter.js
+++ b/js/ui/encounter.js
@@ -1,3 +1,16 @@
+if (typeof formatNumber === 'undefined' && typeof require !== 'undefined') {
+    const utils = require('../utils');
+    if (utils && typeof utils.formatNumber === 'function') {
+        if (typeof globalThis !== 'undefined') {
+            globalThis.formatNumber = utils.formatNumber;
+        } else if (typeof window !== 'undefined') {
+            window.formatNumber = utils.formatNumber;
+        } else if (typeof global !== 'undefined') {
+            global.formatNumber = utils.formatNumber;
+        }
+    }
+}
+
 const EncounterUI = {
     init() {
         if (typeof PubSub !== 'undefined') {
@@ -17,7 +30,9 @@ const EncounterUI = {
         const name = milestone ? milestone.name : EncounterGenerator.milestones[0].name;
         const el = document.getElementById('encounter-location');
         if (el) {
-            el.textContent = `${name} (Level ${EncounterGenerator.level} (Max ${State.maxEncounterLevel}))`;
+            const currentLevel = formatNumber(EncounterGenerator.level);
+            const maxLevel = formatNumber(State.maxEncounterLevel);
+            el.textContent = `${name} (Level ${currentLevel} (Max ${maxLevel}))`;
         }
     },
     updateProgressBar() {

--- a/js/ui/resources_tab.js
+++ b/js/ui/resources_tab.js
@@ -1,3 +1,16 @@
+if (typeof formatNumber === 'undefined' && typeof require !== 'undefined') {
+    const utils = require('../utils');
+    if (utils && typeof utils.formatNumber === 'function') {
+        if (typeof globalThis !== 'undefined') {
+            globalThis.formatNumber = utils.formatNumber;
+        } else if (typeof window !== 'undefined') {
+            window.formatNumber = utils.formatNumber;
+        } else if (typeof global !== 'undefined') {
+            global.formatNumber = utils.formatNumber;
+        }
+    }
+}
+
 const ResourcesTab = {
     container: null,
     entries: {},
@@ -65,7 +78,9 @@ const ResourcesTab = {
         } else {
             max = ResourceSystem.max(res);
         }
-        amt.textContent = max !== Infinity ? `${res.value}/${max}` : `${res.value}`;
+        amt.textContent = max !== Infinity
+            ? `${formatNumber(res.value)}/${formatNumber(max)}`
+            : `${formatNumber(res.value)}`;
         btn.appendChild(label);
         btn.appendChild(amt);
         li.appendChild(btn);
@@ -95,12 +110,12 @@ const ResourcesTab = {
         list.innerHTML = '';
         (res.maxAdditions || []).forEach(a => {
             const li = document.createElement('li');
-            li.textContent = `+${a}`;
+            li.textContent = `+${formatNumber(a)}`;
             list.appendChild(li);
         });
         (res.maxMultipliers || []).forEach(m => {
             const li = document.createElement('li');
-            li.textContent = `×${m}`;
+            li.textContent = `×${formatNumber(m)}`;
             list.appendChild(li);
         });
     },
@@ -120,7 +135,9 @@ const ResourcesTab = {
             return;
         }
         const max = (group === 'stats' || group === 'prestige') ? StatSystem.max(res) : ResourceSystem.max(res);
-        this.entries[name].amount.textContent = max !== Infinity ? `${res.value}/${max}` : `${res.value}`;
+        this.entries[name].amount.textContent = max !== Infinity
+            ? `${formatNumber(res.value)}/${formatNumber(max)}`
+            : `${formatNumber(res.value)}`;
         this._renderMods(name, res);
     }
 };

--- a/tests/test_resources_tab_ui.py
+++ b/tests/test_resources_tab_ui.py
@@ -79,10 +79,10 @@ console.log(JSON.stringify(out));
 """
     result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
     out = json.loads(result.stdout.strip())
-    assert out['strength']['amount'] == '1/10'
-    assert out['energy']['amount'] == '5/10'
-    assert out['wisdom']['amount'] == '2'
-    assert out['mastery']['amount'] == '3'
+    assert out['strength']['amount'] == '1.000/10.000'
+    assert out['energy']['amount'] == '5.000/10.000'
+    assert out['wisdom']['amount'] == '2.000'
+    assert out['mastery']['amount'] == '3.000'
     assert out['strength']['desc'] == 'Power'
     assert out['energy']['desc'] == 'Use'
     assert out['wisdom']['desc'] == 'Bonus'
@@ -155,4 +155,4 @@ console.log(JSON.stringify({ energy: ResourcesTab.entries['energy'].amount.textC
 """
     result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
     data = json.loads(result.stdout.strip())
-    assert data['energy'] == '7/10'
+    assert data['energy'] == '7.000/10.000'


### PR DESCRIPTION
## Summary
- format resource tab amounts and modifiers with the shared `formatNumber` helper and ensure the helper is available when running under Node
- update the encounter location label to show formatted levels
- document the UI change and refresh resource tab UI tests for the new formatting

## Testing
- `pytest` *(fails: `wkhtmltoimage` missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c87d8143fc8330b1553685d7314e81