### PR TITLE
Expose resource softcaps in resources tab

### DIFF
--- a/js/ui/resources_tab.js
+++ b/js/ui/resources_tab.js
@@ -72,15 +72,7 @@ const ResourcesTab = {
         }
         const amt = document.createElement('span');
         amt.className = 'resource-amount';
-        let max;
-        if (group === 'stats' || group === 'prestige') {
-            max = StatSystem.max(res);
-        } else {
-            max = ResourceSystem.max(res);
-        }
-        amt.textContent = max !== Infinity
-            ? `${formatNumber(res.value)}/${formatNumber(max)}`
-            : `${formatNumber(res.value)}`;
+        amt.textContent = this._formatAmount(res.value);
         btn.appendChild(label);
         btn.appendChild(amt);
         li.appendChild(btn);
@@ -93,6 +85,10 @@ const ResourcesTab = {
             descEl.textContent = descText;
             detail.appendChild(descEl);
         }
+        const softcapEl = document.createElement('p');
+        softcapEl.className = 'resource-softcap';
+        softcapEl.textContent = this._buildSoftcapText(group, name, res);
+        detail.appendChild(softcapEl);
         const mods = document.createElement('ul');
         mods.className = 'resource-mods';
         detail.appendChild(mods);
@@ -100,7 +96,7 @@ const ResourcesTab = {
         btn.addEventListener('click', () => {
             detail.classList.toggle('hidden');
         });
-        this.entries[name] = { amount: amt, mods: mods, group: group };
+        this.entries[name] = { amount: amt, mods: mods, group: group, softcap: softcapEl };
         this._renderMods(name, res);
         return li;
     },
@@ -119,6 +115,57 @@ const ResourcesTab = {
             list.appendChild(li);
         });
     },
+    _formatAmount(value) {
+        if (value === undefined || value === null) {
+            return '—';
+        }
+        const numeric = Number(value);
+        if (Number.isFinite(numeric)) {
+            return formatNumber(numeric);
+        }
+        return '∞';
+    },
+    _resolveCapValue(group, name, res) {
+        const softCapSystem = (typeof SoftCapSystem !== 'undefined' && SoftCapSystem) ? SoftCapSystem : null;
+        if (group === 'stats' || group === 'prestige') {
+            if (softCapSystem && typeof softCapSystem.getStatCap === 'function') {
+                const cap = softCapSystem.getStatCap(name);
+                if (cap !== undefined && cap !== null) {
+                    return cap;
+                }
+            }
+            if (typeof StatSystem !== 'undefined' && StatSystem && typeof StatSystem.max === 'function' && res) {
+                return StatSystem.max(res);
+            }
+            return undefined;
+        }
+        if (softCapSystem && typeof softCapSystem.getResourceCap === 'function') {
+            const cap = softCapSystem.getResourceCap(name);
+            if (cap !== undefined && cap !== null) {
+                return cap;
+            }
+        }
+        if (typeof ResourceSystem !== 'undefined' && ResourceSystem && typeof ResourceSystem.max === 'function' && res) {
+            return ResourceSystem.max(res);
+        }
+        return undefined;
+    },
+    _buildSoftcapText(group, name, res) {
+        const cap = this._resolveCapValue(group, name, res);
+        if (cap === undefined || cap === null) {
+            return 'Softcap: —';
+        }
+        const numericCap = Number(cap);
+        if (Number.isFinite(numericCap)) {
+            return `Softcap: ${formatNumber(numericCap)}`;
+        }
+        return 'Softcap: ∞';
+    },
+    _updateSoftcap(name, group, res) {
+        const entry = this.entries[name];
+        if (!entry || !entry.softcap) return;
+        entry.softcap.textContent = this._buildSoftcapText(group, name, res);
+    },
     update(name) {
         let res = State.resources[name] || State.stats[name] || State.prestige[name];
         let group = 'resources';
@@ -134,10 +181,10 @@ const ResourcesTab = {
             this.container.appendChild(el);
             return;
         }
-        const max = (group === 'stats' || group === 'prestige') ? StatSystem.max(res) : ResourceSystem.max(res);
-        this.entries[name].amount.textContent = max !== Infinity
-            ? `${formatNumber(res.value)}/${formatNumber(max)}`
-            : `${formatNumber(res.value)}`;
+        const entry = this.entries[name];
+        entry.group = group;
+        entry.amount.textContent = this._formatAmount(res.value);
+        this._updateSoftcap(name, group, res);
         this._renderMods(name, res);
     }
 };

