### PR TITLE
Align consumable item effects with stat bonuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Consumable item descriptions and consumption logic now only reference stat bonuses, warning if a stat key is missing instead of silently treating it as a resource.
 - Reworked consumable item tests to enforce stat-only restoration keys and added a regression case proving soft-cap diminishing returns when consuming stat boosts.
 - Rebalanced consumable stat bonuses and show their effects as localized stat increases in the inventory tooltip.
 - Consumable items now route restore effects through `StatSystem.add`, skipping resource keys, publishing `stats:updated`, and covering soft-cap behavior with updated tests.

--- a/js/items.js
+++ b/js/items.js
@@ -1,6 +1,6 @@
 // Agents: ItemGenerator and Inventory work together to manage loot. Encounters
-// call `Inventory.add()` with items produced here. Consumable items restore
-// resources directly when used.
+// call `Inventory.add()` with items produced here. Consumable items grant
+// permanent stat increases when used.
 class Item {
     constructor(data) {
         this.id = data.id;
@@ -17,13 +17,11 @@ class Item {
             const parts = [];
             for (const [key, val] of Object.entries(this.restore)) {
                 let label = key;
-                if (typeof Lang !== 'undefined') {
-                    const statName = typeof Lang.stat === 'function' ? Lang.stat(key) : null;
-                    let resName = null;
-                    if (!statName && typeof Lang.resource === 'function') {
-                        resName = Lang.resource(key);
+                if (typeof Lang !== 'undefined' && typeof Lang.stat === 'function') {
+                    const statName = Lang.stat(key);
+                    if (statName) {
+                        label = statName;
                     }
-                    label = statName || resName || key;
                 }
                 parts.push(`+${val} ${label}`);
             }
@@ -133,15 +131,11 @@ const Inventory = {
         if (State.inventory[id].quantity <= 0) deleteState(['inventory', id]);
         if (item && item.type === 'consumable') {
             const stats = (State && State.stats) ? State.stats : {};
-            const resources = (State && State.resources) ? State.resources : {};
             let statsChanged = false;
             const restoreEntries = item.restore ? Object.entries(item.restore) : [];
             for (const [key, amt] of restoreEntries) {
                 const stat = stats ? stats[key] : undefined;
                 if (!stat) {
-                    if (resources && resources[key]) {
-                        continue;
-                    }
                     const message = `Inventory.consume: missing stat definition for "${key}" on item ${id}`;
                     if (typeof Logger !== 'undefined' && typeof Logger.warn === 'function') {
                         Logger.warn(message);


### PR DESCRIPTION
## Summary
- update consumable item descriptions to refer only to stat boosts
- ensure inventory consumption applies restore values strictly to stats and warns about missing definitions
- document the change in the changelog

## Testing
- pytest *(fails: wkhtmltoimage not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cacb5c316c8330a19acb84ee7fda09