### PR TITLE
Refine prestige soft cap recalculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Soft caps now apply prestige boosts through a dedicated SoftCapSystem multiplier helper, keeping stat max arrays untouched.
+- Berries consumables now restore dexterity alongside other stats to match restoration rules.
 - Consumable item descriptions and consumption logic now only reference stat bonuses, warning if a stat key is missing instead of silently treating it as a resource.
 - Reworked consumable item tests to enforce stat-only restoration keys and added a regression case proving soft-cap diminishing returns when consuming stat boosts.
 - Rebalanced consumable stat bonuses and show their effects as localized stat increases in the inventory tooltip.

--- a/data/items.json
+++ b/data/items.json
@@ -156,6 +156,7 @@
         "type": "consumable",
         "restore": {
             "strength": 1,
+            "dexterity": 1,
             "intelligence": 2
         },
         "image": "assets/user_uploaded/berries.jpg",

--- a/js/prestige.js
+++ b/js/prestige.js
@@ -4,8 +4,13 @@ function applyPrestigeBonuses() {
     STAT_KEYS.forEach(k => {
         const pKey = PRESTIGE_MAP[k];
         const p = State.prestige[pKey] ? State.prestige[pKey].value : 0;
-        if (State.stats[k]) {
-            setState(['stats', k, 'maxMultipliers'], [1 + p * 0.02]);
+        if (
+            State.stats[k] &&
+            typeof SoftCapSystem !== 'undefined' &&
+            SoftCapSystem &&
+            typeof SoftCapSystem.bumpStatCap === 'function'
+        ) {
+            SoftCapSystem.bumpStatCap(k, 1 + p * 0.02);
         }
         if (typeof BonusEngine !== 'undefined') {
             BonusEngine.statMultipliers[k] = 1 + p * 0.05;

--- a/js/soft_cap.js
+++ b/js/soft_cap.js
@@ -4,6 +4,7 @@ const SoftCapSystem = {
     baseResourceCaps: { energy: 20, focus: 20, health: 10 },
     statCaps: {},
     resourceCaps: {},
+    statCapMultipliers: {},
     recalculateCaps() {
         this.statCaps = { ...this.baseStatCaps };
         this.resourceCaps = { ...this.baseResourceCaps };
@@ -37,9 +38,28 @@ const SoftCapSystem = {
         Object.keys(State.stats).forEach(key => {
             const stat = State.stats[key];
             if (stat) {
-                this.statCaps[key] = StatSystem.max(stat);
+                const baseCap = StatSystem.max(stat);
+                const multiplier = this._statMultiplierFor(key);
+                this.statCaps[key] = baseCap * multiplier;
             }
         });
+    },
+    bumpStatCap(name, multiplier) {
+        if (!name) return;
+        const numeric = Number(multiplier);
+        if (!Number.isFinite(numeric) || numeric <= 0 || numeric === 1) {
+            delete this.statCapMultipliers[name];
+        } else {
+            this.statCapMultipliers[name] = numeric;
+        }
+        if (!State.stats || !State.stats[name]) {
+            delete this.statCaps[name];
+            return;
+        }
+        const stat = State.stats[name];
+        const baseCap = StatSystem.max(stat);
+        const effectiveMultiplier = this._statMultiplierFor(name);
+        this.statCaps[name] = baseCap * effectiveMultiplier;
     },
     apply() {
         this.refreshCaps();
@@ -58,9 +78,18 @@ const SoftCapSystem = {
             return this.statCaps[name];
         }
         if (this.statCaps[name] === undefined) {
-            this.statCaps[name] = StatSystem.max(State.stats[name]);
+            const baseCap = StatSystem.max(State.stats[name]);
+            const multiplier = this._statMultiplierFor(name);
+            this.statCaps[name] = baseCap * multiplier;
         }
         return this.statCaps[name];
+    },
+    _statMultiplierFor(name) {
+        const mult = this.statCapMultipliers[name];
+        if (!Number.isFinite(mult) || mult <= 0) {
+            return 1;
+        }
+        return mult;
     }
 };
 

--- a/tests/test_prestige.py
+++ b/tests/test_prestige.py
@@ -3,6 +3,16 @@ import os
 import subprocess
 import textwrap
 
+
+def _run_node(script: str):
+    result = subprocess.run(
+        ['node', '-e', script],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout.strip())
+
 def test_prestige_button_exists():
     with open('index.html') as f:
         html = f.read()
@@ -29,6 +39,57 @@ def test_prestige_bonus_applied():
     with open(path) as f:
         text = f.read()
     assert 'applyPrestigeBonuses()' in text
+
+
+def test_prestige_soft_cap_bonus_updates_caps_only():
+    script = textwrap.dedent(
+        """
+        const { State, ResourceSystem, StatSystem, setState, PRESTIGE_MAP } = require('./js/state.js');
+        global.State = State;
+        global.ResourceSystem = ResourceSystem;
+        global.StatSystem = StatSystem;
+        global.setState = setState;
+        global.PRESTIGE_MAP = PRESTIGE_MAP;
+        global.STAT_KEYS = ['strength'];
+        const { SoftCapSystem } = require('./js/soft_cap.js');
+        global.SoftCapSystem = SoftCapSystem;
+        global.BonusEngine = { statMultipliers: {} };
+
+        const { applyPrestigeBonuses } = require('./js/prestige.js');
+
+        State.stats = { strength: StatSystem.create(0, 50, 'strength') };
+        State.stats.strength.maxMultipliers = [0];
+        State.prestige = { constitution: StatSystem.create(5, Infinity, 'constitution') };
+
+        SoftCapSystem.recalculateCaps();
+        const beforeSoftCap = SoftCapSystem.getStatCap('strength');
+        const beforeRawCap = StatSystem.max(State.stats.strength);
+        const beforeMultipliers = (State.stats.strength.maxMultipliers || []).slice();
+
+        applyPrestigeBonuses();
+
+        const afterSoftCap = SoftCapSystem.getStatCap('strength');
+        const afterRawCap = StatSystem.max(State.stats.strength);
+        const afterMultipliers = (State.stats.strength.maxMultipliers || []).slice();
+        const bonusMultiplier = BonusEngine.statMultipliers.strength;
+
+        console.log(JSON.stringify({
+            beforeSoftCap,
+            afterSoftCap,
+            beforeRawCap,
+            afterRawCap,
+            beforeMultipliers,
+            afterMultipliers,
+            bonusMultiplier
+        }));
+        """
+    )
+    data = _run_node(script)
+    assert data['beforeSoftCap'] == data['beforeRawCap']
+    assert round(data['afterSoftCap'], 6) == round(data['beforeSoftCap'] * 1.1, 6)
+    assert data['afterRawCap'] == data['beforeRawCap']
+    assert data['beforeMultipliers'] == data['afterMultipliers'] == [0]
+    assert round(data['bonusMultiplier'], 6) == round(1 + 5 * 0.05, 6)
 
 
 def test_prestige_summary_removed():

--- a/tests/test_soft_caps_behavior.py
+++ b/tests/test_soft_caps_behavior.py
@@ -77,3 +77,49 @@ def test_stats_exceed_soft_cap_with_diminishing_returns():
     assert data['afterFirst'] > data['cap']
     assert 0 < data['gainSecond'] < 10
     assert 0 < data['gainThird'] < data['gainSecond']
+
+
+def test_refresh_caps_uses_stat_multiplier_without_touching_state():
+    script = textwrap.dedent(
+        """
+        const { State, ResourceSystem, StatSystem, setState } = require('./js/state.js');
+        global.State = State;
+        global.ResourceSystem = ResourceSystem;
+        global.StatSystem = StatSystem;
+        global.setState = setState;
+        const { SoftCapSystem } = require('./js/soft_cap.js');
+        global.SoftCapSystem = SoftCapSystem;
+
+        State.stats = { strength: StatSystem.create(0, 50, 'strength') };
+        const beforeMultipliers = (State.stats.strength.maxMultipliers || []).slice();
+
+        SoftCapSystem.recalculateCaps();
+        const baseSoftCap = SoftCapSystem.getStatCap('strength');
+        const baseRawCap = StatSystem.max(State.stats.strength);
+
+        SoftCapSystem.bumpStatCap('strength', 1.5);
+        SoftCapSystem.refreshCaps();
+        const afterRefresh = SoftCapSystem.getStatCap('strength');
+        const rawAfterRefresh = StatSystem.max(State.stats.strength);
+        const afterMultipliers = (State.stats.strength.maxMultipliers || []).slice();
+
+        SoftCapSystem.recalculateCaps();
+        const afterRecalc = SoftCapSystem.getStatCap('strength');
+
+        console.log(JSON.stringify({
+            baseSoftCap,
+            baseRawCap,
+            afterRefresh,
+            rawAfterRefresh,
+            afterRecalc,
+            beforeMultipliers,
+            afterMultipliers
+        }));
+        """
+    )
+    data = _run_node(script)
+    assert data['baseSoftCap'] == data['baseRawCap']
+    assert round(data['afterRefresh'], 6) == round(data['baseSoftCap'] * 1.5, 6)
+    assert data['rawAfterRefresh'] == data['baseRawCap']
+    assert data['afterRecalc'] == data['afterRefresh']
+    assert data['beforeMultipliers'] == data['afterMultipliers']


### PR DESCRIPTION
## Summary
- add a SoftCapSystem multiplier map and `bumpStatCap` helper so refresh logic applies prestige adjustments without touching stat max arrays
- switch `applyPrestigeBonuses` to use the new helper while keeping BonusEngine boosts and add coverage for the behavior
- align berries consumable data with stat restoration expectations and update the changelog

## Testing
- pytest *(fails: `wkhtmltoimage` not installed in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cb088bd65083308a0f627f3e4fc229