### PR TITLE
Ensure tab sections stretch section bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Character layout container now spans full width and slot groups anchor to edges.
 - Character slot containers explicitly use flex column layout with equal widths across viewports.
 - Scoped mobile grid layout to inventory slots so character slots remain vertical.
+- Tab sections keep stretched bodies so lists and slot grids reach panel edges on desktop and mobile.
 - Moved `.hidden` utility to the base stylesheet for earlier loading.
 - Updated `.expand-arrow` to use `margin-inline-start` with a `margin-left` fallback.
 - Replaced `dark` class on `<body>` with `data-theme` attribute and ensured dark mode toggling via `applyDarkMode`.

--- a/css/styles.css
+++ b/css/styles.css
@@ -646,6 +646,7 @@ li.unaffordable {
     display: flex;
     flex-wrap: wrap;
     gap: 0.5rem;
+    align-items: stretch;
 }
 .tab-section ul {
     margin: 0;
@@ -758,6 +759,8 @@ li.unaffordable {
 
 .section-body {
     margin-block-start: var(--space-md);
+    flex: 1;
+    width: 100%;
 }
 
 .collapsible-section .section-body {


### PR DESCRIPTION
## Summary
- extend tab sections with explicit `align-items: stretch` so their contents fill available width
- let collapsible section bodies flex to the full panel width across viewports
- document the tab body stretch update in the changelog

## Testing
- pytest *(fails: requires `wkhtmltoimage` for visual snapshot tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c87d9035088330a84bc9ef1c1f6161