### PR TITLE
Remove softcap labels from slot tags

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -486,11 +486,6 @@ main {
     gap: 0.1rem;
 }
 
-.slot .resource-tag-softcap {
-    font-size: var(--font-size-xs);
-    opacity: 0.8;
-}
-
 .progress-wrapper {
     position: relative;
     cursor: pointer;

--- a/js/slotSetup.js
+++ b/js/slotSetup.js
@@ -56,36 +56,6 @@ function formatTagValue(value) {
     return `${value}`;
 }
 
-function getSoftcapLabel() {
-    if (typeof Lang !== 'undefined' && Lang.ui) {
-        const label = Lang.ui('Softcap');
-        if (label) return label;
-    }
-    return 'Softcap';
-}
-
-function buildTagValueElement(currentValue, maxValue) {
-    const container = document.createElement('span');
-    container.className = 'resource-tag-values';
-
-    const currentEl = document.createElement('span');
-    currentEl.className = 'resource-tag-current';
-    currentEl.textContent = formatTagValue(currentValue);
-    container.appendChild(currentEl);
-
-    if (maxValue !== Infinity) {
-        const softcapText = formatTagValue(maxValue);
-        const softcapEl = document.createElement('span');
-        softcapEl.className = 'resource-tag-softcap';
-        const label = getSoftcapLabel();
-        softcapEl.textContent = `${label} ${softcapText}`;
-        container.appendChild(softcapEl);
-        container.title = `${label} ${softcapText}`;
-    }
-
-    return container;
-}
-
 function assignActionToSlot(actionId) {
     let index = State.slots.findIndex(s => !s.actionId);
     if (index === -1) {
@@ -331,27 +301,25 @@ function updateSlotUI(i) {
             const left = document.createElement('span');
             left.textContent = `${t.sign}${formatTagValue(t.amount)} ${t.name}`;
             let current = 0;
-            let max = Infinity;
             if (t.type === 'resource') {
                 const res = State.resources && State.resources[t.key];
                 if (res) {
                     current = res.value;
-                    if (typeof ResourceSystem !== 'undefined' && ResourceSystem.max) {
-                        max = ResourceSystem.max(res);
-                    }
                 }
             } else {
                 const stat = State.stats && State.stats[t.key];
                 if (stat) {
                     current = stat.value;
-                    if (typeof StatSystem !== 'undefined' && StatSystem.max) {
-                        max = StatSystem.max(stat);
-                    }
                 }
             }
-            const right = buildTagValueElement(current, max);
+            const valuesEl = document.createElement('span');
+            valuesEl.className = 'resource-tag-values';
+            const currentEl = document.createElement('span');
+            currentEl.className = 'resource-tag-current';
+            currentEl.textContent = formatTagValue(current);
+            valuesEl.appendChild(currentEl);
             tag.appendChild(left);
-            tag.appendChild(right);
+            tag.appendChild(valuesEl);
             tagsEl.appendChild(tag);
         }
     }
@@ -440,17 +408,18 @@ function updateAdventureSlotUI(i) {
                 const name = typeof Lang !== 'undefined' && Lang.resource ? (Lang.resource(r) || r) : r;
                 left.textContent = `-${formatTagValue(cost[r])} ${name}`;
                 let current = 0;
-                let max = Infinity;
                 const res = State.resources && State.resources[r];
                 if (res) {
                     current = res.value;
-                    if (typeof ResourceSystem !== 'undefined' && ResourceSystem.max) {
-                        max = ResourceSystem.max(res);
-                    }
                 }
-                const right = buildTagValueElement(current, max);
+                const valuesEl = document.createElement('span');
+                valuesEl.className = 'resource-tag-values';
+                const currentEl = document.createElement('span');
+                currentEl.className = 'resource-tag-current';
+                currentEl.textContent = formatTagValue(current);
+                valuesEl.appendChild(currentEl);
                 tag.appendChild(left);
-                tag.appendChild(right);
+                tag.appendChild(valuesEl);
                 tagsEl.appendChild(tag);
             }
         }

--- a/tests/test_slot_resource_tags.py
+++ b/tests/test_slot_resource_tags.py
@@ -113,9 +113,9 @@ console.log(JSON.stringify(rows));
     result = subprocess.run(['node', '-e', script], capture_output=True, text=True, check=True)
     data = json.loads(result.stdout.strip())
     assert data == [
-        ['-1.000 gold', '5.000', 'Softcap 10.000'],
-        ['-1.000 mana', '3.000', 'Softcap 5.000'],
-        ['+2.000 food', '7.000', 'Softcap 15.000'],
-        ['+3.000 strength', '8.000', 'Softcap 20.000']
+        ['-1.000 gold', '5.000', None],
+        ['-1.000 mana', '3.000', None],
+        ['+2.000 food', '7.000', None],
+        ['+3.000 strength', '8.000', None]
     ]
 


### PR DESCRIPTION
## Summary
- render current resource and stat values directly in slot and adventure resource tags
- remove the unused softcap styling and update slot resource tag tests

## Testing
- pytest (fails: wkhtmltoimage not installed)


------
https://chatgpt.com/codex/tasks/task_e_68cc153489bc8330ad399ed55e4bfea9