--- a/tests/test_resources_tab_ui.py
+++ b/tests/test_resources_tab_ui.py
@@ -55,6 +55,10 @@ global.State = {
 };
 global.StatSystem = { max: r => r.baseMax };
 global.ResourceSystem = { max: r => r.baseMax };
+global.SoftCapSystem = {
+  getStatCap: name => name === 'strength' ? 15 : (name === 'wisdom' ? Infinity : undefined),
+  getResourceCap: name => name === 'energy' ? 12 : undefined
+};
 global.Lang = {
   stat: k => k,
   resource: k => k,
@@ -72,21 +76,31 @@ const out = {};
 for (const li of list) {
   const name = li.children[0].children[0].textContent;
   const amt = li.children[0].children[1].textContent;
-  const desc = li.children[1].children[0].textContent;
-  out[name] = { amount: amt, desc: desc };
+  const detail = li.children[1];
+  let desc = '';
+  let softcap = '';
+  for (const child of detail.children) {
+    if ((child.className || '').includes('resource-desc')) desc = child.textContent;
+    if ((child.className || '').includes('resource-softcap')) softcap = child.textContent;
+  }
+  out[name] = { amount: amt, desc: desc, softcap: softcap };
 }
 console.log(JSON.stringify(out));
 """
     result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
     out = json.loads(result.stdout.strip())
-    assert out['strength']['amount'] == '1.000/10.000'
-    assert out['energy']['amount'] == '5.000/10.000'
+    assert out['strength']['amount'] == '1.000'
+    assert out['energy']['amount'] == '5.000'
     assert out['wisdom']['amount'] == '2.000'
     assert out['mastery']['amount'] == '3.000'
     assert out['strength']['desc'] == 'Power'
     assert out['energy']['desc'] == 'Use'
     assert out['wisdom']['desc'] == 'Bonus'
     assert out['mastery']['desc'] == 'Mastered'
+    assert out['strength']['softcap'] == 'Softcap: 15.000'
+    assert out['energy']['softcap'] == 'Softcap: 12.000'
+    assert out['wisdom']['softcap'] == 'Softcap: ∞'
+    assert out['mastery']['softcap'] == 'Softcap: ∞'
 
 
 def test_uk_translation_resources_tab():
@@ -133,6 +147,11 @@ global.State = {
 };
 global.StatSystem = { max: r => r.baseMax };
 global.ResourceSystem = { max: r => r.baseMax };
+let cap = 10;
+global.SoftCapSystem = {
+  getResourceCap: () => cap,
+  getStatCap: () => undefined
+};
 global.Lang = {
   stat: k => k,
   resource: k => k,
@@ -149,10 +168,12 @@ global.PubSub = {
 };
 const { ResourcesTab } = require('./js/ui/resources_tab.js');
 ResourcesTab.init();
+cap = 15;
 State.resources.energy.value = 7;
 PubSub.publish('resources:updated');
-console.log(JSON.stringify({ energy: ResourcesTab.entries['energy'].amount.textContent }));
+console.log(JSON.stringify({ energy: ResourcesTab.entries['energy'].amount.textContent, softcap: ResourcesTab.entries['energy'].softcap.textContent }));
 """
     result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
     data = json.loads(result.stdout.strip())
-    assert data['energy'] == '7.000/10.000'
+    assert data['energy'] == '7.000'
+    assert data['softcap'] == 'Softcap: 15.000'


### PR DESCRIPTION
## Summary
- show only the current amount value in each resources tab entry and add a softcap line sourced from SoftCapSystem fallbacks
- refresh the stored softcap text during entry updates so changes propagate to the drawer
- extend the resources tab UI test harness to assert the new amount formatting and softcap output

## Testing
- pytest *(fails: wkhtmltoimage binary missing; berries restore data mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68cb088392f08330b7c13062b11175bd