### PR TITLE
Adjust softcap display in resource tags and encounter UI

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -478,6 +478,19 @@ main {
     font-size: var(--font-size-sm);
 }
 
+.slot .resource-tag-values {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    text-align: right;
+    gap: 0.1rem;
+}
+
+.slot .resource-tag-softcap {
+    font-size: var(--font-size-xs);
+    opacity: 0.8;
+}
+
 .progress-wrapper {
     position: relative;
     cursor: pointer;

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -56,6 +56,36 @@ function formatTagValue(value) {
     return `${value}`;
 }
 
+function getSoftcapLabel() {
+    if (typeof Lang !== 'undefined' && Lang.ui) {
+        const label = Lang.ui('Softcap');
+        if (label) return label;
+    }
+    return 'Softcap';
+}
+
+function buildTagValueElement(currentValue, maxValue) {
+    const container = document.createElement('span');
+    container.className = 'resource-tag-values';
+
+    const currentEl = document.createElement('span');
+    currentEl.className = 'resource-tag-current';
+    currentEl.textContent = formatTagValue(currentValue);
+    container.appendChild(currentEl);
+
+    if (maxValue !== Infinity) {
+        const softcapText = formatTagValue(maxValue);
+        const softcapEl = document.createElement('span');
+        softcapEl.className = 'resource-tag-softcap';
+        const label = getSoftcapLabel();
+        softcapEl.textContent = `${label} ${softcapText}`;
+        container.appendChild(softcapEl);
+        container.title = `${label} ${softcapText}`;
+    }
+
+    return container;
+}
+
 function assignActionToSlot(actionId) {
     let index = State.slots.findIndex(s => !s.actionId);
     if (index === -1) {
@@ -300,7 +330,6 @@ function updateSlotUI(i) {
             tag.className = 'resource-tag';
             const left = document.createElement('span');
             left.textContent = `${t.sign}${formatTagValue(t.amount)} ${t.name}`;
-            const right = document.createElement('span');
             let current = 0;
             let max = Infinity;
             if (t.type === 'resource') {
@@ -320,11 +349,7 @@ function updateSlotUI(i) {
                     }
                 }
             }
-            const formattedCurrent = formatTagValue(current);
-            const formattedMax = formatTagValue(max);
-            right.textContent = max === Infinity
-                ? `${formattedCurrent}`
-                : `${formattedCurrent}/${formattedMax}`;
+            const right = buildTagValueElement(current, max);
             tag.appendChild(left);
             tag.appendChild(right);
             tagsEl.appendChild(tag);
@@ -414,7 +439,6 @@ function updateAdventureSlotUI(i) {
                 const left = document.createElement('span');
                 const name = typeof Lang !== 'undefined' && Lang.resource ? (Lang.resource(r) || r) : r;
                 left.textContent = `-${formatTagValue(cost[r])} ${name}`;
-                const right = document.createElement('span');
                 let current = 0;
                 let max = Infinity;
                 const res = State.resources && State.resources[r];
@@ -424,11 +448,7 @@ function updateAdventureSlotUI(i) {
                         max = ResourceSystem.max(res);
                     }
                 }
-                const formattedCurrent = formatTagValue(current);
-                const formattedMax = formatTagValue(max);
-                right.textContent = max === Infinity
-                    ? `${formattedCurrent}`
-                    : `${formattedCurrent}/${formattedMax}`;
+                const right = buildTagValueElement(current, max);
                 tag.appendChild(left);
                 tag.appendChild(right);
                 tagsEl.appendChild(tag);

--- a/js/ui/encounter.js
+++ b/js/ui/encounter.js
@@ -11,6 +11,14 @@ if (typeof formatNumber === 'undefined' && typeof require !== 'undefined') {
     }
 }
 
+function getSoftcapLabel() {
+    if (typeof Lang !== 'undefined' && Lang.ui) {
+        const label = Lang.ui('Softcap');
+        if (label) return label;
+    }
+    return 'Softcap';
+}
+
 const EncounterUI = {
     init() {
         if (typeof PubSub !== 'undefined') {
@@ -31,8 +39,13 @@ const EncounterUI = {
         const el = document.getElementById('encounter-location');
         if (el) {
             const currentLevel = formatNumber(EncounterGenerator.level);
-            const maxLevel = formatNumber(State.maxEncounterLevel);
-            el.textContent = `${name} (Level ${currentLevel} (Max ${maxLevel}))`;
+            const maxLevelValue = typeof State !== 'undefined' ? State.maxEncounterLevel : undefined;
+            let softcapPart = '';
+            if (typeof maxLevelValue === 'number' && Number.isFinite(maxLevelValue)) {
+                const maxLevel = formatNumber(maxLevelValue);
+                softcapPart = `, ${getSoftcapLabel()} ${maxLevel}`;
+            }
+            el.textContent = `${name} (Level ${currentLevel}${softcapPart})`;
         }
     },
     updateProgressBar() {

--- a/tests/test_encounter_ui_display.py
+++ b/tests/test_encounter_ui_display.py
@@ -1,0 +1,51 @@
+import json
+import subprocess
+
+
+def test_encounter_ui_uses_softcap_label():
+    script = r"""
+class Elem {
+    constructor(tag) {
+        this.tagName = tag;
+        this.children = [];
+        this.textContent = '';
+    }
+    appendChild(ch) { this.children.push(ch); }
+}
+
+const locationEl = new Elem('div');
+const progressEl = new Elem('progress');
+
+global.document = {
+    getElementById: id => {
+        if (id === 'encounter-location') return locationEl;
+        if (id === 'encounter-level-progress') return progressEl;
+        return null;
+    }
+};
+
+global.EncounterGenerator = {
+    level: 3,
+    milestones: [
+        { level: 1, name: 'Forest' },
+        { level: 5, name: 'Ruins' }
+    ]
+};
+
+global.State = { maxEncounterLevel: 5, encounterStreak: 0 };
+global.PubSub = { subscribe: () => {} };
+
+const { EncounterUI } = require('./js/ui/encounter.js');
+
+EncounterUI.updateName();
+console.log(JSON.stringify(locationEl.textContent));
+
+State.maxEncounterLevel = Infinity;
+EncounterUI.updateName();
+console.log(JSON.stringify(locationEl.textContent));
+"""
+    result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
+    lines = [json.loads(line) for line in result.stdout.strip().splitlines()]
+    assert lines[0] == 'Forest (Level 3.000, Softcap 5.000)'
+    assert 'Max' not in lines[0]
+    assert lines[1] == 'Forest (Level 3.000)'

--- a/tests/test_slot_resource_tags.py
+++ b/tests/test_slot_resource_tags.py
@@ -101,15 +101,21 @@ global.Lang = { ui: () => '', stat: s => s, resource: r => r };
 
 updateSlotUI(0);
 const tagsEl = slot.el.querySelector('.resource-tags');
-const texts = tagsEl.children.map(ch => ch.children.map(c => c.textContent));
-console.log(JSON.stringify(texts));
+const rows = tagsEl.children.map(tag => {
+    const left = tag.children[0] ? tag.children[0].textContent : '';
+    const right = tag.children[1];
+    const current = right && right.children[0] ? right.children[0].textContent : (right ? right.textContent : '');
+    const softcap = right && right.children[1] ? right.children[1].textContent : null;
+    return [left, current, softcap];
+});
+console.log(JSON.stringify(rows));
 """
     result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
     data = json.loads(result.stdout.strip())
     assert data == [
-        ['-1.000 gold', '5.000/10.000'],
-        ['-1.000 mana', '3.000/5.000'],
-        ['+2.000 food', '7.000/15.000'],
-        ['+3.000 strength', '8.000/20.000']
+        ['-1.000 gold', '5.000', 'Softcap 10.000'],
+        ['-1.000 mana', '3.000', 'Softcap 5.000'],
+        ['+2.000 food', '7.000', 'Softcap 15.000'],
+        ['+3.000 strength', '8.000', 'Softcap 20.000']
     ]
 


### PR DESCRIPTION
## Summary
- update slot resource/stat tags to show the current value with an optional softcap label and refresh the supporting styles
- switch the encounter header to mention the softcap instead of the previous Max wording and add coverage for the new text
- refresh slot resource tag tests for the new markup and add an encounter UI assertion

## Testing
- pytest *(fails: wkhtmltoimage missing, existing consumable restoration expectation)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0889bde883308f33841d87d8ae6a