### PR TITLE
Format resource tags with three-decimal precision

### DIFF
--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -42,6 +42,20 @@ function actionLabel(action) {
     return `${action.name} Lv.${action.level}`;
 }
 
+function formatTagValue(value) {
+    const numeric = Number(value);
+    if (typeof formatNumber === 'function' && Number.isFinite(numeric)) {
+        return formatNumber(numeric);
+    }
+    if (value === Infinity || numeric === Infinity) {
+        return '∞';
+    }
+    if (value === -Infinity || numeric === -Infinity) {
+        return '-∞';
+    }
+    return `${value}`;
+}
+
 function assignActionToSlot(actionId) {
     let index = State.slots.findIndex(s => !s.actionId);
     if (index === -1) {
@@ -285,7 +299,7 @@ function updateSlotUI(i) {
             const tag = document.createElement('div');
             tag.className = 'resource-tag';
             const left = document.createElement('span');
-            left.textContent = `${t.sign}${t.amount} ${t.name}`;
+            left.textContent = `${t.sign}${formatTagValue(t.amount)} ${t.name}`;
             const right = document.createElement('span');
             let current = 0;
             let max = Infinity;
@@ -306,7 +320,11 @@ function updateSlotUI(i) {
                     }
                 }
             }
-            right.textContent = max === Infinity ? `${current}` : `${current}/${max}`;
+            const formattedCurrent = formatTagValue(current);
+            const formattedMax = formatTagValue(max);
+            right.textContent = max === Infinity
+                ? `${formattedCurrent}`
+                : `${formattedCurrent}/${formattedMax}`;
             tag.appendChild(left);
             tag.appendChild(right);
             tagsEl.appendChild(tag);
@@ -395,7 +413,7 @@ function updateAdventureSlotUI(i) {
                 tag.className = 'resource-tag';
                 const left = document.createElement('span');
                 const name = typeof Lang !== 'undefined' && Lang.resource ? (Lang.resource(r) || r) : r;
-                left.textContent = `-${cost[r]} ${name}`;
+                left.textContent = `-${formatTagValue(cost[r])} ${name}`;
                 const right = document.createElement('span');
                 let current = 0;
                 let max = Infinity;
@@ -406,7 +424,11 @@ function updateAdventureSlotUI(i) {
                         max = ResourceSystem.max(res);
                     }
                 }
-                right.textContent = max === Infinity ? `${current}` : `${current}/${max}`;
+                const formattedCurrent = formatTagValue(current);
+                const formattedMax = formatTagValue(max);
+                right.textContent = max === Infinity
+                    ? `${formattedCurrent}`
+                    : `${formattedCurrent}/${formattedMax}`;
                 tag.appendChild(left);
                 tag.appendChild(right);
                 tagsEl.appendChild(tag);

--- a/tests/test_slot_resource_tags.py
+++ b/tests/test_slot_resource_tags.py
@@ -106,5 +106,10 @@ console.log(JSON.stringify(texts));
 """
     result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
     data = json.loads(result.stdout.strip())
-    assert data == [['-1 gold', '5/10'], ['-1 mana', '3/5'], ['+2 food', '7/15'], ['+3 strength', '8/20']]
+    assert data == [
+        ['-1.000 gold', '5.000/10.000'],
+        ['-1.000 mana', '3.000/5.000'],
+        ['+2.000 food', '7.000/15.000'],
+        ['+3.000 strength', '8.000/20.000']
+    ]
 


### PR DESCRIPTION
## Summary
- add a shared helper in `slotSetup.js` to format resource tag numbers with `formatNumber`
- apply the helper to regular and adventure slot resource tags so amounts, current values, and caps use three-decimal precision
- update the slot resource tag unit test to expect the new formatting

## Testing
- pytest *(fails: `wkhtmltoimage` binary is unavailable in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c96117d68883309b9e7d3cfa834192