### PR TITLE
Adjust consumable stat bonuses and tooltip wording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Rebalanced consumable stat bonuses and show their effects as localized stat increases in the inventory tooltip.
 - Consumable items now route restore effects through `StatSystem.add`, skipping resource keys, publishing `stats:updated`, and covering soft-cap behavior with updated tests.
 - Updated consumable item definitions to grant stat increases instead of restoring resources.
 - Adventure encounters now auto-restart once depleted resources are fully restored, stopping the fallback rest action.

--- a/data/items.json
+++ b/data/items.json
@@ -5,7 +5,7 @@
         "rarity": "common",
         "type": "consumable",
         "restore": {
-            "intelligence": 1,
+            "intelligence": 2,
             "dexterity": 1
         },
         "image": "assets/items/herb.png",
@@ -17,7 +17,7 @@
         "rarity": "common",
         "type": "consumable",
         "restore": {
-            "strength": 5
+            "strength": 4
         },
         "image": "assets/items/rabbit.png",
         "description": "Fresh meat from a hunted rabbit."
@@ -120,7 +120,7 @@
         "rarity": "common",
         "type": "consumable",
         "restore": {
-            "strength": 1,
+            "intelligence": 1,
             "dexterity": 2
         },
         "image": "assets/user_uploaded/water_flask.jpg",
@@ -157,7 +157,7 @@
         "type": "consumable",
         "restore": {
             "strength": 1,
-            "dexterity": 1,
+            "dexterity": 2,
             "intelligence": 1
         },
         "image": "assets/user_uploaded/berries.jpg",
@@ -186,8 +186,8 @@
         "rarity": "common",
         "type": "consumable",
         "restore": {
-            "strength": 3,
-            "dexterity": 2
+            "strength": 2,
+            "dexterity": 3
         },
         "image": "assets/user_uploaded/cooked_fish.jpg",
         "description": "Freshly cooked fish that restores vigor."

--- a/data/lang/uk.json
+++ b/data/lang/uk.json
@@ -40,7 +40,8 @@
     "Consumables": "Витратні матеріали",
     "Equipment": "Спорядження",
     "Equip": "Одягти",
-    "Character": "Персонаж"
+    "Character": "Персонаж",
+    "Stat increase": "Збільшення характеристики"
   },
   "actions": {
     "studying": { "name": "Навчання" },

--- a/js/items.js
+++ b/js/items.js
@@ -19,12 +19,22 @@ class Item {
                 let label = key;
                 if (typeof Lang !== 'undefined') {
                     const statName = typeof Lang.stat === 'function' ? Lang.stat(key) : null;
-                    const resName = typeof Lang.resource === 'function' ? Lang.resource(key) : null;
+                    let resName = null;
+                    if (!statName && typeof Lang.resource === 'function') {
+                        resName = Lang.resource(key);
+                    }
                     label = statName || resName || key;
                 }
                 parts.push(`+${val} ${label}`);
             }
-            return `Restores ${parts.join(', ')}`;
+            if (!parts.length) {
+                return '';
+            }
+            let prefix = 'Stat increase';
+            if (typeof Lang !== 'undefined' && typeof Lang.ui === 'function') {
+                prefix = Lang.ui('Stat increase') || prefix;
+            }
+            return `${prefix}: ${parts.join(', ')}`;
         }
         return '';
     }


### PR DESCRIPTION
## Summary
- rebalance consumable stat rewards to reflect design emphasis on agility and focus
- update consumable tooltip copy to label effects as stat increases and localize the prefix
- add Ukrainian translation for the new stat increase label and document the change in the changelog

## Testing
- pytest *(fails: wkhtmltoimage missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c7a80bd083308af092bf9cc40720