### PR TITLE
Implement diminishing returns for soft caps

### DIFF
--- a/js/soft_cap.js
+++ b/js/soft_cap.js
@@ -4,36 +4,66 @@ const SoftCapSystem = {
     baseResourceCaps: { energy: 20, focus: 20, health: 10 },
     statCaps: {},
     resourceCaps: {},
-    falloff: 0.5,
     recalculateCaps() {
         this.statCaps = { ...this.baseStatCaps };
         this.resourceCaps = { ...this.baseResourceCaps };
-        for (const r in this.resourceCaps) {
-            if (State.resources[r]) {
-                setState(['resources', r, 'baseMax'], this.resourceCaps[r]);
+        this._applyBaseCaps('resources', this.baseResourceCaps);
+        this._applyBaseCaps('stats', this.baseStatCaps);
+        this.refreshCaps();
+    },
+    _applyBaseCaps(group, caps) {
+        if (!State[group]) return;
+        Object.keys(caps).forEach(key => {
+            if (State[group][key]) {
+                setState([group, key, 'baseMax'], caps[key]);
             }
-        }
-        for (const s in this.statCaps) {
-            if (State.stats[s]) {
-                setState(['stats', s, 'baseMax'], this.statCaps[s]);
-                this.statCaps[s] = StatSystem.max(State.stats[s]);
+        });
+    },
+    refreshCaps() {
+        this._refreshResourceCaps();
+        this._refreshStatCaps();
+    },
+    _refreshResourceCaps() {
+        if (!State.resources) return;
+        Object.keys(State.resources).forEach(key => {
+            const res = State.resources[key];
+            if (res) {
+                this.resourceCaps[key] = ResourceSystem.max(res);
             }
-        }
+        });
+    },
+    _refreshStatCaps() {
+        if (!State.stats) return;
+        Object.keys(State.stats).forEach(key => {
+            const stat = State.stats[key];
+            if (stat) {
+                this.statCaps[key] = StatSystem.max(stat);
+            }
+        });
     },
     apply() {
-        for (const s in this.statCaps) {
-            const cap = this.statCaps[s];
-            const val = getStatValue(s);
-            if (val > cap) {
-                setStatValue(s, cap + (val - cap) * this.falloff);
-            }
+        this.refreshCaps();
+    },
+    getResourceCap(name) {
+        if (!name || !State.resources || !State.resources[name]) {
+            return this.resourceCaps[name];
         }
-        for (const r in this.resourceCaps) {
-            const cap = this.resourceCaps[r];
-            const val = getResourceValue(r);
-            if (val > cap) {
-                setResourceValue(r, cap + (val - cap) * this.falloff);
-            }
+        if (this.resourceCaps[name] === undefined) {
+            this.resourceCaps[name] = ResourceSystem.max(State.resources[name]);
         }
+        return this.resourceCaps[name];
+    },
+    getStatCap(name) {
+        if (!name || !State.stats || !State.stats[name]) {
+            return this.statCaps[name];
+        }
+        if (this.statCaps[name] === undefined) {
+            this.statCaps[name] = StatSystem.max(State.stats[name]);
+        }
+        return this.statCaps[name];
     }
 };
+
+if (typeof module !== 'undefined') {
+    module.exports = { SoftCapSystem };
+}

--- a/js/state.js
+++ b/js/state.js
@@ -20,12 +20,13 @@ const VERSION = 2;
 
 const ResourceSystem = {
     // baseMax is coerced to a number and defaults to 10
-    create(value, baseMax) {
+    create(value, baseMax, key) {
         return {
             value: value,
             baseMax: Number(baseMax ?? 10),
             maxAdditions: [],
-            maxMultipliers: []
+            maxMultipliers: [],
+            key: key
         };
     },
     max(res) {
@@ -35,7 +36,11 @@ const ResourceSystem = {
         return (base + additions) * mult;
     },
     add(res, amt) {
-        res.value = Math.min(res.value + amt, this.max(res));
+        if (!res || typeof amt !== 'number' || Number.isNaN(amt)) {
+            return;
+        }
+        const cap = resolveResourceCap(res);
+        res.value = applySoftCap(res.value, cap, amt);
     },
     consume(res, amt) {
         if (res.value < amt) return false;
@@ -46,12 +51,13 @@ const ResourceSystem = {
 
 const StatSystem = {
     // baseMax is coerced to a number and defaults to 10
-    create(value, baseMax) {
+    create(value, baseMax, key) {
         return {
             value: value,
             baseMax: Number(baseMax ?? 10),
             maxAdditions: [],
-            maxMultipliers: []
+            maxMultipliers: [],
+            key: key
         };
     },
     max(stat) {
@@ -61,9 +67,63 @@ const StatSystem = {
         return (base + additions) * mult;
     },
     add(stat, amt) {
-        stat.value = Math.min(stat.value + amt, this.max(stat));
+        if (!stat || typeof amt !== 'number' || Number.isNaN(amt)) {
+            return;
+        }
+        const cap = resolveStatCap(stat);
+        stat.value = applySoftCap(stat.value, cap, amt);
     }
 };
+
+function applySoftCap(current, cap, inc) {
+    const baseValue = Number(current ?? 0);
+    const amount = Number(inc ?? 0);
+    if (!Number.isFinite(amount) || amount === 0) {
+        return baseValue;
+    }
+    if (!Number.isFinite(cap)) {
+        return baseValue + amount;
+    }
+    let newValue = baseValue;
+    let delta = amount;
+    if (delta > 0 && newValue < cap) {
+        const toCap = cap - newValue;
+        if (delta <= toCap) {
+            return newValue + delta;
+        }
+        newValue = cap;
+        delta -= toCap;
+    }
+    if (delta <= 0) {
+        return newValue + delta;
+    }
+    const distance = Math.max(0, newValue - cap);
+    return newValue + (delta / (1 + distance));
+}
+
+function resolveResourceCap(res) {
+    if (!res) return undefined;
+    const key = res.key;
+    if (typeof SoftCapSystem !== 'undefined' && SoftCapSystem && typeof SoftCapSystem.getResourceCap === 'function') {
+        const cap = SoftCapSystem.getResourceCap(key);
+        if (cap !== undefined) {
+            return cap;
+        }
+    }
+    return ResourceSystem.max(res);
+}
+
+function resolveStatCap(stat) {
+    if (!stat) return undefined;
+    const key = stat.key;
+    if (typeof SoftCapSystem !== 'undefined' && SoftCapSystem && typeof SoftCapSystem.getStatCap === 'function') {
+        const cap = SoftCapSystem.getStatCap(key);
+        if (cap !== undefined) {
+            return cap;
+        }
+    }
+    return StatSystem.max(stat);
+}
 
 function getResourceValue(name) {
     return State.resources[name].value;
@@ -75,14 +135,26 @@ function getResourceMax(name) {
 
 function setResourceValue(name, val) {
     const r = State.resources[name];
-    r.value = Math.min(val, getResourceMax(name));
+    if (!r) return;
+    if (typeof val !== 'number' || Number.isNaN(val)) {
+        r.value = val;
+        return;
+    }
+    const delta = val - Number(r.value ?? 0);
+    if (delta <= 0) {
+        r.value = val;
+        return;
+    }
+    const cap = resolveResourceCap(r);
+    r.value = applySoftCap(r.value, cap, delta);
 }
 function ensureResource(name, value, max) {
     const res = State.resources[name];
     if (!res || typeof res.value !== "number") {
-        State.resources[name] = ResourceSystem.create(value, max);
+        State.resources[name] = ResourceSystem.create(value, max, name);
     }
     const r = State.resources[name];
+    if (r.key !== name) r.key = name;
     if (!Array.isArray(r.maxAdditions)) r.maxAdditions = [];
     if (!Array.isArray(r.maxMultipliers) || r.maxMultipliers.length === 0) r.maxMultipliers = [0];
 }
@@ -97,15 +169,27 @@ function getStatMax(name) {
 
 function setStatValue(name, val) {
     const s = State.stats[name];
-    s.value = Math.min(val, getStatMax(name));
+    if (!s) return;
+    if (typeof val !== 'number' || Number.isNaN(val)) {
+        s.value = val;
+        return;
+    }
+    const delta = val - Number(s.value ?? 0);
+    if (delta <= 0) {
+        s.value = val;
+        return;
+    }
+    const cap = resolveStatCap(s);
+    s.value = applySoftCap(s.value, cap, delta);
 }
 
 function ensureStat(name, value, max) {
     const stat = State.stats[name];
     if (!stat || typeof stat.value !== "number") {
-        State.stats[name] = StatSystem.create(value, max);
+        State.stats[name] = StatSystem.create(value, max, name);
     }
     const s = State.stats[name];
+    if (s.key !== name) s.key = name;
     if (!Array.isArray(s.maxAdditions)) s.maxAdditions = [];
     if (!Array.isArray(s.maxMultipliers) || s.maxMultipliers.length === 0) s.maxMultipliers = [0];
 }
@@ -114,7 +198,8 @@ function ensureMastery() {
     const savedValue = State.mastery && typeof State.mastery.value === 'number'
         ? State.mastery.value
         : 0;
-    State.mastery = ResourceSystem.create(savedValue, Infinity);
+    State.mastery = ResourceSystem.create(savedValue, Infinity, 'mastery');
+    if (State.mastery.key !== 'mastery') State.mastery.key = 'mastery';
     if (!Array.isArray(State.mastery.maxAdditions)) State.mastery.maxAdditions = [];
     if (!Array.isArray(State.mastery.maxMultipliers) || State.mastery.maxMultipliers.length === 0) State.mastery.maxMultipliers = [0];
 }
@@ -205,7 +290,7 @@ const State = {
     furniture: [],
     researchCompleted: [],
     time: 1,
-    mastery: ResourceSystem.create(0, Infinity),
+    mastery: ResourceSystem.create(0, Infinity, 'mastery'),
     masteryDescription: 'Earned by advancing action tiers.',
     encounterLevel: 1,
     maxEncounterLevel: 1,
@@ -247,18 +332,18 @@ async function loadBaseData() {
         RESOURCE_KEYS = Object.keys(json.resources || {});
         STAT_KEYS.forEach(k => {
             const def = json.stats[k];
-            State.stats[k] = StatSystem.create(def.value, def.baseMax);
+            State.stats[k] = StatSystem.create(def.value, def.baseMax, k);
             State.statDescriptions[k] = def.description || '';
         });
         RESOURCE_KEYS.forEach(k => {
             const def = json.resources[k];
-            State.resources[k] = ResourceSystem.create(def.value, def.baseMax);
+            State.resources[k] = ResourceSystem.create(def.value, def.baseMax, k);
             State.resourceDescriptions[k] = def.description || '';
         });
         State.prestige = {};
         Object.keys(json.prestige || {}).forEach(k => {
             const def = json.prestige[k];
-            State.prestige[k] = StatSystem.create(def.value, Infinity);
+            State.prestige[k] = StatSystem.create(def.value, Infinity, k);
             State.prestigeDescriptions[k] = def.description || '';
         });
         if (typeof BonusEngine !== 'undefined' && BonusEngine.initialize) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -23,9 +23,17 @@ const StatsUI = {
             }
             document.getElementById(`stat-${key}`).textContent = formatNumber(value);
             const capEl = document.getElementById(`stat-${key}-cap`);
-            const cap = SoftCapSystem.statCaps[key] !== undefined
-                ? SoftCapSystem.statCaps[key]
-                : getStatMax(key);
+            let cap;
+            if (typeof SoftCapSystem !== 'undefined') {
+                if (typeof SoftCapSystem.getStatCap === 'function') {
+                    cap = SoftCapSystem.getStatCap(key);
+                } else if (SoftCapSystem.statCaps && SoftCapSystem.statCaps[key] !== undefined) {
+                    cap = SoftCapSystem.statCaps[key];
+                }
+            }
+            if (cap === undefined) {
+                cap = getStatMax(key);
+            }
             if (capEl) capEl.textContent = formatNumber(cap);
             document.getElementById(`stat-${key}-delta`).textContent = formatDelta(statDeltas[key]);
         });
@@ -46,9 +54,17 @@ const ResourcesUI = {
     update() {
         this.list.forEach(key => {
             const value = getResourceValue(key);
-            const cap = SoftCapSystem.resourceCaps[key] !== undefined
-                ? SoftCapSystem.resourceCaps[key]
-                : getResourceMax(key);
+            let cap;
+            if (typeof SoftCapSystem !== 'undefined') {
+                if (typeof SoftCapSystem.getResourceCap === 'function') {
+                    cap = SoftCapSystem.getResourceCap(key);
+                } else if (SoftCapSystem.resourceCaps && SoftCapSystem.resourceCaps[key] !== undefined) {
+                    cap = SoftCapSystem.resourceCaps[key];
+                }
+            }
+            if (cap === undefined) {
+                cap = getResourceMax(key);
+            }
             const fill = document.getElementById(`res-${key}-fill`);
             if (fill) {
                 const percent = cap > 0 ? Math.min(value / cap, 1) * 100 : 0;

--- a/tests/test_soft_caps_behavior.py
+++ b/tests/test_soft_caps_behavior.py
@@ -1,0 +1,79 @@
+import json
+import subprocess
+import textwrap
+
+
+def _run_node(script: str):
+    result = subprocess.run(
+        ['node', '-e', script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout.strip())
+
+
+def test_resources_exceed_soft_cap_with_diminishing_returns():
+    script = textwrap.dedent(
+        """
+        const { State, ResourceSystem, StatSystem, setState } = require('./js/state.js');
+        global.State = State;
+        global.ResourceSystem = ResourceSystem;
+        global.StatSystem = StatSystem;
+        global.setState = setState;
+        const { SoftCapSystem } = require('./js/soft_cap.js');
+
+        State.resources.energy = ResourceSystem.create(0, 20, 'energy');
+        SoftCapSystem.recalculateCaps();
+        const cap = SoftCapSystem.getResourceCap('energy');
+        ResourceSystem.add(State.resources.energy, 30);
+        const afterFirst = State.resources.energy.value;
+        const beforeSecond = State.resources.energy.value;
+        ResourceSystem.add(State.resources.energy, 10);
+        const afterSecond = State.resources.energy.value;
+        const gainSecond = afterSecond - beforeSecond;
+        const beforeThird = State.resources.energy.value;
+        ResourceSystem.add(State.resources.energy, 10);
+        const gainThird = State.resources.energy.value - beforeThird;
+
+        console.log(JSON.stringify({ cap, afterFirst, gainSecond, gainThird }));
+        """
+    )
+    data = _run_node(script)
+    assert data['cap'] == 20
+    assert data['afterFirst'] > data['cap']
+    assert 0 < data['gainSecond'] < 10
+    assert 0 < data['gainThird'] < data['gainSecond']
+
+
+def test_stats_exceed_soft_cap_with_diminishing_returns():
+    script = textwrap.dedent(
+        """
+        const { State, ResourceSystem, StatSystem, setState } = require('./js/state.js');
+        global.State = State;
+        global.ResourceSystem = ResourceSystem;
+        global.StatSystem = StatSystem;
+        global.setState = setState;
+        const { SoftCapSystem } = require('./js/soft_cap.js');
+
+        State.stats.strength = StatSystem.create(0, 50, 'strength');
+        SoftCapSystem.recalculateCaps();
+        const cap = SoftCapSystem.getStatCap('strength');
+        StatSystem.add(State.stats.strength, 70);
+        const afterFirst = State.stats.strength.value;
+        const beforeSecond = State.stats.strength.value;
+        StatSystem.add(State.stats.strength, 10);
+        const afterSecond = State.stats.strength.value;
+        const gainSecond = afterSecond - beforeSecond;
+        const beforeThird = State.stats.strength.value;
+        StatSystem.add(State.stats.strength, 10);
+        const gainThird = State.stats.strength.value - beforeThird;
+
+        console.log(JSON.stringify({ cap, afterFirst, gainSecond, gainThird }));
+        """
+    )
+    data = _run_node(script)
+    assert data['cap'] == 50
+    assert data['afterFirst'] > data['cap']
+    assert 0 < data['gainSecond'] < 10
+    assert 0 < data['gainThird'] < data['gainSecond']


### PR DESCRIPTION
## Summary
- add a reusable soft cap helper to the resource/stat systems so values can exceed their max while applying diminishing returns
- expand `SoftCapSystem` to track per-resource and per-stat caps with getter helpers and refresh logic used by state updates and UI
- update the UI to continue displaying cap values despite over-cap totals and add tests covering the softened growth behaviour

## Testing
- pytest *(fails: `wkhtmltoimage` not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a902829c8330a5f5f2af31799309