### PR TITLE
Route consumables through StatSystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Consumable items now route restore effects through `StatSystem.add`, skipping resource keys, publishing `stats:updated`, and covering soft-cap behavior with updated tests.
 - Adventure encounters now auto-restart once depleted resources are fully restored, stopping the fallback rest action.
 - Resource and encounter displays now format all values with the shared `formatNumber` helper for consistency.
 - Normalized stat, resource, and tooltip numbers to use a shared `formatNumber` helper with three-decimal precision.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Changed
 - Consumable items now route restore effects through `StatSystem.add`, skipping resource keys, publishing `stats:updated`, and covering soft-cap behavior with updated tests.
+- Updated consumable item definitions to grant stat increases instead of restoring resources.
 - Adventure encounters now auto-restart once depleted resources are fully restored, stopping the fallback rest action.
 - Resource and encounter displays now format all values with the shared `formatNumber` helper for consistency.
 - Normalized stat, resource, and tooltip numbers to use a shared `formatNumber` helper with three-decimal precision.

--- a/data/items.json
+++ b/data/items.json
@@ -5,8 +5,8 @@
         "rarity": "common",
         "type": "consumable",
         "restore": {
-            "health": 1,
-            "focus": 1
+            "intelligence": 1,
+            "dexterity": 1
         },
         "image": "assets/items/herb.png",
         "description": "A collection of useful medicinal plants."
@@ -17,7 +17,7 @@
         "rarity": "common",
         "type": "consumable",
         "restore": {
-            "health": 5
+            "strength": 5
         },
         "image": "assets/items/rabbit.png",
         "description": "Fresh meat from a hunted rabbit."
@@ -120,8 +120,8 @@
         "rarity": "common",
         "type": "consumable",
         "restore": {
-            "health": 1,
-            "energy": 2
+            "strength": 1,
+            "dexterity": 2
         },
         "image": "assets/user_uploaded/water_flask.jpg",
         "description": "A simple container filled with fresh water."
@@ -156,9 +156,9 @@
         "rarity": "common",
         "type": "consumable",
         "restore": {
-            "health": 1,
-            "energy": 1,
-            "focus": 1
+            "strength": 1,
+            "dexterity": 1,
+            "intelligence": 1
         },
         "image": "assets/user_uploaded/berries.jpg",
         "description": "A handful of ripe forest berries."
@@ -186,8 +186,8 @@
         "rarity": "common",
         "type": "consumable",
         "restore": {
-            "health": 3,
-            "energy": 2
+            "strength": 3,
+            "dexterity": 2
         },
         "image": "assets/user_uploaded/cooked_fish.jpg",
         "description": "Freshly cooked fish that restores vigor."

