### PR TITLE
Respect soft cap thresholds before resuming adventure queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Adventure encounters resume queued runs once resources reach soft-cap limits or encounter costs, ensuring retreats recover to achievable thresholds and adding regression coverage.
 - Soft caps now apply prestige boosts through a dedicated SoftCapSystem multiplier helper, keeping stat max arrays untouched.
 - Berries consumables now restore dexterity alongside other stats to match restoration rules.
 - Consumable item descriptions and consumption logic now only reference stat bonuses, warning if a stat key is missing instead of silently treating it as a resource.

--- a/js/adventure_engine.js
+++ b/js/adventure_engine.js
@@ -71,10 +71,7 @@ const AdventureEngine = {
 
                 if (queue.restart) {
                     const resources = Array.isArray(queue.resources) ? queue.resources : [];
-                    const ready = resources.length === 0 || resources.every(r => {
-                        const res = State.resources[r];
-                        return res && res.value >= ResourceSystem.max(res);
-                    });
+                    const ready = resources.length === 0 || resources.every(r => resourceAtQueueThreshold(r));
                     if (ready) {
                         slot.queue = null;
                         this.start();
@@ -83,10 +80,14 @@ const AdventureEngine = {
                 }
 
                 if (queue.encounter) {
-                    const cost = queue.encounter.getResourceCost();
-                    const ready = Object.keys(cost).every(r => {
-                        const res = State.resources[r];
-                        return res && res.value >= ResourceSystem.max(res);
+                    const cost = typeof queue.encounter.getResourceCost === 'function' ?
+                        queue.encounter.getResourceCost() || {} : {};
+                    const costKeys = Object.keys(cost);
+                    const ready = costKeys.length === 0 || costKeys.every(r => {
+                        const rawCost = cost[r];
+                        const numericCost = Number(rawCost);
+                        const threshold = Number.isNaN(numericCost) ? undefined : numericCost;
+                        return resourceAtQueueThreshold(r, threshold);
                     });
                     if (ready) {
                         slot.encounter = queue.encounter;
@@ -174,6 +175,55 @@ function checkHealth() {
             retreat(name);
         }
     }
+}
+
+function resolveQueueResourceCap(name) {
+    if (typeof State === 'undefined' || !State || !State.resources) {
+        return undefined;
+    }
+    const res = State.resources[name];
+    if (!res) {
+        return undefined;
+    }
+    if (
+        typeof SoftCapSystem !== 'undefined' &&
+        SoftCapSystem &&
+        typeof SoftCapSystem.getResourceCap === 'function'
+    ) {
+        const cap = SoftCapSystem.getResourceCap(name);
+        if (cap !== undefined && cap !== null) {
+            return cap;
+        }
+    }
+    if (
+        typeof ResourceSystem !== 'undefined' &&
+        ResourceSystem &&
+        typeof ResourceSystem.max === 'function'
+    ) {
+        return ResourceSystem.max(res);
+    }
+    if (res.baseMax !== undefined) {
+        return res.baseMax;
+    }
+    return undefined;
+}
+
+function resourceAtQueueThreshold(name, explicitThreshold) {
+    if (typeof State === 'undefined' || !State || !State.resources) {
+        return false;
+    }
+    const res = State.resources[name];
+    if (!res || typeof res.value !== 'number') {
+        return false;
+    }
+    if (typeof explicitThreshold === 'number' && !Number.isNaN(explicitThreshold)) {
+        return res.value >= explicitThreshold;
+    }
+    const cap = resolveQueueResourceCap(name);
+    if (cap === undefined) {
+        return res.value > 0;
+    }
+    return res.value >= cap;
 }
 
 if (typeof module !== 'undefined') {

--- a/tests/test_adventure_encounter_queue_resume.py
+++ b/tests/test_adventure_encounter_queue_resume.py
@@ -1,0 +1,116 @@
+import json
+import subprocess
+
+
+SCRIPT = r"""
+const state = require('./js/state.js');
+const { EncounterGenerator } = require('./js/encounter.js');
+
+global.State = state.State;
+global.setState = state.setState;
+global.updateState = state.updateState;
+global.ResourceSystem = state.ResourceSystem;
+global.actions = { rest: { name: 'Rest', progress: 0 } };
+global.PubSub = { publish: () => {} };
+global.updateSlotUI = () => {};
+global.updateAdventureSlotUI = () => {};
+global.ItemGenerator = { itemList: [], generateFromEncounter: () => null };
+global.Inventory = { add: () => {} };
+global.Lang = { log: () => '', resource: () => '' };
+global.Log = { add: () => {} };
+global.StorySystem = { trigger: () => {} };
+global.EncounterGenerator = EncounterGenerator;
+
+global.SoftCapSystem = {
+    getResourceCap(name) {
+        if (name === 'energy') return 8;
+        return undefined;
+    },
+    recalculateCaps: () => {},
+    refreshCaps: () => {}
+};
+
+const { AdventureEngine } = require('./js/adventure_engine.js');
+
+const testEncounter = {
+    id: 'queued',
+    name: 'Queued Encounter',
+    getDuration() { return 1; },
+    getResourceCost() { return { energy: 6 }; }
+};
+
+EncounterGenerator.randomEncounter = () => testEncounter;
+EncounterGenerator.updateName = () => {};
+EncounterGenerator.updateProgressBar = () => {};
+EncounterGenerator.populateSlots = EncounterGenerator.populateSlots || (() => {});
+EncounterGenerator.decrementLevel = () => {};
+EncounterGenerator.resetProgress = () => {};
+
+State.resources.energy = state.ResourceSystem.create(0, 10, 'energy');
+State.resources.energy.value = 10;
+State.resources.focus = state.ResourceSystem.create(10, 10, 'focus');
+State.resources.health = state.ResourceSystem.create(10, 10, 'health');
+
+AdventureEngine.start();
+
+const slot = State.adventureSlots[0];
+const queuedEncounter = slot.encounter;
+const queuedProgress = slot.progress;
+
+State.resources.energy.value = 0;
+
+AdventureEngine.cancel();
+
+slot.queue = { encounter: queuedEncounter, progress: queuedProgress };
+slot.encounter = null;
+slot.active = false;
+
+const snapshots = [];
+
+AdventureEngine.tick(1);
+snapshots.push({ step: 'zero', active: AdventureEngine.active, queue: !!slot.queue });
+
+State.resources.energy.value = 5;
+AdventureEngine.tick(1);
+snapshots.push({ step: 'belowCost', active: AdventureEngine.active, queue: !!slot.queue });
+
+State.resources.energy.value = 6;
+AdventureEngine.tick(1);
+snapshots.push({ step: 'atCost', active: AdventureEngine.active, queue: !!slot.queue, encounterId: slot.encounter && slot.encounter.id });
+
+console.log(JSON.stringify({
+    snapshots,
+    finalActive: AdventureEngine.active,
+    finalActiveIndex: AdventureEngine.activeIndex,
+    finalQueue: slot.queue,
+    finalEncounterId: slot.encounter && slot.encounter.id
+}));
+"""
+
+
+def run_script():
+    proc = subprocess.run(['node', '-e', SCRIPT], capture_output=True, text=True, check=True)
+    return json.loads(proc.stdout.strip())
+
+
+def test_queued_encounter_resumes_at_cost_threshold():
+    data = run_script()
+
+    assert len(data['snapshots']) == 3
+    snapshots = {entry['step']: entry for entry in data['snapshots']}
+
+    assert snapshots['zero']['active'] is False
+    assert snapshots['zero']['queue'] is True
+
+    assert snapshots['belowCost']['active'] is False
+    assert snapshots['belowCost']['queue'] is True
+
+    at_cost = snapshots['atCost']
+    assert at_cost['active'] is True
+    assert at_cost['queue'] is False
+    assert at_cost['encounterId'] == 'queued'
+
+    assert data['finalActive'] is True
+    assert data['finalQueue'] is None
+    assert data['finalEncounterId'] == 'queued'
+    assert data['finalActiveIndex'] == 0


### PR DESCRIPTION
## Summary
- ensure adventure restart queues wait for soft cap resource caps and queued encounters wait for their resource costs
- add shared helpers for queue readiness checks and cover the encounter threshold with a regression test
- document the soft-cap-aware auto-resume fix in the changelog

## Testing
- pytest *(fails: `wkhtmltoimage` is not available in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc153ee3bc8330a8067b20f0a5caa6