### PR TITLE
Add auto adventure restart after resource recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Adventure encounters now auto-restart once depleted resources are fully restored, stopping the fallback rest action.
 - Resource and encounter displays now format all values with the shared `formatNumber` helper for consistency.
 - Normalized stat, resource, and tooltip numbers to use a shared `formatNumber` helper with three-decimal precision.
 - Enlarged active slot labels and positioned resource cost tags beneath them for improved readability.

--- a/js/adventure_engine.js
+++ b/js/adventure_engine.js
@@ -66,15 +66,31 @@ const AdventureEngine = {
         if (!this.active) {
             for (let i = 0; i < State.adventureSlots.length; i++) {
                 const slot = State.adventureSlots[i];
-                if (slot.queue) {
-                    const cost = slot.queue.encounter.getResourceCost();
+                const queue = slot.queue;
+                if (!queue) continue;
+
+                if (queue.restart) {
+                    const resources = Array.isArray(queue.resources) ? queue.resources : [];
+                    const ready = resources.length === 0 || resources.every(r => {
+                        const res = State.resources[r];
+                        return res && res.value >= ResourceSystem.max(res);
+                    });
+                    if (ready) {
+                        slot.queue = null;
+                        this.start();
+                    }
+                    break;
+                }
+
+                if (queue.encounter) {
+                    const cost = queue.encounter.getResourceCost();
                     const ready = Object.keys(cost).every(r => {
                         const res = State.resources[r];
                         return res && res.value >= ResourceSystem.max(res);
                     });
                     if (ready) {
-                        slot.encounter = slot.queue.encounter;
-                        slot.progress = slot.queue.progress;
+                        slot.encounter = queue.encounter;
+                        slot.progress = queue.progress;
                         slot.duration = slot.encounter.getDuration();
                         slot.queue = null;
                         slot.active = true;
@@ -84,6 +100,8 @@ const AdventureEngine = {
                     }
                     break;
                 }
+
+                break;
             }
             return;
         }
@@ -131,6 +149,18 @@ function retreat(resourceName, manual = false) {
     const msg = Lang.log('retreat', { encounter: enc, resource: resLabel }) ||
         `You had to retreat after ${enc} because you ran out of ${resLabel}.`;
     if (State.showEncounterLog) Log.add(msg);
+    if (!manual && slot) {
+        const queue = { restart: true };
+        const resources = new Set();
+        if (slot.encounter && typeof slot.encounter.getResourceCost === 'function') {
+            Object.keys(slot.encounter.getResourceCost() || {}).forEach(r => resources.add(r));
+        }
+        if (resourceName) resources.add(resourceName);
+        if (resources.size) {
+            queue.resources = Array.from(resources);
+        }
+        slot.queue = queue;
+    }
     EncounterGenerator.decrementLevel();
     EncounterGenerator.resetProgress();
     AdventureEngine.cancel(manual);

--- a/tests/test_adventure_auto_restart.py
+++ b/tests/test_adventure_auto_restart.py
@@ -1,0 +1,104 @@
+import json
+import subprocess
+
+
+SCRIPT = r"""
+const state = require('./js/state.js');
+const { EncounterGenerator } = require('./js/encounter.js');
+
+global.State = state.State;
+global.setState = state.setState;
+global.updateState = state.updateState;
+global.ResourceSystem = state.ResourceSystem;
+global.actions = { rest: { name: 'Rest', progress: 0 } };
+global.PubSub = { publish: () => {} };
+global.updateSlotUI = () => {};
+global.updateAdventureSlotUI = () => {};
+global.ItemGenerator = { itemList: [], generateFromEncounter: () => null };
+global.Inventory = { add: () => {} };
+global.Lang = { log: () => '', resource: () => '' };
+global.Log = { add: () => {} };
+global.StorySystem = { trigger: () => {} };
+global.EncounterGenerator = EncounterGenerator;
+
+const { AdventureEngine, retreat } = require('./js/adventure_engine.js');
+
+const testEncounter = {
+    id: 'test',
+    name: 'Test Encounter',
+    getDuration() { return 1; },
+    getResourceCost() { return { energy: 10 }; }
+};
+
+EncounterGenerator.randomEncounter = () => testEncounter;
+EncounterGenerator.updateName = () => {};
+EncounterGenerator.updateProgressBar = () => {};
+EncounterGenerator.populateSlots = EncounterGenerator.populateSlots || (() => {});
+EncounterGenerator.decrementLevel = () => {};
+EncounterGenerator.resetProgress = () => {};
+
+State.resources.energy = state.ResourceSystem.create(5, 10);
+State.resources.focus = state.ResourceSystem.create(10, 10);
+State.resources.health = state.ResourceSystem.create(10, 10);
+
+AdventureEngine.start();
+const initialAction = State.slots[0].actionId;
+
+State.resources.energy.value = 0;
+retreat('energy');
+
+const queuedRestart = State.adventureSlots[0].queue;
+const actionAfterRetreat = State.slots[0].actionId;
+const activeAfterRetreat = AdventureEngine.active;
+
+AdventureEngine.tick(1);
+
+const stillQueued = State.adventureSlots[0].queue;
+const actionBeforeRefill = State.slots[0].actionId;
+const activeBeforeRefill = AdventureEngine.active;
+
+State.resources.energy.value = state.ResourceSystem.max(State.resources.energy);
+AdventureEngine.tick(1);
+
+const actionAfterRestart = State.slots[0].actionId;
+const activeAfterRestart = AdventureEngine.active;
+const queueAfterRestart = State.adventureSlots[0].queue;
+
+console.log(JSON.stringify({
+    initialAction,
+    actionAfterRetreat,
+    activeAfterRetreat,
+    queuedRestart,
+    stillQueued,
+    actionBeforeRefill,
+    activeBeforeRefill,
+    actionAfterRestart,
+    activeAfterRestart,
+    queueAfterRestart
+}));
+"""
+
+
+def run_script():
+    proc = subprocess.run(['node', '-e', SCRIPT], capture_output=True, text=True, check=True)
+    return json.loads(proc.stdout.strip())
+
+
+def test_adventure_restarts_after_resource_recovery():
+    data = run_script()
+
+    assert data['initialAction'] is None
+    assert data['actionAfterRetreat'] == 'rest'
+    assert data['activeAfterRetreat'] is False
+
+    queue = data['queuedRestart']
+    assert queue['restart'] is True
+    assert set(queue.get('resources', [])) == {'energy'}
+
+    assert data['stillQueued']['restart'] is True
+    assert data['actionBeforeRefill'] == 'rest'
+    assert data['activeBeforeRefill'] is False
+
+    assert data['actionAfterRestart'] is None
+    assert data['activeAfterRestart'] is True
+    assert data['queueAfterRestart'] is None


### PR DESCRIPTION
## Summary
- queue an automatic restart when a retreat happens due to depleted resources
- restart the adventure slot once the tracked resources refill and stop the fallback rest action
- cover the regression with a new Node-backed pytest and document the behavior in the changelog

## Testing
- pytest *(fails: wkhtmltoimage missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a8e978d8833088bcef08ec9bbcad