### PR TITLE
Update consumable item tests for stat soft caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Reworked consumable item tests to enforce stat-only restoration keys and added a regression case proving soft-cap diminishing returns when consuming stat boosts.
 - Rebalanced consumable stat bonuses and show their effects as localized stat increases in the inventory tooltip.
 - Consumable items now route restore effects through `StatSystem.add`, skipping resource keys, publishing `stats:updated`, and covering soft-cap behavior with updated tests.
 - Updated consumable item definitions to grant stat increases instead of restoring resources.

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -1,97 +1,202 @@
 import json
 import os
 import subprocess
+import textwrap
 
 import pytest
+
+
+def _run_node_script(script: str) -> dict:
+    result = subprocess.run(
+        ['node', '-e', script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    output = result.stdout.strip()
+    if not output:
+        raise AssertionError('Node script produced no output')
+    return json.loads(output)
 
 
 def test_item_fields():
     item_path = os.path.join('data', 'items.json')
     resource_path = os.path.join('data', 'resources.json')
-    with open(item_path) as f:
+    with open(item_path, encoding='utf-8') as f:
         data = json.load(f)
-    with open(resource_path) as f:
+    with open(resource_path, encoding='utf-8') as f:
         base_data = json.load(f)
+
     stat_keys = set(base_data['stats'].keys())
     resource_keys = set(base_data['resources'].keys())
+
     for item in data:
         assert 'id' in item
         assert 'name' in item
         assert 'rarity' in item
         assert 'type' in item
+
         if item['type'] == 'consumable':
-            assert 'restore' in item
-            assert isinstance(item['restore'], dict)
-            assert item['restore']
-            restore_keys = set(item['restore'].keys())
-            assert restore_keys.issubset(stat_keys)
-            assert not restore_keys.intersection(resource_keys)
+            restore = item.get('restore', {})
+            assert isinstance(restore, dict) and restore
+            restore_keys = set(restore)
+            missing_stats = restore_keys.difference(stat_keys)
+            assert not missing_stats, (
+                f"Consumable {item['id']} uses non-stat restore keys: {sorted(missing_stats)}"
+            )
+            assert restore_keys.isdisjoint(resource_keys)
         else:
-            assert 'restore' not in item or item['restore'] == {}
+            assert item.get('restore', {}) in ({}, None)
+
         if item['type'] == 'equipment':
             # Equipment items must define the slot they occupy
             assert 'slot' in item
+
         assert 'image' in item
 
+
 def test_consumable_restoration_values():
-    path = os.path.join('data', 'items.json')
-    with open(path) as f:
+    items_path = os.path.join('data', 'items.json')
+    base_path = os.path.join('data', 'resources.json')
+    with open(items_path, encoding='utf-8') as f:
         data = json.load(f)
+    with open(base_path, encoding='utf-8') as f:
+        base_data = json.load(f)
+
+    stat_keys = set(base_data['stats'])
+
     rabbit = next(i for i in data if i['id'] == 'rabbit_meat')
+    assert set(rabbit['restore']) == {'strength'}
     assert rabbit['restore']['strength'] > 1
+    assert all(key in stat_keys for key in rabbit['restore'])
+
     berries = next(i for i in data if i['id'] == 'berries')
     assert set(berries['restore'].keys()) == {'strength', 'dexterity', 'intelligence'}
+    assert all(key in stat_keys for key in berries['restore'])
+    assert all(value > 0 for value in berries['restore'].values())
 
 
 def test_inventory_consume_updates_stats_and_events():
-    script = r"""
-const { ItemGenerator, Inventory } = require('./js/items.js');
-global.State = {
-    inventory: { berries: { quantity: 2 } },
-    stats: {},
-    resources: {
-        health: { value: 0 }
-    },
-    equipment: {}
-};
-const { StatSystem } = require('./js/state.js');
-global.StatSystem = StatSystem;
-State.stats.strength = StatSystem.create(9, 10, 'strength');
-const expected = StatSystem.create(9, 10, 'strength');
-StatSystem.add(expected, 3);
-global.updateState = function(path, fn) {
-    const [root, id, prop] = path;
-    if (root === 'inventory' && prop === 'quantity') {
-        State.inventory[id][prop] = fn(State.inventory[id][prop]);
-    }
-};
-global.deleteState = function(path) {
-    const [root, id] = path;
-    if (root === 'inventory') delete State.inventory[id];
-};
-ItemGenerator.itemList = [
-    { id: 'berries', type: 'consumable', restore: { strength: 3, health: 2 } }
-];
-const events = [];
-global.PubSub = { publish: (event) => events.push(event) };
+    script = textwrap.dedent(
+        """
+        const { ItemGenerator, Inventory } = require('./js/items.js');
+        const { StatSystem } = require('./js/state.js');
 
-Inventory.consume('berries');
+        global.State = {
+            inventory: { berries: { quantity: 2 } },
+            stats: {},
+            resources: { health: { value: 25 } },
+            equipment: {},
+        };
+        global.StatSystem = StatSystem;
+        global.updateState = function(path, fn) {
+            const [root, id, prop] = path;
+            if (root === 'inventory' && prop === 'quantity') {
+                State.inventory[id][prop] = fn(State.inventory[id][prop]);
+            }
+        };
+        global.deleteState = function(path) {
+            const [root, id] = path;
+            if (root === 'inventory') delete State.inventory[id];
+        };
 
-console.log(JSON.stringify({
-    inventory: State.inventory,
-    resources: State.resources,
-    stats: State.stats,
-    events,
-    expected: expected.value
-}));
-""";
-    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
-    data = json.loads(result.stdout.strip())
+        State.stats.strength = StatSystem.create(9, 10, 'strength');
+        const before = State.stats.strength.value;
+        const expected = StatSystem.create(9, 10, 'strength');
+        StatSystem.add(expected, 3);
+
+        ItemGenerator.itemList = [
+            { id: 'berries', type: 'consumable', restore: { strength: 3 } }
+        ];
+
+        const events = [];
+        global.PubSub = { publish: (event) => events.push(event) };
+
+        Inventory.consume('berries');
+
+        console.log(JSON.stringify({
+            before,
+            restore: ItemGenerator.itemList[0].restore.strength,
+            inventory: State.inventory,
+            resources: State.resources,
+            stats: State.stats,
+            events,
+            expected: expected.value
+        }));
+        """
+    )
+
+    data = _run_node_script(script)
     assert data['inventory']['berries']['quantity'] == 1
-    assert data['resources']['health']['value'] == 0
+    assert data['resources']['health']['value'] == 25
     strength_val = data['stats']['strength']['value']
     assert strength_val == pytest.approx(data['expected'])
-    assert strength_val < 12  # confirms soft cap applied instead of linear growth
+    assert strength_val > data['before']
+    assert strength_val < data['before'] + data['restore']
     assert 'inventory:changed' in data['events']
     assert 'stats:updated' in data['events']
     assert 'resources:updated' not in data['events']
+
+
+def test_consumable_diminishing_returns_after_soft_cap():
+    script = textwrap.dedent(
+        """
+        const { ItemGenerator, Inventory } = require('./js/items.js');
+        const { StatSystem } = require('./js/state.js');
+
+        global.State = {
+            inventory: { tonic: { quantity: 2 } },
+            stats: {},
+            resources: {},
+            equipment: {},
+        };
+        global.StatSystem = StatSystem;
+        global.updateState = function(path, fn) {
+            const [root, id, prop] = path;
+            if (root === 'inventory' && prop === 'quantity') {
+                State.inventory[id][prop] = fn(State.inventory[id][prop]);
+            }
+        };
+        global.deleteState = function(path) {
+            const [root, id] = path;
+            if (root === 'inventory') delete State.inventory[id];
+        };
+
+        State.stats.strength = StatSystem.create(0, 10, 'strength');
+
+        ItemGenerator.itemList = [
+            { id: 'tonic', type: 'consumable', restore: { strength: 5 } }
+        ];
+
+        const beforeFirst = State.stats.strength.value;
+        Inventory.consume('tonic');
+        const afterFirst = State.stats.strength.value;
+        const gainBefore = afterFirst - beforeFirst;
+
+        StatSystem.add(State.stats.strength, 10);
+        const beforeSecond = State.stats.strength.value;
+        Inventory.consume('tonic');
+        const afterSecond = State.stats.strength.value;
+        const gainAfter = afterSecond - beforeSecond;
+
+        const finalQuantity = State.inventory.tonic ? State.inventory.tonic.quantity : 0;
+
+        console.log(JSON.stringify({
+            gainBefore,
+            gainAfter,
+            afterFirst,
+            beforeSecond,
+            afterSecond,
+            restore: ItemGenerator.itemList[0].restore.strength,
+            finalQuantity
+        }));
+        """
+    )
+
+    data = _run_node_script(script)
+    assert data['finalQuantity'] == 0
+    assert data['gainBefore'] == pytest.approx(data['restore'])
+    assert data['gainAfter'] > 0
+    assert data['gainAfter'] < data['gainBefore']
+    assert data['gainAfter'] < data['restore']
+    assert data['afterSecond'] > data['afterFirst']


### PR DESCRIPTION
## Summary
- rewrite the consumable item fixtures to require stat-only restore keys and reuse a helper for Node-based assertions
- refresh the inventory consumption scenario to validate stat gains, unchanged resources, and the published stats event
- add a regression test proving consumable gains diminish once a stat pushes past its soft cap and document the change in the changelog

## Testing
- pytest *(fails: wkhtmltoimage binary is unavailable for visual layout captures)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c7a876ec8330a813abaab62ba689