### PR TITLE
Update action queue resource thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Action engine now resumes queued actions once resources meet upfront costs or soft-cap thresholds via a shared queue helper, honoring pre-paid costs and extending regression coverage.
 - Adventure encounters resume queued runs once resources reach soft-cap limits or encounter costs, ensuring retreats recover to achievable thresholds and adding regression coverage.
 - Soft caps now apply prestige boosts through a dedicated SoftCapSystem multiplier helper, keeping stat max arrays untouched.
 - Berries consumables now restore dexterity alongside other stats to match restoration rules.

--- a/index.html
+++ b/index.html
@@ -223,6 +223,7 @@
     <script src="js/prestige.js"></script>
     <script src="js/action_utils.js"></script>
     <script src="js/engine.js"></script>
+    <script src="js/resource_queue_helpers.js"></script>
     <script src="js/action_engine.js"></script>
     <script src="js/adventure_engine.js"></script>
     <script src="js/ui/adventure.js"></script>

--- a/js/action_engine.js
+++ b/js/action_engine.js
@@ -3,6 +3,15 @@
 // FurnitureSystem, SoftCapSystem, SaveSystem
 // Exports: ActionEngine
 
+let queueResourceHelpers = null;
+if (typeof module !== 'undefined' && module.exports) {
+    try {
+        queueResourceHelpers = require('./resource_queue_helpers.js');
+    } catch (err) {
+        queueResourceHelpers = null;
+    }
+}
+
 const ActionEngine = {
     start(slotIndex, actionId) {
         if (typeof AdventureEngine !== 'undefined' && AdventureEngine.active) {
@@ -54,20 +63,16 @@ const ActionEngine = {
                 const qAction = actions[slot.queue.id];
                 let canResume = true;
                 if (qAction.resourceCost && !slot.queue.costPaid) {
-                    // resume only when cost resources are fully replenished
                     for (const r in qAction.resourceCost) {
-                        const res = State.resources[r];
-                        if (!res || res.value !== ResourceSystem.max(res)) {
+                        if (!queueResourceAtThreshold(r, qAction.resourceCost[r])) {
                             canResume = false;
                             break;
                         }
                     }
                 }
                 if (canResume && qAction.resourceConsumption) {
-                    // consumption resources must also be at maximum before resuming
                     for (const r in qAction.resourceConsumption) {
-                        const res = State.resources[r];
-                        if (!res || res.value !== ResourceSystem.max(res)) {
+                        if (!queueResourceAtThreshold(r)) {
                             canResume = false;
                             break;
                         }
@@ -161,6 +166,18 @@ const ActionEngine = {
         SaveSystem.save();
     }
 };
+
+function queueResourceAtThreshold(name, explicitThreshold) {
+    const helper = queueResourceHelpers ||
+        (typeof QueueResourceHelper !== 'undefined' ? QueueResourceHelper : null);
+    if (helper && typeof helper.resourceAtQueueThreshold === 'function') {
+        return helper.resourceAtQueueThreshold(name, explicitThreshold);
+    }
+    if (typeof resourceAtQueueThreshold === 'function') {
+        return resourceAtQueueThreshold(name, explicitThreshold);
+    }
+    return false;
+}
 
 if (typeof module !== 'undefined') {
     module.exports = { ActionEngine };

--- a/js/adventure_engine.js
+++ b/js/adventure_engine.js
@@ -1,5 +1,14 @@
 // AdventureEngine handles encounter slots and retreat logic
 
+let queueResourceHelpers = null;
+if (typeof module !== 'undefined' && module.exports) {
+    try {
+        queueResourceHelpers = require('./resource_queue_helpers.js');
+    } catch (err) {
+        queueResourceHelpers = null;
+    }
+}
+
 const AdventureEngine = {
     activeIndex: null,
     active: false,
@@ -178,52 +187,21 @@ function checkHealth() {
 }
 
 function resolveQueueResourceCap(name) {
-    if (typeof State === 'undefined' || !State || !State.resources) {
-        return undefined;
-    }
-    const res = State.resources[name];
-    if (!res) {
-        return undefined;
-    }
-    if (
-        typeof SoftCapSystem !== 'undefined' &&
-        SoftCapSystem &&
-        typeof SoftCapSystem.getResourceCap === 'function'
-    ) {
-        const cap = SoftCapSystem.getResourceCap(name);
-        if (cap !== undefined && cap !== null) {
-            return cap;
-        }
-    }
-    if (
-        typeof ResourceSystem !== 'undefined' &&
-        ResourceSystem &&
-        typeof ResourceSystem.max === 'function'
-    ) {
-        return ResourceSystem.max(res);
-    }
-    if (res.baseMax !== undefined) {
-        return res.baseMax;
+    const helper = queueResourceHelpers ||
+        (typeof QueueResourceHelper !== 'undefined' ? QueueResourceHelper : null);
+    if (helper && typeof helper.resolveQueueResourceCap === 'function') {
+        return helper.resolveQueueResourceCap(name);
     }
     return undefined;
 }
 
 function resourceAtQueueThreshold(name, explicitThreshold) {
-    if (typeof State === 'undefined' || !State || !State.resources) {
-        return false;
+    const helper = queueResourceHelpers ||
+        (typeof QueueResourceHelper !== 'undefined' ? QueueResourceHelper : null);
+    if (helper && typeof helper.resourceAtQueueThreshold === 'function') {
+        return helper.resourceAtQueueThreshold(name, explicitThreshold);
     }
-    const res = State.resources[name];
-    if (!res || typeof res.value !== 'number') {
-        return false;
-    }
-    if (typeof explicitThreshold === 'number' && !Number.isNaN(explicitThreshold)) {
-        return res.value >= explicitThreshold;
-    }
-    const cap = resolveQueueResourceCap(name);
-    if (cap === undefined) {
-        return res.value > 0;
-    }
-    return res.value >= cap;
+    return false;
 }
 
 if (typeof module !== 'undefined') {

--- a/js/resource_queue_helpers.js
+++ b/js/resource_queue_helpers.js
@@ -1,0 +1,60 @@
+(function (global) {
+    function resolveQueueResourceCap(name) {
+        if (typeof State === 'undefined' || !State || !State.resources) {
+            return undefined;
+        }
+        const res = State.resources[name];
+        if (!res) {
+            return undefined;
+        }
+        if (
+            typeof SoftCapSystem !== 'undefined' &&
+            SoftCapSystem &&
+            typeof SoftCapSystem.getResourceCap === 'function'
+        ) {
+            const cap = SoftCapSystem.getResourceCap(name);
+            if (cap !== undefined && cap !== null) {
+                return cap;
+            }
+        }
+        if (
+            typeof ResourceSystem !== 'undefined' &&
+            ResourceSystem &&
+            typeof ResourceSystem.max === 'function'
+        ) {
+            return ResourceSystem.max(res);
+        }
+        if (res.baseMax !== undefined) {
+            return res.baseMax;
+        }
+        return undefined;
+    }
+
+    function resourceAtQueueThreshold(name, explicitThreshold) {
+        if (typeof State === 'undefined' || !State || !State.resources) {
+            return false;
+        }
+        const res = State.resources[name];
+        if (!res || typeof res.value !== 'number') {
+            return false;
+        }
+        if (typeof explicitThreshold === 'number' && !Number.isNaN(explicitThreshold)) {
+            return res.value >= explicitThreshold;
+        }
+        const cap = resolveQueueResourceCap(name);
+        if (cap === undefined) {
+            return res.value > 0;
+        }
+        return res.value >= cap;
+    }
+
+    const helpers = { resolveQueueResourceCap, resourceAtQueueThreshold };
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = helpers;
+    } else {
+        global.QueueResourceHelper = helpers;
+        global.resolveQueueResourceCap = resolveQueueResourceCap;
+        global.resourceAtQueueThreshold = resourceAtQueueThreshold;
+    }
+}(typeof globalThis !== 'undefined' ? globalThis : this));

--- a/tests/test_action_queue.py
+++ b/tests/test_action_queue.py
@@ -16,21 +16,22 @@ def test_queue_slot_styles_defined():
     assert '.resource-tags' in text and '.resource-tag' in text
 
 
-def test_action_repeats_queues_and_resumes_at_max():
+def test_action_queue_resumes_at_thresholds():
     script = r"""
 const { ActionEngine } = require('./js/action_engine.js');
+let publishCount = 0;
 global.State = {
     defaultActionId: 'idle',
     time: 1,
     slots: [{ actionId: 'idle', progress: 0, blocked: false, text: '', queue: null }],
     resources: {
-        gold: { value: 2, baseMax: 2, maxAdditions: [], maxMultipliers: [] },
-        mana: { value: 2, baseMax: 2, maxAdditions: [], maxMultipliers: [] }
+        gold: { value: 4, baseMax: 5, maxAdditions: [], maxMultipliers: [] },
+        mana: { value: 4, baseMax: 6, maxAdditions: [], maxMultipliers: [] }
     }
 };
 global.actions = {
     idle: { name: 'Idle', progress: 0 },
-    work: { name: 'Work', progress: 0, resourceCost: { gold: 1 }, resourceConsumption: { mana: 1 } }
+    work: { name: 'Work', progress: 0, resourceCost: { gold: 2 }, resourceConsumption: { mana: 1 } }
 };
 global.ResourceSystem = {
     max: res => res.baseMax,
@@ -49,38 +50,89 @@ global.canAfford = (costs, delta) => {
 global.scalingMultiplier = () => 1;
 global.applyYield = () => {};
 global.gainExp = () => {};
-global.PubSub = { publish: () => {} };
-global.SoftCapSystem = { apply: () => {} };
+global.PubSub = {
+    publish: event => {
+        if (event === 'resources:updated') publishCount += 1;
+    }
+};
+global.SoftCapSystem = {
+    apply: () => {},
+    getResourceCap: name => name === 'mana' ? 4 : undefined
+};
 global.checkHealth = () => {};
 global.SaveSystem = { save: () => {} };
 
+const states = [];
+function snapshot(label) {
+    states.push({
+        label,
+        slot: JSON.parse(JSON.stringify(State.slots[0])),
+        resources: JSON.parse(JSON.stringify(State.resources)),
+        publishCount
+    });
+}
+
 ActionEngine.start(0, 'work');
-console.log(JSON.stringify({slot: State.slots[0], res: State.resources}));
+snapshot('start');
+
 ActionEngine.tick(2);
-console.log(JSON.stringify({slot: State.slots[0], res: State.resources}));
-State.resources.gold.value = State.resources.gold.baseMax;
-ActionEngine.tick(1);
-console.log(JSON.stringify({slot: State.slots[0], res: State.resources}));
-State.resources.mana.value = State.resources.mana.baseMax;
+snapshot('queuedForCost');
+
+State.resources.gold.value = 2;
+State.resources.mana.value = 4;
 ActionEngine.tick(0);
-console.log(JSON.stringify({slot: State.slots[0], res: State.resources}));
+snapshot('resumedAtThreshold');
+
+State.resources.mana.value = 0;
+ActionEngine.tick(1);
+snapshot('queuedForConsumption');
+
+State.resources.mana.value = 4;
+ActionEngine.tick(0);
+snapshot('resumedAfterConsumption');
+
+console.log(JSON.stringify(states));
 """
     result = subprocess.run(
         ['node', '-e', script], check=True, capture_output=True, text=True
     )
-    lines = result.stdout.strip().splitlines()
-    assert len(lines) == 4
-    start_state = json.loads(lines[0])
-    tick1_state = json.loads(lines[1])
-    tick2_state = json.loads(lines[2])
-    tick3_state = json.loads(lines[3])
-    # action starts and runs immediately
+    states = json.loads(result.stdout.strip())
+    assert len(states) == 5
+
+    start_state = states[0]
+    queued_cost = states[1]
+    resumed_cost = states[2]
+    queued_consumption = states[3]
+    resumed_consumption = states[4]
+
     assert start_state['slot']['actionId'] == 'work'
-    # after resources drop below cost, action queues and default runs
-    assert tick1_state['slot']['actionId'] == 'idle'
-    assert tick1_state['slot']['queue']['id'] == 'work'
-    assert tick1_state['res']['gold']['value'] == 0
-    # replenishing only gold is not enough to resume
-    assert tick2_state['slot']['actionId'] == 'idle'
-    # once all resources are at max, queued action resumes
-    assert tick3_state['slot']['actionId'] == 'work'
+    assert start_state['resources']['gold']['value'] == 2
+    assert start_state['resources']['mana']['value'] == 4
+    assert start_state['publishCount'] == 1
+
+    assert queued_cost['slot']['actionId'] == 'idle'
+    assert queued_cost['slot']['queue']['id'] == 'work'
+    assert queued_cost['slot']['queue']['costPaid'] is False
+    assert queued_cost['resources']['gold']['value'] == 0
+    assert queued_cost['resources']['mana']['value'] == 2
+    assert queued_cost['publishCount'] == 3
+
+    assert resumed_cost['slot']['actionId'] == 'work'
+    assert resumed_cost['slot']['queue'] is None
+    assert resumed_cost['resources']['gold']['value'] == 0
+    assert resumed_cost['resources']['mana']['value'] == 4
+    assert resumed_cost['resources']['gold']['value'] < resumed_cost['resources']['gold']['baseMax']
+    assert resumed_cost['resources']['mana']['value'] < resumed_cost['resources']['mana']['baseMax']
+    assert resumed_cost['publishCount'] == 5
+
+    assert queued_consumption['slot']['actionId'] == 'idle'
+    assert queued_consumption['slot']['queue']['costPaid'] is True
+    assert queued_consumption['resources']['mana']['value'] == 0
+    assert queued_consumption['publishCount'] == 5
+
+    assert resumed_consumption['slot']['actionId'] == 'work'
+    assert resumed_consumption['slot']['queue'] is None
+    assert resumed_consumption['resources']['mana']['value'] == 4
+    assert resumed_consumption['resources']['mana']['value'] < resumed_consumption['resources']['mana']['baseMax']
+    assert resumed_consumption['resources']['gold']['value'] == resumed_cost['resources']['gold']['value']
+    assert resumed_consumption['publishCount'] == 6


### PR DESCRIPTION
## Summary
- extract shared resource threshold helper and load it for both the action and adventure engines
- update action resume checks to honor upfront costs, soft-cap thresholds, and queued cost payments
- extend action queue regression coverage for resuming below max resources

## Testing
- pytest *(fails: `wkhtmltoimage` missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1cfcc898833097781f753c746167