### PR TITLE
Adjust tab section layout to avoid horizontal shifts

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -644,8 +644,7 @@ li.unaffordable {
 .tab-section {
     width: 100%;
     display: flex;
-    flex-wrap: wrap;
-    gap: 0.5rem;
+    flex-direction: column;
 }
 .tab-section ul {
     margin: 0;
@@ -757,7 +756,7 @@ li.unaffordable {
 }
 
 .section-body {
-    margin-block-start: var(--space-md);
+    margin-block-start: 0;
 }
 
 .collapsible-section .section-body {


### PR DESCRIPTION
## Summary
- orient tab sections vertically by default to prevent horizontal shifting
- remove extra spacing above section bodies so content aligns with headings

## Testing
- pytest *(fails: wkhtmltoimage executable not available in environment)*
- pytest --cov *(fails: pytest: error: unrecognized arguments: --cov)*

------
https://chatgpt.com/codex/tasks/task_e_68c87d8e78348330aa98692a397d637d