### PR TITLE
Clarify consumable stat boosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Changed
 - Consumable items now route restore effects through `StatSystem.add`, skipping resource keys, publishing `stats:updated`, and covering soft-cap behavior with updated tests.
+- Consumable effect descriptions now present stat boosts with a "Grants" prefix and skip output when no modifiers are configured.
+- Updated consumable item definitions to grant stat increases instead of restoring resources.
 - Adventure encounters now auto-restart once depleted resources are fully restored, stopping the fallback rest action.
 - Resource and encounter displays now format all values with the shared `formatNumber` helper for consistency.
 - Normalized stat, resource, and tooltip numbers to use a shared `formatNumber` helper with three-decimal precision.

--- a/data/items.json
+++ b/data/items.json
@@ -5,8 +5,8 @@
         "rarity": "common",
         "type": "consumable",
         "restore": {
-            "health": 1,
-            "focus": 1
+            "intelligence": 1,
+            "dexterity": 1
         },
         "image": "assets/items/herb.png",
         "description": "A collection of useful medicinal plants."
@@ -17,7 +17,7 @@
         "rarity": "common",
         "type": "consumable",
         "restore": {
-            "health": 5
+            "strength": 5
         },
         "image": "assets/items/rabbit.png",
         "description": "Fresh meat from a hunted rabbit."
@@ -120,8 +120,8 @@
         "rarity": "common",
         "type": "consumable",
         "restore": {
-            "health": 1,
-            "energy": 2
+            "strength": 1,
+            "dexterity": 2
         },
         "image": "assets/user_uploaded/water_flask.jpg",
         "description": "A simple container filled with fresh water."
@@ -156,9 +156,9 @@
         "rarity": "common",
         "type": "consumable",
         "restore": {
-            "health": 1,
-            "energy": 1,
-            "focus": 1
+            "strength": 1,
+            "dexterity": 1,
+            "intelligence": 1
         },
         "image": "assets/user_uploaded/berries.jpg",
         "description": "A handful of ripe forest berries."
@@ -186,8 +186,8 @@
         "rarity": "common",
         "type": "consumable",
         "restore": {
-            "health": 3,
-            "energy": 2
+            "strength": 3,
+            "dexterity": 2
         },
         "image": "assets/user_uploaded/cooked_fish.jpg",
         "description": "Freshly cooked fish that restores vigor."

--- a/js/items.js
+++ b/js/items.js
@@ -1,6 +1,6 @@
 // Agents: ItemGenerator and Inventory work together to manage loot. Encounters
-// call `Inventory.add()` with items produced here. Consumable items restore
-// resources directly when used.
+// call `Inventory.add()` with items produced here. Consumable items now grant
+// stat boosts when used instead of restoring resources directly.
 class Item {
     constructor(data) {
         this.id = data.id;
@@ -16,10 +16,18 @@ class Item {
         if (this.type === 'consumable' && this.restore) {
             const parts = [];
             for (const [key, val] of Object.entries(this.restore)) {
-                const resName = Lang.resource(key) || key;
-                parts.push(`+${val} ${resName}`);
+                let label = key;
+                if (typeof Lang !== 'undefined') {
+                    const statName = typeof Lang.stat === 'function' ? Lang.stat(key) : null;
+                    const resName = typeof Lang.resource === 'function' ? Lang.resource(key) : null;
+                    label = statName || resName || key;
+                }
+                parts.push(`+${val} ${label}`);
             }
-            return `Restores ${parts.join(', ')}`;
+            if (!parts.length) {
+                return '';
+            }
+            return `Grants ${parts.join(', ')}`;
         }
         return '';
     }

--- a/tests/test_items.py
+++ b/tests/test_items.py
@@ -6,9 +6,14 @@ import pytest
 
 
 def test_item_fields():
-    path = os.path.join('data', 'items.json')
-    with open(path) as f:
+    item_path = os.path.join('data', 'items.json')
+    resource_path = os.path.join('data', 'resources.json')
+    with open(item_path) as f:
         data = json.load(f)
+    with open(resource_path) as f:
+        base_data = json.load(f)
+    stat_keys = set(base_data['stats'].keys())
+    resource_keys = set(base_data['resources'].keys())
     for item in data:
         assert 'id' in item
         assert 'name' in item
@@ -17,7 +22,10 @@ def test_item_fields():
         if item['type'] == 'consumable':
             assert 'restore' in item
             assert isinstance(item['restore'], dict)
-            assert 'health' in item['restore']
+            assert item['restore']
+            restore_keys = set(item['restore'].keys())
+            assert restore_keys.issubset(stat_keys)
+            assert not restore_keys.intersection(resource_keys)
         else:
             assert 'restore' not in item or item['restore'] == {}
         if item['type'] == 'equipment':
@@ -30,9 +38,23 @@ def test_consumable_restoration_values():
     with open(path) as f:
         data = json.load(f)
     rabbit = next(i for i in data if i['id'] == 'rabbit_meat')
-    assert rabbit['restore']['health'] > 1
+    assert rabbit['restore']['strength'] > 1
     berries = next(i for i in data if i['id'] == 'berries')
-    assert set(berries['restore'].keys()) == {'health', 'energy', 'focus'}
+    assert set(berries['restore'].keys()) == {'strength', 'dexterity', 'intelligence'}
+
+
+def test_item_effect_description_uses_stat_labels():
+    script = r"""
+const { Item } = require('./js/items.js');
+global.Lang = {
+    stat: (key) => ({ strength: 'Strength' }[key] || null),
+    resource: () => null
+};
+const item = new Item({ id: 'tonic', type: 'consumable', restore: { strength: 2 } });
+console.log(item.getEffectDescription());
+""";
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    assert result.stdout.strip() == 'Grants +2 Strength'
 
 
 def test_inventory_consume_updates_stats_and_events():


### PR DESCRIPTION
## Summary
- update consumable item effect descriptions to report stat boosts with a "Grants" prefix and skip empty outputs
- add a Node-based regression test that verifies consumables use localized stat labels in their effect text
- document the revised consumable copy in the changelog

## Testing
- pytest tests/test_items.py
- pytest *(fails: wkhtmltoimage missing in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9cb6f752c83309cca865294c4fd24