--- a/js/items.js
+++ b/js/items.js
@@ -16,8 +16,13 @@ class Item {
         if (this.type === 'consumable' && this.restore) {
             const parts = [];
             for (const [key, val] of Object.entries(this.restore)) {
-                const resName = Lang.resource(key) || key;
-                parts.push(`+${val} ${resName}`);
+                let label = key;
+                if (typeof Lang !== 'undefined') {
+                    const statName = typeof Lang.stat === 'function' ? Lang.stat(key) : null;
+                    const resName = typeof Lang.resource === 'function' ? Lang.resource(key) : null;
+                    label = statName || resName || key;
+                }
+                parts.push(`+${val} ${label}`);
             }
             return `Restores ${parts.join(', ')}`;
         }

--- a/js/items.js
+++ b/js/items.js
@@ -117,13 +117,33 @@ const Inventory = {
         updateState(['inventory', id, 'quantity'], q => q - qty);
         if (State.inventory[id].quantity <= 0) deleteState(['inventory', id]);
         if (item && item.type === 'consumable') {
-            for (const [res, amt] of Object.entries(item.restore)) {
-                if (State.resources[res]) {
-                    ResourceSystem.add(State.resources[res], amt * qty);
+            const stats = (State && State.stats) ? State.stats : {};
+            const resources = (State && State.resources) ? State.resources : {};
+            let statsChanged = false;
+            const restoreEntries = item.restore ? Object.entries(item.restore) : [];
+            for (const [key, amt] of restoreEntries) {
+                const stat = stats ? stats[key] : undefined;
+                if (!stat) {
+                    if (resources && resources[key]) {
+                        continue;
+                    }
+                    const message = `Inventory.consume: missing stat definition for "${key}" on item ${id}`;
+                    if (typeof Logger !== 'undefined' && typeof Logger.warn === 'function') {
+                        Logger.warn(message);
+                    } else if (typeof console !== 'undefined' && typeof console.warn === 'function') {
+                        console.warn(message);
+                    }
+                    continue;
                 }
+                if (typeof StatSystem !== 'undefined' && typeof StatSystem.add === 'function') {
+                    StatSystem.add(stat, amt * qty);
+                } else {
+                    stat.value = (Number(stat.value) || 0) + amt * qty;
+                }
+                statsChanged = true;
             }
-            if (typeof PubSub !== 'undefined') {
-                PubSub.publish('resources:updated');
+            if (statsChanged && typeof PubSub !== 'undefined') {
+                PubSub.publish('stats:updated');
             }
         }
         if (typeof PubSub !== 'undefined') {

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -2,6 +2,8 @@ import json
 import os
 import subprocess
 
+import pytest
+
 
 def test_item_fields():
     path = os.path.join('data', 'items.json')
@@ -33,18 +35,22 @@ def test_consumable_restoration_values():
     assert set(berries['restore'].keys()) == {'health', 'energy', 'focus'}
 
 
-def test_inventory_consume_updates_resources_and_events():
+def test_inventory_consume_updates_stats_and_events():
     script = r"""
 const { ItemGenerator, Inventory } = require('./js/items.js');
 global.State = {
     inventory: { berries: { quantity: 2 } },
+    stats: {},
     resources: {
-        health: { value: 0 },
-        energy: { value: 0 },
-        focus: { value: 0 }
+        health: { value: 0 }
     },
     equipment: {}
 };
+const { StatSystem } = require('./js/state.js');
+global.StatSystem = StatSystem;
+State.stats.strength = StatSystem.create(9, 10, 'strength');
+const expected = StatSystem.create(9, 10, 'strength');
+StatSystem.add(expected, 3);
 global.updateState = function(path, fn) {
     const [root, id, prop] = path;
     if (root === 'inventory' && prop === 'quantity') {
@@ -55,24 +61,29 @@ global.deleteState = function(path) {
     const [root, id] = path;
     if (root === 'inventory') delete State.inventory[id];
 };
-global.ResourceSystem = {
-    add: (res, amt) => { res.value += amt; }
-};
 ItemGenerator.itemList = [
-    { id: 'berries', type: 'consumable', restore: { health: 1, energy: 1, focus: 1 } }
+    { id: 'berries', type: 'consumable', restore: { strength: 3, health: 2 } }
 ];
 const events = [];
 global.PubSub = { publish: (event) => events.push(event) };
 
 Inventory.consume('berries');
 
-console.log(JSON.stringify({ inventory: State.inventory, resources: State.resources, events }));
+console.log(JSON.stringify({
+    inventory: State.inventory,
+    resources: State.resources,
+    stats: State.stats,
+    events,
+    expected: expected.value
+}));
 """;
     result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
     data = json.loads(result.stdout.strip())
     assert data['inventory']['berries']['quantity'] == 1
-    assert data['resources']['health']['value'] == 1
-    assert data['resources']['energy']['value'] == 1
-    assert data['resources']['focus']['value'] == 1
+    assert data['resources']['health']['value'] == 0
+    strength_val = data['stats']['strength']['value']
+    assert strength_val == pytest.approx(data['expected'])
+    assert strength_val < 12  # confirms soft cap applied instead of linear growth
     assert 'inventory:changed' in data['events']
-    assert 'resources:updated' in data['events']
+    assert 'stats:updated' in data['events']
+    assert 'resources:updated' not in data['events']

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -6,9 +6,14 @@ import pytest
 
 
 def test_item_fields():
-    path = os.path.join('data', 'items.json')
-    with open(path) as f:
+    item_path = os.path.join('data', 'items.json')
+    resource_path = os.path.join('data', 'resources.json')
+    with open(item_path) as f:
         data = json.load(f)
+    with open(resource_path) as f:
+        base_data = json.load(f)
+    stat_keys = set(base_data['stats'].keys())
+    resource_keys = set(base_data['resources'].keys())
     for item in data:
         assert 'id' in item
         assert 'name' in item
@@ -17,7 +22,10 @@ def test_item_fields():
         if item['type'] == 'consumable':
             assert 'restore' in item
             assert isinstance(item['restore'], dict)
-            assert 'health' in item['restore']
+            assert item['restore']
+            restore_keys = set(item['restore'].keys())
+            assert restore_keys.issubset(stat_keys)
+            assert not restore_keys.intersection(resource_keys)
         else:
             assert 'restore' not in item or item['restore'] == {}
         if item['type'] == 'equipment':
@@ -30,9 +38,9 @@ def test_consumable_restoration_values():
     with open(path) as f:
         data = json.load(f)
     rabbit = next(i for i in data if i['id'] == 'rabbit_meat')
-    assert rabbit['restore']['health'] > 1
+    assert rabbit['restore']['strength'] > 1
     berries = next(i for i in data if i['id'] == 'berries')
-    assert set(berries['restore'].keys()) == {'health', 'energy', 'focus'}
+    assert set(berries['restore'].keys()) == {'strength', 'dexterity', 'intelligence'}
 
 
 def test_inventory_consume_updates_stats_and_events():


### PR DESCRIPTION
## Summary
- send consumable restore effects through StatSystem.add so stats obey soft caps and publish stats:updated instead of resources:updated
- ignore resource restore keys, warn about unknown stats, and keep inventory updates intact
- adjust the consumable integration test to validate stat growth and updated events

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9c7a7cff48330bd8e0ad0b7fbced5