### PR TITLE
Align character equipment slots around portrait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tests cover resource consumption, encounter retreats, and equipment flows.
 
 ### Changed
+- Character tab portrait now uses an overlaid slot frame so five equipment slots line up along each side without covering the character art.
 - Action engine now resumes queued actions once resources meet upfront costs or soft-cap thresholds via a shared queue helper, honoring pre-paid costs and extending regression coverage.
 - Adventure encounters resume queued runs once resources reach soft-cap limits or encounter costs, ensuring retreats recover to achievable thresholds and adding regression coverage.
 - Soft caps now apply prestige boosts through a dedicated SoftCapSystem multiplier helper, keeping stat max arrays untouched.

--- a/css/styles.css
+++ b/css/styles.css
@@ -826,38 +826,68 @@ body[data-theme="dark"] {
 }
 
 .tab-section[data-section="character"] {
+    position: relative;
+}
+
+.character-layout {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    margin-top: var(--space-md);
+}
+
+.character-portrait {
+    position: relative;
+    width: min(100%, 520px);
+    aspect-ratio: 3 / 4;
     background-repeat: no-repeat;
     background-position: center;
     background-size: contain;
 }
 
-.character-layout {
-    gap: var(--space-md);
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-}
-
-/* Equalize column widths for left and right slot groups */
-#character-slots-left,
-#character-slots-right {
-    flex: 1;
-}
-
-.character-layout .slots {
+.character-slot-column {
+    position: absolute;
+    top: 6%;
+    bottom: 6%;
     display: flex;
     flex-direction: column;
+    justify-content: space-between;
+    align-items: center;
+    width: clamp(82px, 28%, 132px);
+    padding-block: clamp(1rem, 4vh, 2.5rem);
+    padding-inline: clamp(0.5rem, 2vw, 1.25rem);
+    z-index: 1;
+}
+
+.character-slot-column-left {
+    inset-inline-start: 0;
+}
+
+.character-slot-column-right {
+    inset-inline-end: 0;
 }
 
 .character-layout .slot {
-    width: 80px;
-    height: 80px;
     border: 2px solid var(--slot-border-color);
     background-color: var(--slot-bg);
-    opacity: 0.8;
+}
+
+.character-slot-column .slot {
+    flex: none;
+    width: 100%;
+    max-width: 100%;
+    aspect-ratio: 1;
+    min-height: 0;
     padding: var(--space-xs);
-    flex: 0 0 auto;
+    border-width: 3px;
+    border-color: var(--slot-border-color);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.35);
+    background-color: var(--slot-bg);
+}
+
+.character-slot-column .slot .label {
+    top: 0.6rem;
+    font-size: 0.75rem;
 }
 
 @media (max-width: 700px) {
@@ -869,14 +899,17 @@ body[data-theme="dark"] {
         grid-template-columns: repeat(3, 1fr);
         gap: var(--space-sm);
     }
-    /* Stack character slots vertically on narrow screens */
-    .character-layout .slots {
-        display: flex;
-        flex-direction: column;
+    .character-slot-column {
+        width: clamp(70px, 32vw, 110px);
+        padding-block: clamp(0.75rem, 3vh, 1.8rem);
+        padding-inline: clamp(0.5rem, 3vw, 1rem);
     }
-    .character-layout .slot {
-        width: 60px;
-        height: 60px;
+    .character-slot-column .slot {
+        border-width: 2px;
+    }
+    .character-slot-column .slot .label {
+        top: 0.45rem;
+        font-size: 0.7rem;
     }
     .tab-section {
         flex-direction: column;

--- a/index.html
+++ b/index.html
@@ -102,8 +102,10 @@
                             <h2 class="section-heading" data-i18n="Character">Character</h2>
                             <div class="section-body">
                                 <div class="character-layout">
-                                    <div id="character-slots-left" class="slots"></div>
-                                    <div id="character-slots-right" class="slots"></div>
+                                    <div class="character-portrait">
+                                        <div id="character-slots-left" class="character-slot-column character-slot-column-left"></div>
+                                        <div id="character-slots-right" class="character-slot-column character-slot-column-right"></div>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/js/ui/char_bg.js
+++ b/js/ui/char_bg.js
@@ -6,7 +6,9 @@ const CharacterBackground = {
     fullGearImage: 'assets/char/set+sword.png',
     container: null,
     init() {
-        this.container = document.querySelector('.tab-section[data-section="character"]');
+        const portrait = document.querySelector('.character-portrait');
+        const fallback = document.querySelector('.tab-section[data-section="character"]');
+        this.container = portrait || fallback;
         if (!this.container) return;
         this.container.style.backgroundImage = `url(${this.baseImage})`;
         if (typeof PubSub !== 'undefined') {

--- a/tests/test_char_bg.py
+++ b/tests/test_char_bg.py
@@ -8,7 +8,14 @@ class Elem {
   constructor(){ this.style = {}; }
 }
 const elem = new Elem();
-global.document = { querySelector: () => elem };
+global.document = {
+  querySelector: (selector) => {
+    if (selector === '.character-portrait' || selector === '.tab-section[data-section="character"]') {
+      return elem;
+    }
+    return null;
+  }
+};
 global.PubSub = {
   events: {},
   subscribe(ev, fn){ this.events[ev] = fn; },

--- a/tests/test_character_layout_visual.py
+++ b/tests/test_character_layout_visual.py
@@ -24,8 +24,8 @@ def _hash(path):
     return sha.hexdigest()
 
 # Baseline screenshot hashes; update only when layout changes
-EXPECTED_DESKTOP = "773cc230a1663b668361e08f83c09e80fc5c42f8b5e9fe390a2a7c3743b9edaf"
-EXPECTED_MOBILE = "f82121994ca703c8ff0f58086c7719018943bb42e78451753daad252fdfd012c"
+EXPECTED_DESKTOP = "767d428396ddaf8d804f5e634dc324e67c280fcef7145bf1bc53e2e74d1a1bd0"
+EXPECTED_MOBILE = "a618cefd7ec17223177969674d6676dbee15e3964849e433dd37ec43cac89024"
 
 
 


### PR DESCRIPTION
## Summary
- wrap the Character tab layout in a dedicated portrait container with explicit left and right slot columns
- restyle the character equipment CSS so columns overlay the background image while remaining responsive
- point CharacterBackground and associated tests at the new portrait node and refresh screenshot hashes for the updated layout

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc2ff86acc8330952f83282ea51a3a