### PR TITLE
Fix queue helper namespace collisions in engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
 - Character layout uses flexbox with left and right slot containers and no spacer div.
 
 ### Fixed
+- Renamed action and adventure queue helper bindings to avoid global collisions
+  that triggered SyntaxErrors when both engines loaded together.
 - Equipment items retain grid layout on small screens.
 - Fixed missing closing brace in `#stats` rule so the global typography comment is outside the selector.
 - Character slots respect theme variables and dark mode defines hover and active state colors.

--- a/js/action_engine.js
+++ b/js/action_engine.js
@@ -3,12 +3,12 @@
 // FurnitureSystem, SoftCapSystem, SaveSystem
 // Exports: ActionEngine
 
-let queueResourceHelpers = null;
+let actionQueueResourceHelpers = null;
 if (typeof module !== 'undefined' && module.exports) {
     try {
-        queueResourceHelpers = require('./resource_queue_helpers.js');
+        actionQueueResourceHelpers = require('./resource_queue_helpers.js');
     } catch (err) {
-        queueResourceHelpers = null;
+        actionQueueResourceHelpers = null;
     }
 }
 
@@ -168,7 +168,7 @@ const ActionEngine = {
 };
 
 function queueResourceAtThreshold(name, explicitThreshold) {
-    const helper = queueResourceHelpers ||
+    const helper = actionQueueResourceHelpers ||
         (typeof QueueResourceHelper !== 'undefined' ? QueueResourceHelper : null);
     if (helper && typeof helper.resourceAtQueueThreshold === 'function') {
         return helper.resourceAtQueueThreshold(name, explicitThreshold);

--- a/js/adventure_engine.js
+++ b/js/adventure_engine.js
@@ -1,11 +1,11 @@
 // AdventureEngine handles encounter slots and retreat logic
 
-let queueResourceHelpers = null;
+let adventureQueueResourceHelpers = null;
 if (typeof module !== 'undefined' && module.exports) {
     try {
-        queueResourceHelpers = require('./resource_queue_helpers.js');
+        adventureQueueResourceHelpers = require('./resource_queue_helpers.js');
     } catch (err) {
-        queueResourceHelpers = null;
+        adventureQueueResourceHelpers = null;
     }
 }
 
@@ -222,7 +222,7 @@ function checkHealth() {
 }
 
 function resolveQueueResourceCap(name) {
-    const helper = queueResourceHelpers ||
+    const helper = adventureQueueResourceHelpers ||
         (typeof QueueResourceHelper !== 'undefined' ? QueueResourceHelper : null);
     if (helper && typeof helper.resolveQueueResourceCap === 'function') {
         return helper.resolveQueueResourceCap(name);
@@ -231,7 +231,7 @@ function resolveQueueResourceCap(name) {
 }
 
 function resourceAtQueueThreshold(name, explicitThreshold) {
-    const helper = queueResourceHelpers ||
+    const helper = adventureQueueResourceHelpers ||
         (typeof QueueResourceHelper !== 'undefined' ? QueueResourceHelper : null);
     if (helper && typeof helper.resourceAtQueueThreshold === 'function') {
         return helper.resourceAtQueueThreshold(name, explicitThreshold);


### PR DESCRIPTION
## Summary
- give action and adventure engines unique queue helper bindings to avoid global name collisions
- document the fix in the changelog

## Testing
- node -e "require('./js/action_engine.js'); require('./js/adventure_engine.js'); console.log('modules loaded');"


------
https://chatgpt.com/codex/tasks/task_e_68cc2cee5b3483308c0d17099ba1f422